### PR TITLE
[ADH-3676] Metastore storage refactoring

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -360,11 +360,20 @@
   </property>
 
   <property>
-    <name>smart.metastore.character.takeup.bytes</name>
-    <value>1</value>
+    <name>smart.metastore.migration.liquibase.changelog.path</name>
+    <value>db/changelog/changelog-root.xml</value>
     <description>
-      How many bytes that one character takes up, default value is 1.
-      This property is used to make mysql5.6 compatible with SSM.
+      Path to liquibase changelog root file.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.metastore.migration.liquibase.labels</name>
+    <value></value>
+    <description>
+      Comma-separated liquibase changeSet labels to run migration with.
+      E.g. 'old_mysql' to enable support of db object names longer than 797 bytes in
+      versions of MySQL lesser than 5.7.
     </description>
   </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <licenses>
@@ -320,6 +321,10 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -537,7 +542,7 @@
             <format>html</format>
             <format>xml</format>
           </formats>
-          <check />
+          <check/>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
       <dependency>
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
-        <version>3.16.1</version>
+        <version>3.34.0</version>
       </dependency>
       <dependency>
         <groupId>mysql</groupId>

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -66,14 +66,14 @@ public class SmartConfKeys {
   public static final String SMART_SECURITY_ENABLE = "smart.security.enable";
   public static final String SMART_SERVER_KEYTAB_FILE_KEY = "smart.server.keytab.file";
   public static final String SMART_SERVER_KERBEROS_PRINCIPAL_KEY =
-    "smart.server.kerberos.principal";
+      "smart.server.kerberos.principal";
   public static final String SMART_AGENT_KEYTAB_FILE_KEY = "smart.agent.keytab.file";
   public static final String SMART_AGENT_KERBEROS_PRINCIPAL_KEY =
-    "smart.agent.kerberos.principal";
+      "smart.agent.kerberos.principal";
   public static final String SMART_SECURITY_CLIENT_PROTOCOL_ACL =
-    "smart.security.client.protocol.acl";
+      "smart.security.client.protocol.acl";
   public static final String SMART_SECURITY_ADMIN_PROTOCOL_ACL =
-    "smart.security.admin.protocol.acl";
+      "smart.security.admin.protocol.acl";
   public static final String SMART_METASTORE_DB_URL_KEY = "smart.metastore.db.url";
   // Password which get from hadoop credentialProvider used for metastore connect
   public static final String SMART_METASTORE_PASSWORD = "smart.metastore.password";
@@ -83,11 +83,11 @@ public class SmartConfKeys {
   public static final int SMART_METASTORE_CHARACTER_TAKEUP_BYTES_DEFAULT = 1;
 
   public static final String SMART_METASTORE_MIGRATION_CHANGELOG_PATH_KEY =
-          "smart.metastore.migration.liquibase.changelog.path";
+      "smart.metastore.migration.liquibase.changelog.path";
   public static final String SMART_METASTORE_MIGRATION_CHANGELOG_PATH_DEFAULT =
-          "db/changelog/changelog-root.xml";
+      "db/changelog/changelog-root.xml";
   public static final String SMART_METASTORE_MIGRATION_LABELS_KEY =
-          "smart.metastore.migration.liquibase.labels";
+      "smart.metastore.migration.liquibase.labels";
   public static final String SMART_METASTORE_MIGRATION_LABELS_DEFAULT = "";
 
   // StatesManager
@@ -158,7 +158,7 @@ public class SmartConfKeys {
   public static final String SMART_ACTION_EC_THROTTLE_MB_KEY = "smart.action.ec.throttle.mb";
   public static final long SMART_ACTION_EC_THROTTLE_MB_DEFAULT = 0L;
   public static final String SMART_ACTION_LOCAL_EXECUTION_DISABLED_KEY =
-    "smart.action.local.execution.disabled";
+      "smart.action.local.execution.disabled";
   public static final boolean SMART_ACTION_LOCAL_EXECUTION_DISABLED_DEFAULT = false;
 
   // SmartAgent

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -82,6 +82,14 @@ public class SmartConfKeys {
       "smart.metastore.character.takeup.bytes";
   public static final int SMART_METASTORE_CHARACTER_TAKEUP_BYTES_DEFAULT = 1;
 
+  public static final String SMART_METASTORE_MIGRATION_CHANGELOG_PATH_KEY =
+          "smart.metastore.migration.liquibase.changelog.path";
+  public static final String SMART_METASTORE_MIGRATION_CHANGELOG_PATH_DEFAULT =
+          "db/changelog/changelog-root.xml";
+  public static final String SMART_METASTORE_MIGRATION_LABELS_KEY =
+          "smart.metastore.migration.liquibase.labels";
+  public static final String SMART_METASTORE_MIGRATION_LABELS_DEFAULT = "";
+
   // StatesManager
 
   // RuleManager

--- a/smart-engine/src/test/java/org/smartdata/server/engine/rule/TestRuleExecutor.java
+++ b/smart-engine/src/test/java/org/smartdata/server/engine/rule/TestRuleExecutor.java
@@ -36,7 +36,7 @@ public class TestRuleExecutor extends TestDaoUtil {
   public void initActionDao() throws Exception {
     initDao();
     metaStoreHelper = new MetaStoreHelper(druidPool.getDataSource());
-    adapter = new MetaStore(druidPool);
+    adapter = createMetastore();
   }
 
   @After

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
@@ -30,15 +30,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.smartdata.SmartContext;
+import org.smartdata.conf.SmartConf;
 import org.smartdata.hdfs.MiniClusterFactory;
 import org.smartdata.hdfs.action.CacheFileAction;
 import org.smartdata.hdfs.action.UncacheFileAction;
 import org.smartdata.hdfs.scheduler.CacheScheduler;
-import org.smartdata.model.CachedFileStatus;
-import org.smartdata.model.FileInfo;
-import org.smartdata.conf.SmartConf;
 import org.smartdata.metastore.MetaStore;
 import org.smartdata.metastore.TestDaoUtil;
+import org.smartdata.model.CachedFileStatus;
+import org.smartdata.model.FileInfo;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -109,7 +109,7 @@ public class TestCachedListFetcher extends TestDaoUtil {
     byte erasureCodingPolicy = 0;
     fid++;
     return new FileInfo(pathString, fileId, length,
-        isDir, (short)blockReplication, blockSize, modTime, accessTime,
+        isDir, (short) blockReplication, blockSize, modTime, accessTime,
         (short) 1, owner, group, storagePolicy, erasureCodingPolicy);
   }
 

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
@@ -74,7 +74,7 @@ public class TestCachedListFetcher extends TestDaoUtil {
     dfs = cluster.getFileSystem();
     dfsClient = dfs.getClient();
     smartContext = new SmartContext(conf);
-    metaStore = new MetaStore(druidPool);
+    metaStore = createMetastore();
     cachedListFetcher = new CachedListFetcher(600l, dfsClient, metaStore);
   }
 

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestDataNodeInfoFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestDataNodeInfoFetcher.java
@@ -76,6 +76,6 @@ public abstract class TestDataNodeInfoFetcher extends TestDaoUtil {
     while (!fetcher.isFetchFinished()) {
       Thread.sleep(1000);
     }
-    Assert.assertEquals(2,metaStore.getAllDataNodeInfo().size());
+    Assert.assertEquals(2, metaStore.getAllDataNodeInfo().size());
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestDataNodeInfoFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestDataNodeInfoFetcher.java
@@ -54,7 +54,7 @@ public abstract class TestDataNodeInfoFetcher extends TestDaoUtil {
     dfs = cluster.getFileSystem();
     dfsClient = dfs.getClient();
     scheduledExecutorService = Executors.newScheduledThreadPool(2);
-    metaStore = new MetaStore(druidPool);
+    metaStore = createMetastore();
     fetcher = new DataNodeInfoFetcher(dfsClient, metaStore,
         scheduledExecutorService, conf);
   }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
@@ -49,7 +49,7 @@ public class TestInotifyEventApplier extends TestDaoUtil {
   @Before
   public void init() throws Exception {
     initDao();
-    metaStore = new MetaStore(druidPool);
+    metaStore = createMetastore();
   }
 
   @Test

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
@@ -32,7 +32,6 @@ import org.smartdata.conf.SmartConf;
 import org.smartdata.hdfs.CompatibilityHelperLoader;
 import org.smartdata.hdfs.HadoopUtil;
 import org.smartdata.metastore.MetaStore;
-
 import org.smartdata.metastore.TestDaoUtil;
 import org.smartdata.model.BackUpInfo;
 import org.smartdata.model.FileDiff;
@@ -46,6 +45,7 @@ import java.util.List;
 
 public class TestInotifyEventApplier extends TestDaoUtil {
   private MetaStore metaStore = null;
+
   @Before
   public void init() throws Exception {
     initDao();
@@ -92,8 +92,9 @@ public class TestInotifyEventApplier extends TestDaoUtil {
             null,
             (byte) 0);
     Mockito.when(client.getFileInfo(Matchers.startsWith("/file"))).thenReturn(status1);
-    Mockito.when(client.getFileInfo(Matchers.startsWith("/dir"))).thenReturn(getDummyDirStatus("", 1010));
-    applier.apply(new Event[] {createEvent});
+    Mockito.when(client.getFileInfo(Matchers.startsWith("/dir")))
+        .thenReturn(getDummyDirStatus("", 1010));
+    applier.apply(new Event[]{createEvent});
 
     FileInfo result1 = metaStore.getFile().get(1);
     Assert.assertEquals(result1.getPath(), "/file");
@@ -101,7 +102,7 @@ public class TestInotifyEventApplier extends TestDaoUtil {
     Assert.assertEquals(result1.getPermission(), 511);
 
     Event close = new Event.CloseEvent("/file", 1024, 0);
-    applier.apply(new Event[] {close});
+    applier.apply(new Event[]{close});
     FileInfo result2 = metaStore.getFile().get(1);
     Assert.assertEquals(result2.getLength(), 1024);
     Assert.assertEquals(result2.getModificationTime(), 0L);
@@ -122,7 +123,7 @@ public class TestInotifyEventApplier extends TestDaoUtil {
             .ownerName("user2")
             .groupName("cg2")
             .build();
-    applier.apply(new Event[] {meta});
+    applier.apply(new Event[]{meta});
     FileInfo result4 = metaStore.getFile().get(1);
     Assert.assertEquals(result4.getAccessTime(), 3);
     Assert.assertEquals(result4.getModificationTime(), 2);
@@ -134,7 +135,7 @@ public class TestInotifyEventApplier extends TestDaoUtil {
             .ownerName("user1")
             .groupName("cg1")
             .build();
-    applier.apply(new Event[] {meta1});
+    applier.apply(new Event[]{meta1});
     result4 = metaStore.getFile().get(1);
     Assert.assertEquals(result4.getOwner(), "user1");
     Assert.assertEquals(result4.getGroup(), "cg1");
@@ -162,9 +163,9 @@ public class TestInotifyEventApplier extends TestDaoUtil {
             .replication(3)
             .build();
     Event rename =
-      new Event.RenameEvent.Builder().dstPath("/dir2").srcPath("/dir").timestamp(5).build();
+        new Event.RenameEvent.Builder().dstPath("/dir2").srcPath("/dir").timestamp(5).build();
 
-    applier.apply(new Event[] {createEvent2, createEvent3, rename});
+    applier.apply(new Event[]{createEvent2, createEvent3, rename});
     List<FileInfo> result5 = metaStore.getFile();
     List<String> expectedPaths = Arrays.asList("/dir2", "/dir2/file", "/file");
     List<String> actualPaths = new ArrayList<>();
@@ -212,8 +213,10 @@ public class TestInotifyEventApplier extends TestDaoUtil {
     Mockito.when(client.getFileInfo("/file1")).thenReturn(status1);
 
     List<Event> events = new ArrayList<>();
-    Event.CreateEvent createEvent = new Event.CreateEvent.Builder().path("/file1").defaultBlockSize(123).ownerName("test")
-        .replication(2).perms(new FsPermission(FsAction.NONE, FsAction.NONE, FsAction.NONE)).build();
+    Event.CreateEvent createEvent =
+        new Event.CreateEvent.Builder().path("/file1").defaultBlockSize(123).ownerName("test")
+            .replication(2)
+            .perms(new FsPermission(FsAction.NONE, FsAction.NONE, FsAction.NONE)).build();
     events.add(createEvent);
     Mockito.when(client.getFileInfo("/file1")).thenReturn(status1);
     applier.apply(events);
@@ -256,7 +259,7 @@ public class TestInotifyEventApplier extends TestDaoUtil {
         .srcPath("/dir")
         .dstPath("/dir1")
         .build();
-    applier.apply(new Event[] {dirRenameEvent});
+    applier.apply(new Event[]{dirRenameEvent});
     Assert.assertTrue(metaStore.getFile("/dir") == null);
     Assert.assertTrue(metaStore.getFile("/dir/file1") == null);
     Assert.assertTrue(metaStore.getFile("/dirfile") != null);

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyFetcher.java
@@ -80,12 +80,12 @@ public abstract class TestInotifyFetcher extends TestDaoUtil {
     try {
       cluster.waitActive();
       DFSClient client = new DFSClient(cluster.getNameNode(0)
-        .getNameNodeAddress(), conf);
+          .getNameNodeAddress(), conf);
 
       MetaStore metaStore = createMetastore();
       EventApplierForTest applierForTest = new EventApplierForTest(metaStore, client);
       final InotifyEventFetcher fetcher = new InotifyEventFetcher(client, metaStore,
-        Executors.newScheduledThreadPool(2), applierForTest, new Callable() {
+          Executors.newScheduledThreadPool(2), applierForTest, new Callable() {
         @Override
         public Object call() throws Exception {
           return null; // Do nothing
@@ -99,7 +99,7 @@ public abstract class TestInotifyFetcher extends TestDaoUtil {
       DFSTestUtil.createFile(fs, new Path("/file3"), BLOCK_SIZE, (short) 1, 0L);
       DFSTestUtil.createFile(fs, new Path("/file5"), BLOCK_SIZE, (short) 1, 0L);
       DFSTestUtil.createFile(fs, new Path("/truncate_file"),
-        BLOCK_SIZE * 2, (short) 1, 0L);
+          BLOCK_SIZE * 2, (short) 1, 0L);
       fs.mkdirs(new Path("/tmp"), new FsPermission("777"));
 
       Thread thread = new Thread() {
@@ -145,12 +145,12 @@ public abstract class TestInotifyFetcher extends TestDaoUtil {
       client.setOwner("/dir", "username", "groupname");
       client.createSymlink("/dir", "/dir2", false); // SymlinkOp -> CreateEvent
       client.setXAttr("/file5", "user.field", "value".getBytes(), EnumSet.of(
-        XAttrSetFlag.CREATE)); // SetXAttrOp -> MetadataUpdateEvent
+          XAttrSetFlag.CREATE)); // SetXAttrOp -> MetadataUpdateEvent
       // RemoveXAttrOp -> MetadataUpdateEvent
       client.removeXAttr("/file5", "user.field");
       // SetAclOp -> MetadataUpdateEvent
       client.setAcl("/file5", AclEntry.parseAclSpec(
-        "user::rwx,user:foo:rw-,group::r--,other::---", true));
+          "user::rwx,user:foo:rw-,group::r--,other::---", true));
       client.removeAcl("/file5"); // SetAclOp -> MetadataUpdateEvent
       client.rename("/file5", "/dir"); // RenameOldOp -> RenameEvent
       //TruncateOp -> TruncateEvent
@@ -194,7 +194,8 @@ public abstract class TestInotifyFetcher extends TestDaoUtil {
               client,
               Long.parseLong(
                   metaStore
-                      .getSystemInfoByProperty(SmartConstants.SMART_HDFS_LAST_INOTIFY_TXID)
+                      .getSystemInfoByProperty(
+                          SmartConstants.SMART_HDFS_LAST_INOTIFY_TXID)
                       .getValue())));
     } finally {
       cluster.shutdown();
@@ -202,7 +203,9 @@ public abstract class TestInotifyFetcher extends TestDaoUtil {
     }
   }
 
-  public HdfsDataOutputStream append(DFSClient client, String src, int bufferSize) throws IOException {
-    return (HdfsDataOutputStream)CompatibilityHelperLoader.getHelper().getDFSClientAppend(client, src, bufferSize);
+  public HdfsDataOutputStream append(DFSClient client, String src, int bufferSize)
+      throws IOException {
+    return (HdfsDataOutputStream) CompatibilityHelperLoader.getHelper()
+        .getDFSClientAppend(client, src, bufferSize);
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyFetcher.java
@@ -82,7 +82,7 @@ public abstract class TestInotifyFetcher extends TestDaoUtil {
       DFSClient client = new DFSClient(cluster.getNameNode(0)
         .getNameNodeAddress(), conf);
 
-      MetaStore metaStore = new MetaStore(druidPool);
+      MetaStore metaStore = createMetastore();
       EventApplierForTest applierForTest = new EventApplierForTest(metaStore, client);
       final InotifyEventFetcher fetcher = new InotifyEventFetcher(client, metaStore,
         Executors.newScheduledThreadPool(2), applierForTest, new Callable() {

--- a/smart-metastore/pom.xml
+++ b/smart-metastore/pom.xml
@@ -31,6 +31,10 @@
     <version>1.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
+    <properties>
+        <liquibaseVersion>4.23.2</liquibaseVersion>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.smartdata</groupId>
@@ -57,6 +61,12 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquibaseVersion}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.dbunit</groupId>
             <artifactId>dbunit</artifactId>

--- a/smart-metastore/pom.xml
+++ b/smart-metastore/pom.xml
@@ -32,7 +32,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <liquibaseVersion>4.23.2</liquibaseVersion>
+        <liquibase.version>4.23.2</liquibase.version>
+        <liquibase-slf4j.version>5.0.0</liquibase-slf4j.version>
     </properties>
 
     <dependencies>
@@ -64,7 +65,13 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>${liquibaseVersion}</version>
+            <version>${liquibase.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mattbertolini</groupId>
+            <artifactId>liquibase-slf4j</artifactId>
+            <version>${liquibase-slf4j.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -31,6 +31,7 @@ import org.smartdata.metastore.dao.ClusterConfigDao;
 import org.smartdata.metastore.dao.ClusterInfoDao;
 import org.smartdata.metastore.dao.CmdletDao;
 import org.smartdata.metastore.dao.CompressionFileDao;
+import org.smartdata.metastore.dao.DaoProvider;
 import org.smartdata.metastore.dao.DataNodeInfoDao;
 import org.smartdata.metastore.dao.DataNodeStorageInfoDao;
 import org.smartdata.metastore.dao.ErasureCodingPolicyDao;
@@ -80,7 +81,6 @@ import org.smartdata.model.StoragePolicy;
 import org.smartdata.model.SystemInfo;
 import org.smartdata.model.UserInfo;
 import org.smartdata.model.XAttribute;
-
 import org.springframework.dao.EmptyResultDataAccessException;
 
 import java.sql.Connection;
@@ -112,62 +112,64 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   private Map<String, Integer> mapStoragePolicyNameId = null;
   private Map<String, StorageCapacity> mapStorageCapacity = null;
   private Set<String> setBackSrc = null;
-  private RuleDao ruleDao;
-  private CmdletDao cmdletDao;
-  private ActionDao actionDao;
-  private FileInfoDao fileInfoDao;
-  private CacheFileDao cacheFileDao;
-  private StorageDao storageDao;
-  private StorageHistoryDao storageHistoryDao;
-  private XattrDao xattrDao;
-  private FileDiffDao fileDiffDao;
-  private AccessCountDao accessCountDao;
-  private MetaStoreHelper metaStoreHelper;
-  private ClusterConfigDao clusterConfigDao;
-  private GlobalConfigDao globalConfigDao;
-  private DataNodeInfoDao dataNodeInfoDao;
-  private DataNodeStorageInfoDao dataNodeStorageInfoDao;
-  private BackUpInfoDao backUpInfoDao;
-  private ClusterInfoDao clusterInfoDao;
-  private SystemInfoDao systemInfoDao;
-  private UserInfoDao userInfoDao;
-  private FileStateDao fileStateDao;
-  private CompressionFileDao compressionFileDao;
-  private GeneralDao generalDao;
-  private SmallFileDao smallFileDao;
-  private ErasureCodingPolicyDao ecDao;
-  private WhitelistDao whitelistDao;
+  private final RuleDao ruleDao;
+  private final CmdletDao cmdletDao;
+  private final ActionDao actionDao;
+  private final FileInfoDao fileInfoDao;
+  private final CacheFileDao cacheFileDao;
+  private final StorageDao storageDao;
+  private final StorageHistoryDao storageHistoryDao;
+  private final XattrDao xattrDao;
+  private final FileDiffDao fileDiffDao;
+  private final AccessCountDao accessCountDao;
+  private final MetaStoreHelper metaStoreHelper;
+  private final ClusterConfigDao clusterConfigDao;
+  private final GlobalConfigDao globalConfigDao;
+  private final DataNodeInfoDao dataNodeInfoDao;
+  private final DataNodeStorageInfoDao dataNodeStorageInfoDao;
+  private final BackUpInfoDao backUpInfoDao;
+  private final ClusterInfoDao clusterInfoDao;
+  private final SystemInfoDao systemInfoDao;
+  private final UserInfoDao userInfoDao;
+  private final FileStateDao fileStateDao;
+  private final CompressionFileDao compressionFileDao;
+  private final GeneralDao generalDao;
+  private final SmallFileDao smallFileDao;
+  private final ErasureCodingPolicyDao ecDao;
+  private final WhitelistDao whitelistDao;
   private final ReentrantLock accessCountLock;
 
-  public MetaStore(DBPool pool, DBManager dbManager) throws MetaStoreException {
+  public MetaStore(DBPool pool,
+                   DBManager dbManager,
+                   DaoProvider daoProvider) throws MetaStoreException {
     this.pool = pool;
     this.dbManager = dbManager;
     initDbInfo();
-    ruleDao = new RuleDao(pool.getDataSource());
-    cmdletDao = new CmdletDao(pool.getDataSource());
-    actionDao = new ActionDao(pool.getDataSource());
-    fileInfoDao = new FileInfoDao(pool.getDataSource());
-    xattrDao = new XattrDao(pool.getDataSource());
-    cacheFileDao = new CacheFileDao(pool.getDataSource());
-    storageDao = new StorageDao(pool.getDataSource());
-    storageHistoryDao = new StorageHistoryDao(pool.getDataSource());
-    accessCountDao = new AccessCountDao(pool.getDataSource());
-    fileDiffDao = new FileDiffDao(pool.getDataSource());
+    ruleDao = daoProvider.ruleDao();
+    cmdletDao = daoProvider.cmdletDao();
+    actionDao = daoProvider.actionDao();
+    fileInfoDao = daoProvider.fileInfoDao();
+    xattrDao = daoProvider.xattrDao();
+    cacheFileDao = daoProvider.cacheFileDao();
+    storageDao = daoProvider.storageDao();
+    storageHistoryDao = daoProvider.storageHistoryDao();
+    accessCountDao = daoProvider.accessCountDao();
+    fileDiffDao = daoProvider.fileDiffDao();
     metaStoreHelper = new MetaStoreHelper(pool.getDataSource());
-    clusterConfigDao = new ClusterConfigDao(pool.getDataSource());
-    globalConfigDao = new GlobalConfigDao(pool.getDataSource());
-    dataNodeInfoDao = new DataNodeInfoDao(pool.getDataSource());
-    dataNodeStorageInfoDao = new DataNodeStorageInfoDao(pool.getDataSource());
-    backUpInfoDao = new BackUpInfoDao(pool.getDataSource());
-    clusterInfoDao = new ClusterInfoDao(pool.getDataSource());
-    systemInfoDao = new SystemInfoDao(pool.getDataSource());
-    userInfoDao = new UserInfoDao(pool.getDataSource());
-    fileStateDao = new FileStateDao(pool.getDataSource());
-    compressionFileDao = new CompressionFileDao(pool.getDataSource());
-    generalDao = new GeneralDao(pool.getDataSource());
-    smallFileDao = new SmallFileDao(pool.getDataSource());
-    ecDao = new ErasureCodingPolicyDao(pool.getDataSource());
-    whitelistDao = new WhitelistDao(pool.getDataSource());
+    clusterConfigDao = daoProvider.clusterConfigDao();
+    globalConfigDao = daoProvider.globalConfigDao();
+    dataNodeInfoDao = daoProvider.dataNodeInfoDao();
+    dataNodeStorageInfoDao = daoProvider.dataNodeStorageInfoDao();
+    backUpInfoDao = daoProvider.backUpInfoDao();
+    clusterInfoDao = daoProvider.clusterInfoDao();
+    systemInfoDao = daoProvider.systemInfoDao();
+    userInfoDao = daoProvider.userInfoDao();
+    fileStateDao = daoProvider.fileStateDao();
+    compressionFileDao = daoProvider.compressionFileDao();
+    generalDao = daoProvider.generalDao();
+    smallFileDao = daoProvider.smallFileDao();
+    ecDao = daoProvider.ecDao();
+    whitelistDao = daoProvider.whitelistDao();
     accessCountLock = new ReentrantLock();
   }
 
@@ -235,7 +237,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
    * @param file
    */
   public void insertFile(FileInfo file)
-    throws MetaStoreException {
+      throws MetaStoreException {
     updateCache();
     fileInfoDao.insert(file);
   }
@@ -247,19 +249,19 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
    * @param files
    */
   public void insertFiles(FileInfo[] files)
-    throws MetaStoreException {
+      throws MetaStoreException {
     updateCache();
     fileInfoDao.insert(files);
   }
 
   public int updateFileStoragePolicy(String path, String policyName)
-    throws MetaStoreException {
+      throws MetaStoreException {
     if (mapStoragePolicyIdName == null) {
       updateCache();
     }
     if (!mapStoragePolicyNameId.containsKey(policyName)) {
       throw new MetaStoreException("Unknown storage policy name '"
-        + policyName + "'");
+          + policyName + "'");
     }
     try {
       return storageDao.updateFileStoragePolicy(path, mapStoragePolicyNameId.get(policyName));
@@ -324,7 +326,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<FileInfo> getFilesByPaths(Collection<String> paths)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return fileInfoDao.getFilesByPaths(paths);
     } catch (EmptyResultDataAccessException e) {
@@ -335,7 +337,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public Map<String, Long> getFileIDs(Collection<String> paths)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return fileInfoDao.getPathFids(paths);
     } catch (EmptyResultDataAccessException e) {
@@ -346,7 +348,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public Map<Long, String> getFilePaths(Collection<Long> ids)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return fileInfoDao.getFidPaths(ids);
     } catch (EmptyResultDataAccessException e) {
@@ -357,13 +359,13 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<FileAccessInfo> getHotFiles(
-    List<AccessCountTable> tables,
-    int topNum) throws MetaStoreException {
+      List<AccessCountTable> tables,
+      int topNum) throws MetaStoreException {
     Iterator<AccessCountTable> tableIterator = tables.iterator();
     if (tableIterator.hasNext()) {
       try {
         Map<Long, Integer> accessCounts =
-          accessCountDao.getHotFiles(tables, topNum);
+            accessCountDao.getHotFiles(tables, topNum);
         if (accessCounts.size() == 0) {
           return new ArrayList<>();
         }
@@ -373,7 +375,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
           Long fid = entry.getKey();
           if (idToPath.containsKey(fid) && entry.getValue() > 0) {
             result.add(
-              new FileAccessInfo(fid, idToPath.get(fid), entry.getValue()));
+                new FileAccessInfo(fid, idToPath.get(fid), entry.getValue()));
           }
         }
         return result;
@@ -469,7 +471,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void deleteAccessCountTable(
-    AccessCountTable table) throws MetaStoreException {
+      AccessCountTable table) throws MetaStoreException {
     accessCountLock.lock();
     try {
       accessCountDao.delete(table);
@@ -481,7 +483,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertAccessCountTable(
-    AccessCountTable accessCountTable) throws MetaStoreException {
+      AccessCountTable accessCountTable) throws MetaStoreException {
     try {
       if (accessCountDao.getAccessCountTableByName(accessCountTable.getTableName()).isEmpty()) {
         accessCountDao.insert(accessCountTable);
@@ -492,7 +494,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertUpdateStoragesTable(StorageCapacity[] storages)
-    throws MetaStoreException {
+      throws MetaStoreException {
     mapStorageCapacity = null;
     try {
       storageDao.insertUpdateStoragesTable(storages);
@@ -502,18 +504,18 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertUpdateStoragesTable(List<StorageCapacity> storages)
-    throws MetaStoreException {
+      throws MetaStoreException {
     mapStorageCapacity = null;
     try {
       storageDao.insertUpdateStoragesTable(
-        storages.toArray(new StorageCapacity[storages.size()]));
+          storages.toArray(new StorageCapacity[storages.size()]));
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }
   }
 
   public void insertUpdateStoragesTable(StorageCapacity storage)
-    throws MetaStoreException {
+      throws MetaStoreException {
     insertUpdateStoragesTable(new StorageCapacity[]{storage});
   }
 
@@ -540,7 +542,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public StorageCapacity getStorageCapacity(
-    String type) throws MetaStoreException {
+      String type) throws MetaStoreException {
     updateCache();
     Map<String, StorageCapacity> currentMapStorageCapacity = mapStorageCapacity;
     while (currentMapStorageCapacity == null) {
@@ -561,7 +563,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean updateStoragesTable(String type,
-      Long capacity, Long free) throws MetaStoreException {
+                                     Long capacity, Long free) throws MetaStoreException {
     try {
       mapStorageCapacity = null;
       return storageDao.updateStoragesTable(type, capacity, free);
@@ -571,7 +573,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertStorageHistTable(StorageCapacity[] storages, long interval)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       storageHistoryDao.insertStorageHistTable(storages, interval);
     } catch (Exception e) {
@@ -580,12 +582,12 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<StorageCapacity> getStorageHistoryData(String type, long interval,
-      long startTime, long endTime) {
+                                                     long startTime, long endTime) {
     return storageHistoryDao.getStorageHistoryData(type, interval, startTime, endTime);
   }
 
   public void deleteStorageHistoryOldRecords(String type, long interval, long beforTimeStamp)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       storageHistoryDao.deleteOldRecords(type, interval, beforTimeStamp);
     } catch (Exception e) {
@@ -617,8 +619,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertCachedFiles(long fid, String path,
-      long fromTime,
-      long lastAccessTime, int numAccessed) throws MetaStoreException {
+                                long fromTime,
+                                long lastAccessTime, int numAccessed) throws MetaStoreException {
     try {
       cacheFileDao.insert(fid, path, fromTime, lastAccessTime, numAccessed);
     } catch (Exception e) {
@@ -627,7 +629,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertCachedFiles(List<CachedFileStatus> s)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       cacheFileDao.insert(s.toArray(new CachedFileStatus[s.size()]));
     } catch (Exception e) {
@@ -644,8 +646,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean updateCachedFiles(Long fid,
-      Long lastAccessTime,
-      Integer numAccessed) throws MetaStoreException {
+                                   Long lastAccessTime,
+                                   Integer numAccessed) throws MetaStoreException {
     try {
       return cacheFileDao.update(fid, lastAccessTime, numAccessed) >= 0;
     } catch (Exception e) {
@@ -654,8 +656,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void updateCachedFiles(Map<String, Long> pathToIds,
-      List<FileAccessEvent> events)
-    throws MetaStoreException {
+                                List<FileAccessEvent> events)
+      throws MetaStoreException {
     try {
       cacheFileDao.update(pathToIds, events);
     } catch (Exception e) {
@@ -692,7 +694,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public CachedFileStatus getCachedFileStatus(
-    long fid) throws MetaStoreException {
+      long fid) throws MetaStoreException {
     try {
       return cacheFileDao.getById(fid);
     } catch (EmptyResultDataAccessException e) {
@@ -703,8 +705,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void createProportionTable(AccessCountTable dest,
-      AccessCountTable source)
-    throws MetaStoreException {
+                                    AccessCountTable source)
+      throws MetaStoreException {
     try {
       accessCountDao.createProportionTable(dest, source);
     } catch (Exception e) {
@@ -738,7 +740,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<String> executeFilesPathQuery(
-    String sql) throws MetaStoreException {
+      String sql) throws MetaStoreException {
     try {
       LOG.debug("ExecuteFilesPathQuery sql = {}", sql);
       return metaStoreHelper.getFilesPath(sql);
@@ -750,7 +752,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<DetailedFileAction> listFileActions(long rid,
-      int size) throws MetaStoreException {
+                                                  int size) throws MetaStoreException {
     if (mapStoragePolicyIdName == null) {
       updateCache();
     }
@@ -765,17 +767,17 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
         // LOG.debug("Namespace is not sync! File {} not in file table!", filePath);
         // Add a mock fileInfo
         fileInfo = new FileInfo(filePath, 0L, 0L, false,
-          (short) 0, 0L, 0L, 0L, (short) 0,
-          "root", "root", (byte) 0, (byte) 0);
+            (short) 0, 0L, 0L, 0L, (short) 0,
+            "root", "root", (byte) 0, (byte) 0);
       }
       detailedFileAction.setFileLength(fileInfo.getLength());
       detailedFileAction.setFilePath(filePath);
       if (actionInfo.getActionName().contains("allssd")
-        || actionInfo.getActionName().contains("onessd")
-        || actionInfo.getActionName().contains("archive")
-        || actionInfo.getActionName().contains("alldisk")
-        || actionInfo.getActionName().contains("onedisk")
-        || actionInfo.getActionName().contains("ramdisk")) {
+          || actionInfo.getActionName().contains("onessd")
+          || actionInfo.getActionName().contains("archive")
+          || actionInfo.getActionName().contains("alldisk")
+          || actionInfo.getActionName().contains("onedisk")
+          || actionInfo.getActionName().contains("ramdisk")) {
         detailedFileAction.setTarget(actionInfo.getActionName());
         detailedFileAction.setSrc(mapStoragePolicyIdName.get((int) fileInfo.getStoragePolicy()));
       } else {
@@ -788,7 +790,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<DetailedFileAction> listFileActions(long rid, long start, long offset)
-    throws MetaStoreException {
+      throws MetaStoreException {
     if (mapStoragePolicyIdName == null) {
       updateCache();
     }
@@ -802,17 +804,17 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
         // LOG.debug("Namespace is not sync! File {} not in file table!", filePath);
         // Add a mock fileInfo
         fileInfo = new FileInfo(filePath, 0L, 0L, false,
-          (short) 0, 0L, 0L, 0L, (short) 0,
-          "root", "root", (byte) 0, (byte) 0);
+            (short) 0, 0L, 0L, 0L, (short) 0,
+            "root", "root", (byte) 0, (byte) 0);
       }
       detailedFileAction.setFileLength(fileInfo.getLength());
       detailedFileAction.setFilePath(filePath);
       if (actionInfo.getActionName().contains("allssd")
-        || actionInfo.getActionName().contains("onessd")
-        || actionInfo.getActionName().contains("archive")
-        || actionInfo.getActionName().contains("alldisk")
-        || actionInfo.getActionName().contains("onedisk")
-        || actionInfo.getActionName().contains("ramdisk")) {
+          || actionInfo.getActionName().contains("onessd")
+          || actionInfo.getActionName().contains("archive")
+          || actionInfo.getActionName().contains("alldisk")
+          || actionInfo.getActionName().contains("onedisk")
+          || actionInfo.getActionName().contains("ramdisk")) {
         detailedFileAction.setTarget(actionInfo.getActionName());
         detailedFileAction.setSrc(mapStoragePolicyIdName.get((int) fileInfo.getStoragePolicy()));
       } else {
@@ -837,11 +839,11 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
       if (lastPart.contains("sync")) {
         continue;
       } else if (lastPart.contains("allssd")
-              || lastPart.contains("onessd")
-              || lastPart.contains("archive")
-              || lastPart.contains("alldisk")
-              || lastPart.contains("onedisk")
-              || lastPart.contains("ramdisk")) {
+          || lastPart.contains("onessd")
+          || lastPart.contains("archive")
+          || lastPart.contains("alldisk")
+          || lastPart.contains("onedisk")
+          || lastPart.contains("ramdisk")) {
         DetailedRuleInfo detailedRuleInfo = new DetailedRuleInfo(ruleInfo);
         // Add mover progress
         List<CmdletInfo> cmdletInfos = cmdletDao.getByRid(ruleInfo.getId());
@@ -859,9 +861,9 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
           }
         }
         detailedRuleInfo
-          .setBaseProgress(cmdletInfos.size() - currPos);
+            .setBaseProgress(cmdletInfos.size() - currPos);
         detailedRuleInfo.setRunningProgress(countRunning);
-        if (detailedRuleInfo.getState() != RuleState.DELETED){
+        if (detailedRuleInfo.getState() != RuleState.DELETED) {
           detailedRuleInfos.add(detailedRuleInfo);
         }
       }
@@ -895,10 +897,10 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
           detailedRuleInfo.setRunningProgress(count);
         } else {
           detailedRuleInfo
-            .setBaseProgress(0);
+              .setBaseProgress(0);
           detailedRuleInfo.setRunningProgress(0);
         }
-        if (detailedRuleInfo.getState() != RuleState.DELETED){
+        if (detailedRuleInfo.getState() != RuleState.DELETED) {
           detailedRuleInfos.add(detailedRuleInfo);
         }
       }
@@ -907,7 +909,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean insertNewRule(RuleInfo info)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return ruleDao.insert(info) >= 0;
     } catch (Exception e) {
@@ -916,22 +918,22 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean updateRuleInfo(long ruleId, RuleState rs,
-      long lastCheckTime, long checkedCount, int commandsGen)
-    throws MetaStoreException {
+                                long lastCheckTime, long checkedCount, int commandsGen)
+      throws MetaStoreException {
     try {
       if (rs == null) {
         return ruleDao.update(ruleId,
-          lastCheckTime, checkedCount, commandsGen) >= 0;
+            lastCheckTime, checkedCount, commandsGen) >= 0;
       }
       return ruleDao.update(ruleId,
-        rs.getValue(), lastCheckTime, checkedCount, commandsGen) >= 0;
+          rs.getValue(), lastCheckTime, checkedCount, commandsGen) >= 0;
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }
   }
 
   public boolean updateRuleState(long ruleId, RuleState rs)
-    throws MetaStoreException {
+      throws MetaStoreException {
     if (rs == null) {
       throw new MetaStoreException("Rule state can not be null, ruleId = " + ruleId);
     }
@@ -953,8 +955,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<RuleInfo> listPageRule(long start, long offset, List<String> orderBy,
-      List<Boolean> desc)
-    throws MetaStoreException {
+                                     List<Boolean> desc)
+      throws MetaStoreException {
     LOG.debug("List Rule, start {}, offset {}", start, offset);
     try {
       if (orderBy.size() == 0) {
@@ -979,8 +981,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<CmdletInfo> listPageCmdlets(long rid, long start, long offset,
-      List<String> orderBy, List<Boolean> desc)
-    throws MetaStoreException {
+                                          List<String> orderBy, List<Boolean> desc)
+      throws MetaStoreException {
     LOG.debug("List cmdlet, start {}, offset {}", start, offset);
     try {
       if (orderBy.size() == 0) {
@@ -1002,8 +1004,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<CmdletInfo> listPageCmdlets(long start, long offset,
-      List<String> orderBy, List<Boolean> desc)
-    throws MetaStoreException {
+                                          List<String> orderBy, List<Boolean> desc)
+      throws MetaStoreException {
     LOG.debug("List cmdlet, start {}, offset {}", start, offset);
     try {
       if (orderBy.size() == 0) {
@@ -1026,7 +1028,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
 
 
   public void insertCmdlets(CmdletInfo[] commands)
-    throws MetaStoreException {
+      throws MetaStoreException {
     if (commands.length == 0) {
       return;
     }
@@ -1038,7 +1040,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertCmdlet(CmdletInfo command)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       // Update if exists
       if (getCmdletById(command.getCid()) != null) {
@@ -1073,8 +1075,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
 
   @Override
   public List<CmdletInfo> getCmdlets(String cidCondition,
-      String ridCondition,
-      CmdletState state) throws MetaStoreException {
+                                     String ridCondition,
+                                     CmdletState state) throws MetaStoreException {
     try {
       return cmdletDao.getByCondition(cidCondition, ridCondition, state);
     } catch (EmptyResultDataAccessException e) {
@@ -1095,7 +1097,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean updateCmdlet(CmdletInfo cmdletInfo)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return cmdletDao.update(cmdletInfo) >= 0;
     } catch (Exception e) {
@@ -1105,7 +1107,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
 
   @Override
   public boolean updateCmdlet(long cid, CmdletState state)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return cmdletDao.update(cid, state.getValue()) >= 0;
     } catch (Exception e) {
@@ -1115,7 +1117,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
 
   @Override
   public boolean updateCmdlet(long cid, String parameters, CmdletState state)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return cmdletDao.update(cid, parameters, state.getValue()) >= 0;
     } catch (Exception e) {
@@ -1173,7 +1175,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertActions(ActionInfo[] actionInfos)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       actionDao.replace(actionInfos);
     } catch (Exception e) {
@@ -1182,7 +1184,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertAction(ActionInfo actionInfo)
-    throws MetaStoreException {
+      throws MetaStoreException {
     LOG.debug("Insert Action ID {}", actionInfo.getActionId());
     try {
       if (getActionById(actionInfo.getActionId()) != null) {
@@ -1196,8 +1198,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<ActionInfo> listPageAction(long start, long offset, List<String> orderBy,
-      List<Boolean> desc)
-    throws MetaStoreException {
+                                         List<Boolean> desc)
+      throws MetaStoreException {
     LOG.debug("List Action, start {}, offset {}", start, offset);
     try {
       if (orderBy.size() == 0) {
@@ -1211,8 +1213,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<ActionInfo> searchAction(String path, long start,
-      long offset, List<String> orderBy, List<Boolean> desc,
-      long[] retTotalNumActions) throws MetaStoreException {
+                                       long offset, List<String> orderBy, List<Boolean> desc,
+                                       long[] retTotalNumActions) throws MetaStoreException {
     try {
       return actionDao.searchAction(path, start, offset, orderBy, desc, retTotalNumActions);
     } catch (EmptyResultDataAccessException e) {
@@ -1280,7 +1282,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void updateActions(ActionInfo[] actionInfos)
-    throws MetaStoreException {
+      throws MetaStoreException {
     if (actionInfos == null || actionInfos.length == 0) {
       return;
     }
@@ -1293,7 +1295,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<ActionInfo> getNewCreatedActions(
-    int size) throws MetaStoreException {
+      int size) throws MetaStoreException {
     if (size < 0) {
       return new ArrayList<>();
     }
@@ -1307,7 +1309,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<ActionInfo> getNewCreatedActions(String actionName,
-      int size) throws MetaStoreException {
+                                               int size) throws MetaStoreException {
     if (size < 0) {
       return new ArrayList<>();
     }
@@ -1321,8 +1323,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<ActionInfo> getNewCreatedActions(String actionName,
-      int size, boolean successful,
-      boolean finished) throws MetaStoreException {
+                                               int size, boolean successful,
+                                               boolean finished) throws MetaStoreException {
     if (size < 0) {
       return new ArrayList<>();
     }
@@ -1336,8 +1338,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<ActionInfo> getNewCreatedActions(String actionName,
-      int size,
-      boolean finished) throws MetaStoreException {
+                                               int size,
+                                               boolean finished) throws MetaStoreException {
     if (size < 0) {
       return new ArrayList<>();
     }
@@ -1351,8 +1353,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<ActionInfo> getNewCreatedActions(String actionName,
-      boolean successful,
-      int size) throws MetaStoreException {
+                                               boolean successful,
+                                               int size) throws MetaStoreException {
     if (size < 0) {
       return new ArrayList<>();
     }
@@ -1367,7 +1369,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
 
 
   public List<ActionInfo> getActions(
-    List<Long> aids) throws MetaStoreException {
+      List<Long> aids) throws MetaStoreException {
     if (aids == null || aids.size() == 0) {
       return new ArrayList<>();
     }
@@ -1485,7 +1487,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertStoragePolicy(StoragePolicy s)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       storageDao.insertStoragePolicyTable(s);
     } catch (Exception e) {
@@ -1505,7 +1507,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public Integer getStoragePolicyID(
-    String policyName) throws MetaStoreException {
+      String policyName) throws MetaStoreException {
     try {
       updateCache();
       return mapStoragePolicyNameId.get(policyName);
@@ -1546,7 +1548,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertFileDiffs(FileDiff[] fileDiffs)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       fileDiffDao.insert(fileDiffs);
     } catch (Exception e) {
@@ -1600,8 +1602,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean batchUpdateFileDiff(
-    List<Long> did, List<FileDiffState> states, List<String> parameters)
-    throws MetaStoreException {
+      List<Long> did, List<FileDiffState> states, List<String> parameters)
+      throws MetaStoreException {
     try {
       return fileDiffDao.batchUpdate(did, states, parameters).length > 0;
     } catch (Exception e) {
@@ -1610,8 +1612,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean batchUpdateFileDiff(
-    List<Long> did, FileDiffState state)
-    throws MetaStoreException {
+      List<Long> did, FileDiffState state)
+      throws MetaStoreException {
     try {
       return fileDiffDao.batchUpdate(did, state).length > 0;
     } catch (Exception e) {
@@ -1638,7 +1640,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public boolean updateFileDiff(FileDiff fileDiff)
-    throws MetaStoreException {
+      throws MetaStoreException {
     long did = fileDiff.getDiffId();
     FileDiff preFileDiff = getFileDiff(did);
     if (preFileDiff == null) {
@@ -1652,7 +1654,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void updateFileDiff(List<FileDiff> fileDiffs)
-    throws MetaStoreException {
+      throws MetaStoreException {
     if (fileDiffs == null || fileDiffs.size() == 0) {
       return;
     }
@@ -1702,7 +1704,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     try {
       dbManager.clearDatabase();
     } catch (Exception e) {
-        throw new MetaStoreException(e);
+      throw new MetaStoreException(e);
     }
   }
 
@@ -1719,11 +1721,11 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
       int num = getTablesNum(MetaStoreUtils.TABLESET);
       if (num == 0) {
         LOG.info("The table set required by SSM does not exist. "
-          + "The configured database will be formatted.");
+            + "The configured database will be formatted.");
         formatDataBase();
       } else if (num < MetaStoreUtils.TABLESET.length) {
         LOG.error("One or more tables required by SSM are missing! "
-          + "You can restart SSM with -format option or configure another database.");
+            + "You can restart SSM with -format option or configure another database.");
         System.exit(1);
       }
     } catch (Exception e) {
@@ -1742,7 +1744,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void aggregateTables(AccessCountTable destinationTable
-    , List<AccessCountTable> tablesToAggregate) throws MetaStoreException {
+      , List<AccessCountTable> tablesToAggregate) throws MetaStoreException {
     try {
       accessCountDao.aggregateTables(destinationTable, tablesToAggregate);
     } catch (Exception e) {
@@ -1751,7 +1753,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void setClusterConfig(
-    ClusterConfig clusterConfig) throws MetaStoreException {
+      ClusterConfig clusterConfig) throws MetaStoreException {
     try {
 
       if (clusterConfigDao.getCountByName(clusterConfig.getNodeName()) == 0) {
@@ -1760,7 +1762,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
       } else {
         //update
         clusterConfigDao.updateByNodeName(clusterConfig.getNodeName(),
-          clusterConfig.getConfigPath());
+            clusterConfig.getConfigPath());
       }
     } catch (Exception e) {
       throw new MetaStoreException(e);
@@ -1768,7 +1770,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void delClusterConfig(
-    ClusterConfig clusterConfig) throws MetaStoreException {
+      ClusterConfig clusterConfig) throws MetaStoreException {
     try {
       if (clusterConfigDao.getCountByName(clusterConfig.getNodeName()) > 0) {
         //insert
@@ -1788,7 +1790,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public GlobalConfig getDefaultGlobalConfigByName(
-    String configName) throws MetaStoreException {
+      String configName) throws MetaStoreException {
     try {
       if (globalConfigDao.getCountByName(configName) > 0) {
         //the property is existed
@@ -1802,11 +1804,11 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void setGlobalConfig(
-    GlobalConfig globalConfig) throws MetaStoreException {
+      GlobalConfig globalConfig) throws MetaStoreException {
     try {
       if (globalConfigDao.getCountByName(globalConfig.getPropertyName()) > 0) {
         globalConfigDao.update(globalConfig.getPropertyName(),
-          globalConfig.getPropertyValue());
+            globalConfig.getPropertyValue());
       } else {
         globalConfigDao.insert(globalConfig);
       }
@@ -1816,7 +1818,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertDataNodeInfo(DataNodeInfo dataNodeInfo)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeInfoDao.insert(dataNodeInfo);
     } catch (Exception e) {
@@ -1825,7 +1827,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertDataNodeInfos(DataNodeInfo[] dataNodeInfos)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeInfoDao.insert(dataNodeInfos);
     } catch (Exception e) {
@@ -1834,7 +1836,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertDataNodeInfos(List<DataNodeInfo> dataNodeInfos)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeInfoDao.insert(dataNodeInfos);
     } catch (Exception e) {
@@ -1843,7 +1845,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<DataNodeInfo> getDataNodeInfoByUuid(String uuid)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return dataNodeInfoDao.getByUuid(uuid);
     } catch (EmptyResultDataAccessException e) {
@@ -1854,7 +1856,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<DataNodeInfo> getAllDataNodeInfo()
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return dataNodeInfoDao.getAll();
     } catch (EmptyResultDataAccessException e) {
@@ -1865,7 +1867,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void deleteDataNodeInfo(String uuid)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeInfoDao.delete(uuid);
     } catch (Exception e) {
@@ -1874,7 +1876,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void deleteAllDataNodeInfo()
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeInfoDao.deleteAll();
     } catch (Exception e) {
@@ -1883,7 +1885,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertDataNodeStorageInfo(DataNodeStorageInfo dataNodeStorageInfo)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeStorageInfoDao.insert(dataNodeStorageInfo);
     } catch (Exception e) {
@@ -1892,8 +1894,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertDataNodeStorageInfos(
-    DataNodeStorageInfo[] dataNodeStorageInfos)
-    throws MetaStoreException {
+      DataNodeStorageInfo[] dataNodeStorageInfos)
+      throws MetaStoreException {
     try {
       dataNodeStorageInfoDao.insert(dataNodeStorageInfos);
     } catch (Exception e) {
@@ -1902,8 +1904,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertDataNodeStorageInfos(
-    List<DataNodeStorageInfo> dataNodeStorageInfos)
-    throws MetaStoreException {
+      List<DataNodeStorageInfo> dataNodeStorageInfos)
+      throws MetaStoreException {
     try {
       dataNodeStorageInfoDao.insert(dataNodeStorageInfos);
     } catch (Exception e) {
@@ -1986,7 +1988,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<DataNodeStorageInfo> getDataNodeStorageInfoByUuid(String uuid)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return dataNodeStorageInfoDao.getByUuid(uuid);
     } catch (EmptyResultDataAccessException e) {
@@ -1998,7 +2000,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
 
 
   public List<DataNodeStorageInfo> getAllDataNodeStorageInfo()
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return dataNodeStorageInfoDao.getAll();
     } catch (EmptyResultDataAccessException e) {
@@ -2009,7 +2011,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void deleteDataNodeStorageInfo(String uuid)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeStorageInfoDao.delete(uuid);
     } catch (Exception e) {
@@ -2018,7 +2020,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void deleteAllDataNodeStorageInfo()
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       dataNodeStorageInfoDao.deleteAll();
     } catch (Exception e) {
@@ -2106,8 +2108,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   @Override
-  public void insertBackUpInfo (
-    BackUpInfo backUpInfo) throws MetaStoreException {
+  public void insertBackUpInfo(
+      BackUpInfo backUpInfo) throws MetaStoreException {
     try {
       backUpInfoDao.insert(backUpInfo);
       if (setBackSrc == null) {
@@ -2153,7 +2155,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public SystemInfo getSystemInfoByProperty(
-    String property) throws MetaStoreException {
+      String property) throws MetaStoreException {
     try {
       return systemInfoDao.getByProperty(property);
     } catch (Exception e) {
@@ -2196,7 +2198,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void updateSystemInfo(
-    SystemInfo systemInfo) throws MetaStoreException {
+      SystemInfo systemInfo) throws MetaStoreException {
     try {
       systemInfoDao.update(systemInfo);
     } catch (Exception e) {
@@ -2214,7 +2216,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void updateAndInsertIfNotExist(
-    SystemInfo systemInfo) throws MetaStoreException {
+      SystemInfo systemInfo) throws MetaStoreException {
     try {
       if (systemInfoDao.update(systemInfo) <= 0) {
         systemInfoDao.insert(systemInfo);
@@ -2233,7 +2235,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void deleteSystemInfo(
-    String property) throws MetaStoreException {
+      String property) throws MetaStoreException {
     try {
       systemInfoDao.delete(property);
     } catch (Exception e) {
@@ -2242,7 +2244,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertClusterInfo(
-    ClusterInfo clusterInfo) throws MetaStoreException {
+      ClusterInfo clusterInfo) throws MetaStoreException {
     try {
       if (clusterInfoDao.getCountByName(clusterInfo.getName()) != 0) {
         throw new Exception("name has already exist");
@@ -2254,7 +2256,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertSystemInfo(SystemInfo systemInfo)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       if (systemInfoDao.containsProperty(systemInfo.getProperty())) {
         throw new Exception("The system property already exists");
@@ -2298,7 +2300,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void insertCompactFileStates(CompactFileState[] compactFileStates)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       fileStateDao.batchInsertUpdate(compactFileStates);
       smallFileDao.batchInsertUpdate(compactFileStates);
@@ -2347,7 +2349,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public Map<String, FileState> getFileStates(List<String> paths)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return fileStateDao.getByPaths(paths);
     } catch (EmptyResultDataAccessException e1) {
@@ -2385,7 +2387,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public void deleteCompactFileStates(List<String> paths)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       fileStateDao.batchDelete(paths);
       smallFileDao.batchDelete(paths);
@@ -2395,7 +2397,7 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
   }
 
   public List<String> getSmallFilesByContainerFile(String containerFilePath)
-    throws MetaStoreException {
+      throws MetaStoreException {
     try {
       return smallFileDao.getSmallFilesByContainerFile(containerFilePath);
     } catch (EmptyResultDataAccessException e1) {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/AbstractDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/AbstractDao.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+import javax.sql.DataSource;
+
+import java.util.List;
+import java.util.Map;
+
+/** Contains common methods for DAOs. */
+public class AbstractDao {
+  protected final DataSource dataSource;
+  protected final JdbcTemplate jdbcTemplate;
+  protected final String tableName;
+
+  public AbstractDao(DataSource dataSource, String tableName) {
+    this.dataSource = dataSource;
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.tableName = tableName;
+  }
+
+  protected SimpleJdbcInsert simpleJdbcInsert() {
+    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
+    simpleJdbcInsert.setTableName(tableName);
+    return simpleJdbcInsert;
+  }
+
+  protected <T> void insert(T entity, EntityToMapConverter<T> converter) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    simpleJdbcInsert.execute(converter.toMap(entity));
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <T> void insert(List<T> entities, EntityToMapConverter<T> converter) {
+    insert((T[]) entities.toArray(), converter);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <T> void insert(T[] entities, EntityToMapConverter<T> converter) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    Map<String, Object>[] maps = new Map[entities.length];
+    for (int i = 0; i < entities.length; i++) {
+      maps[i] = converter.toMap(entities[i]);
+    }
+    simpleJdbcInsert.executeBatch(maps);
+  }
+
+  protected interface EntityToMapConverter<T> {
+    Map<String, Object> toMap(T entity);
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/AccessCountDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/AccessCountDao.java
@@ -17,195 +17,40 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
-import org.springframework.jdbc.support.rowset.SqlRowSet;
-
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class AccessCountDao {
-  private DataSource dataSource;
-  static final String FILE_FIELD = "fid";
-  static final String ACCESSCOUNT_FIELD = "count";
+public interface AccessCountDao {
+  String FILE_FIELD = "fid";
+  String ACCESSCOUNT_FIELD = "count";
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
-
-  public AccessCountDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
-
-  public void insert(AccessCountTable accessCountTable) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("access_count_table");
-    simpleJdbcInsert.execute(toMap(accessCountTable));
-  }
-
-  public void insert(AccessCountTable[] accessCountTables) {
-    for (AccessCountTable accessCountTable : accessCountTables) {
-      insert(accessCountTable);
-    }
-  }
-
-  public List<AccessCountTable> getAccessCountTableByName(String name) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT * FROM access_count_table WHERE table_name = '" + name + "'";
-    return jdbcTemplate.query(sql, new AccessCountRowMapper());
-  }
-
-  public void delete(Long startTime, Long endTime) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql =
-        String.format(
-        "DELETE FROM access_count_table WHERE start_time >= %s AND end_time <= %s",
-            startTime,
-            endTime);
-    jdbcTemplate.update(sql);
-  }
-
-  public void delete(AccessCountTable table) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM access_count_table WHERE table_name = ?";
-    jdbcTemplate.update(sql, table.getTableName());
-  }
-
-  public static String createAccessCountTableSQL(String tableName) {
+  static String createAccessCountTableSQL(String tableName) {
     return String.format(
         "CREATE TABLE %s (%s INTEGER NOT NULL, %s INTEGER NOT NULL)",
         tableName, FILE_FIELD, ACCESSCOUNT_FIELD);
   }
 
-  public List<AccessCountTable> getAllSortedTables() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT * FROM access_count_table ORDER BY start_time ASC";
-    return jdbcTemplate.query(sql, new AccessCountRowMapper());
-  }
+  void insert(AccessCountTable accessCountTable);
 
-  public void aggregateTables(
-      AccessCountTable destinationTable, List<AccessCountTable> tablesToAggregate) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String create = AccessCountDao.createAccessCountTableSQL(destinationTable.getTableName());
-    jdbcTemplate.execute(create);
-    String insert =
-        String.format(
-            "INSERT INTO %s SELECT tmp1.%s, tmp1.%s FROM ((SELECT %s, SUM(%s) AS %s FROM(%s) "
-                + "tmp0 GROUP BY %s) AS tmp1 LEFT JOIN file ON file.fid = tmp1.fid);",
-            destinationTable.getTableName(),
-            AccessCountDao.FILE_FIELD,
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            AccessCountDao.FILE_FIELD,
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            getUnionStatement(tablesToAggregate),
-            AccessCountDao.FILE_FIELD);
-    jdbcTemplate.execute(insert);
-  }
+  void insert(AccessCountTable[] accessCountTables);
 
-  public Map<Long, Integer> getHotFiles(List<AccessCountTable> tables, int topNum)
-      throws SQLException {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String statement =
-        String.format(
-            "SELECT %s, SUM(%s) AS %s FROM (%s) tmp WHERE %s IN (SELECT fid FROM file) "
-                + "GROUP BY %s ORDER BY %s DESC LIMIT %s",
-            AccessCountDao.FILE_FIELD,
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            getUnionStatement(tables),
-            AccessCountDao.FILE_FIELD,
-            AccessCountDao.FILE_FIELD,
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            topNum);
-    SqlRowSet sqlRowSet = jdbcTemplate.queryForRowSet(statement);
-    Map<Long, Integer> accessCounts = new HashMap<>();
-    while (sqlRowSet.next()) {
-      accessCounts.put(
-          sqlRowSet.getLong(AccessCountDao.FILE_FIELD),
-          sqlRowSet.getInt(AccessCountDao.ACCESSCOUNT_FIELD));
-    }
-    return accessCounts;
-  }
+  List<AccessCountTable> getAccessCountTableByName(String name);
 
-  private String getUnionStatement(List<AccessCountTable> tables) {
-    StringBuilder union = new StringBuilder();
-    Iterator<AccessCountTable> tableIterator = tables.iterator();
-    while (tableIterator.hasNext()) {
-      AccessCountTable table = tableIterator.next();
-      if (tableIterator.hasNext()) {
-        union.append("SELECT * FROM " + table.getTableName() + " UNION ALL ");
-      } else {
-        union.append("SELECT * FROM " + table.getTableName());
-      }
-    }
-    return union.toString();
-  }
+  void delete(Long startTime, Long endTime);
 
-  public void createProportionTable(AccessCountTable dest, AccessCountTable source)
-      throws SQLException {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    double percentage =
-        ((double) dest.getEndTime() - dest.getStartTime())
-            / (source.getEndTime() - source.getStartTime());
-    jdbcTemplate.execute(AccessCountDao.createAccessCountTableSQL(dest.getTableName()));
-    String sql =
-        String.format(
-            "INSERT INTO %s SELECT %s, ROUND(%s.%s * %s) AS %s FROM %s",
-            dest.getTableName(),
-            AccessCountDao.FILE_FIELD,
-            source.getTableName(),
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            percentage,
-            AccessCountDao.ACCESSCOUNT_FIELD,
-            source.getTableName());
-    jdbcTemplate.execute(sql);
-  }
+  void delete(AccessCountTable table);
 
-  public void updateFid(long fidSrc, long fidDest) throws SQLException {
-    int failedNum = 0;
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    List<AccessCountTable> accessCountTables = getAllSortedTables();
-    for (AccessCountTable table : accessCountTables) {
-      String sql = String.format("update %s set %s=%s where %s=%s", table.getTableName(),
-          AccessCountDao.FILE_FIELD, fidDest, AccessCountDao.FILE_FIELD, fidSrc);
-      try {
-        jdbcTemplate.execute(sql);
-      } catch (Exception e) {
-        failedNum++;
-      }
-    }
-    // Otherwise, ignore the exception because table evictor can evict access
-    // count tables, which is not synchronized. Even so, there is no impact on
-    // the measurement for data temperature.
-    if (failedNum == accessCountTables.size()) {
-      // Throw exception if all tables are not updated.
-      throw new SQLException("Failed to update fid!");
-    }
-  }
+  List<AccessCountTable> getAllSortedTables();
 
-  private Map<String, Object> toMap(AccessCountTable accessCountTable) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("table_name", accessCountTable.getTableName());
-    parameters.put("start_time", accessCountTable.getStartTime());
-    parameters.put("end_time", accessCountTable.getEndTime());
-    return parameters;
-  }
+  void aggregateTables(
+      AccessCountTable destinationTable, List<AccessCountTable> tablesToAggregate);
 
-  class AccessCountRowMapper implements RowMapper<AccessCountTable> {
-    @Override
-    public AccessCountTable mapRow(ResultSet resultSet, int i) throws SQLException {
-      AccessCountTable accessCountTable = new AccessCountTable(
-        resultSet.getLong("start_time"),
-        resultSet.getLong("end_time"));
-      return accessCountTable;
-    }
-  }
+  Map<Long, Integer> getHotFiles(List<AccessCountTable> tables, int topNum)
+      throws SQLException;
+
+  void createProportionTable(AccessCountTable dest, AccessCountTable source)
+      throws SQLException;
+
+  void updateFid(long fidSrc, long fidDest) throws SQLException;
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/AccessCountTableAggregator.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/AccessCountTableAggregator.java
@@ -35,8 +35,8 @@ public class AccessCountTableAggregator {
   }
 
   public void aggregate(AccessCountTable destinationTable,
-      List<AccessCountTable> tablesToAggregate) throws MetaStoreException {
-    if (tablesToAggregate.size() > 0) {
+                        List<AccessCountTable> tablesToAggregate) throws MetaStoreException {
+    if (!tablesToAggregate.isEmpty()) {
       ReentrantLock accessCountLock = metaStore.getAccessCountLock();
       if (accessCountLock != null) {
         accessCountLock.lock();

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/AccessCountTableDeque.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/AccessCountTableDeque.java
@@ -25,8 +25,8 @@ import java.util.List;
  * Use deque to accelerate remove operation.
  */
 public class AccessCountTableDeque extends ArrayDeque<AccessCountTable> {
-  private TableAddOpListener listener;
-  private TableEvictor tableEvictor;
+  private final TableAddOpListener listener;
+  private final TableEvictor tableEvictor;
 
   public AccessCountTableDeque(TableEvictor tableEvictor) {
     this(tableEvictor, null);

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/BackUpInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/BackUpInfoDao.java
@@ -78,7 +78,6 @@ public class BackUpInfoDao {
         "SELECT * FROM backup_file WHERE dest = ?", new Object[] {dest}, new BackUpInfoRowMapper());
   }
 
-
   public void delete(long rid) {
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
     final String sql = "DELETE FROM backup_file WHERE rid = ?";

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/BackUpInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/BackUpInfoDao.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,121 +17,30 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.lang.StringUtils;
 import org.smartdata.model.BackUpInfo;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class BackUpInfoDao {
-  private DataSource dataSource;
+public interface BackUpInfoDao {
+  List<BackUpInfo> getAll();
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<BackUpInfo> getByIds(List<Long> rids);
 
-  public BackUpInfoDao(DataSource dataSource){
-    this.dataSource = dataSource;
-  }
+  int getCountByRid(int rid);
 
-  public List<BackUpInfo> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM backup_file", new BackUpInfoRowMapper());
-  }
+  BackUpInfo getByRid(long rid);
 
-  public List<BackUpInfo> getByIds(List<Long> rids) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM backup_file WHERE rid IN (?)",
-        new Object[]{StringUtils.join(rids, ",")},
-        new BackUpInfoRowMapper());
-  }
+  List<BackUpInfo> getBySrc(String src);
 
-  public int getCountByRid(int rid){
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(
-        "SELECT COUNT(*) FROM backup_file WHERE rid = ?", new Object[rid], Integer.class);
-  }
+  List<BackUpInfo> getByDest(String dest);
 
-  public BackUpInfo getByRid(long rid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM backup_file WHERE rid = ?",
-        new Object[]{rid}, new BackUpInfoRowMapper());
-  }
+  void delete(long rid);
 
-  public List<BackUpInfo> getBySrc(String src) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM backup_file WHERE src = ?", new Object[] {src}, new BackUpInfoRowMapper());
-  }
+  void insert(BackUpInfo backUpInfo);
 
-  public List<BackUpInfo> getByDest(String dest) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM backup_file WHERE dest = ?", new Object[] {dest}, new BackUpInfoRowMapper());
-  }
+  void insert(BackUpInfo[] backUpInfos);
 
-  public void delete(long rid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM backup_file WHERE rid = ?";
-    jdbcTemplate.update(sql, rid);
-  }
+  int update(long rid, long period);
 
-  public void insert(BackUpInfo backUpInfo) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("backup_file");
-    simpleJdbcInsert.execute(toMap(backUpInfo));
-  }
-
-  public void insert(BackUpInfo[] backUpInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("backup_file");
-    Map<String, Object>[] maps = new Map[backUpInfos.length];
-    for (int i = 0; i < backUpInfos.length; i++) {
-      maps[i] = toMap(backUpInfos[i]);
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public int update(long rid, long period) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE backup_file SET period = ? WHERE rid = ?";
-    return jdbcTemplate.update(sql, period, rid);
-  }
-
-  public void deleteAll(){
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM backup_file";
-    jdbcTemplate.execute(sql);
-  }
-
-  private Map<String, Object> toMap(BackUpInfo backUpInfo) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rid", backUpInfo.getRid());
-    parameters.put("src", backUpInfo.getSrc());
-    parameters.put("dest", backUpInfo.getDest());
-    parameters.put("period", backUpInfo.getPeriod());
-    return parameters;
-  }
-
-  class BackUpInfoRowMapper implements RowMapper<BackUpInfo> {
-
-    @Override
-    public BackUpInfo mapRow(ResultSet resultSet, int i) throws SQLException {
-      BackUpInfo backUpInfo = new BackUpInfo();
-      backUpInfo.setRid(resultSet.getLong("rid"));
-      backUpInfo.setSrc(resultSet.getString("src"));
-      backUpInfo.setDest(resultSet.getString("dest"));
-      backUpInfo.setPeriod(resultSet.getLong("period"));
-
-      return backUpInfo;
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/CacheFileDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/CacheFileDao.java
@@ -17,155 +17,32 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.smartdata.metrics.FileAccessEvent;
 import org.smartdata.model.CachedFileStatus;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CacheFileDao {
+public interface CacheFileDao {
+  List<CachedFileStatus> getAll();
 
-  private DataSource dataSource;
+  CachedFileStatus getById(long fid);
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<Long> getFids();
 
-  public CacheFileDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  void insert(CachedFileStatus cachedFileStatus);
 
-  public List<CachedFileStatus> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM cached_file",
-        new CacheFileRowMapper());
-  }
+  void insert(long fid, String path, long fromTime,
+              long lastAccessTime, int numAccessed);
 
-  public CachedFileStatus getById(long fid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM cached_file WHERE fid = ?",
-        new Object[]{fid}, new CacheFileRowMapper());
-  }
+  void insert(CachedFileStatus[] cachedFileStatusList);
 
-  public List<Long> getFids() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT fid FROM cached_file";
-    List<Long> fids = jdbcTemplate.query(sql,
-        new RowMapper<Long>() {
-          public Long mapRow(ResultSet rs, int rowNum) throws SQLException {
-            return rs.getLong("fid");
-          }
-        });
-    return fids;
-  }
+  int update(Long fid, Long lastAccessTime, Integer numAccessed);
 
-  public void insert(CachedFileStatus cachedFileStatus) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("cached_file");
-    simpleJdbcInsert.execute(toMap(cachedFileStatus));
-  }
+  void update(Map<String, Long> pathToIds,
+              List<FileAccessEvent> events);
 
-  public void insert(long fid, String path, long fromTime,
-                     long lastAccessTime, int numAccessed) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("cached_file");
-    simpleJdbcInsert.execute(toMap(new CachedFileStatus(fid, path,
-        fromTime, lastAccessTime, numAccessed)));
-  }
+  void deleteById(long fid);
 
-  public void insert(CachedFileStatus[] cachedFileStatusList) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("cached_file");
-
-    Map<String, Object>[] maps = new Map[cachedFileStatusList.length];
-    for (int i = 0; i < cachedFileStatusList.length; i++) {
-      maps[i] = toMap(cachedFileStatusList[i]);
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public int update(Long fid, Long lastAccessTime, Integer numAccessed) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE cached_file SET last_access_time = ?, accessed_num = ? WHERE fid = ?";
-    return jdbcTemplate.update(sql, lastAccessTime, numAccessed, fid);
-  }
-
-  public void update(Map<String, Long> pathToIds,
-                     List<FileAccessEvent> events) {
-    Map<Long, CachedFileStatus> idToStatus = new HashMap<>();
-    List<CachedFileStatus> cachedFileStatuses = getAll();
-    for (CachedFileStatus status : cachedFileStatuses) {
-      idToStatus.put(status.getFid(), status);
-    }
-    Collection<Long> cachedIds = idToStatus.keySet();
-    Collection<Long> needToUpdate = CollectionUtils.intersection(cachedIds, pathToIds.values());
-    if (!needToUpdate.isEmpty()) {
-      Map<Long, Integer> idToCount = new HashMap<>();
-      Map<Long, Long> idToLastTime = new HashMap<>();
-      for (FileAccessEvent event : events) {
-        Long fid = pathToIds.get(event.getPath());
-        if (needToUpdate.contains(fid)) {
-          if (!idToCount.containsKey(fid)) {
-            idToCount.put(fid, 0);
-          }
-          idToCount.put(fid, idToCount.get(fid) + 1);
-          if (!idToLastTime.containsKey(fid)) {
-            idToLastTime.put(fid, event.getTimestamp());
-          }
-          idToLastTime.put(fid, Math.max(event.getTimestamp(), idToLastTime.get(fid)));
-        }
-      }
-      for (Long fid : needToUpdate) {
-        Integer newAccessCount = idToStatus.get(fid).getNumAccessed() + idToCount.get(fid);
-        this.update(fid, idToLastTime.get(fid), newAccessCount);
-      }
-    }
-  }
-
-  public void deleteById(long fid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM cached_file WHERE fid = ?";
-    jdbcTemplate.update(sql, fid);
-  }
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "DELETE FROM cached_file";
-    jdbcTemplate.execute(sql);
-  }
-
-  private Map<String, Object> toMap(CachedFileStatus cachedFileStatus) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("fid", cachedFileStatus.getFid());
-    parameters.put("path", cachedFileStatus.getPath());
-    parameters.put("from_time", cachedFileStatus.getFromTime());
-    parameters.put("last_access_time", cachedFileStatus.getLastAccessTime());
-    parameters.put("accessed_num", cachedFileStatus.getNumAccessed());
-    return parameters;
-  }
-
-
-  class CacheFileRowMapper implements RowMapper<CachedFileStatus> {
-
-    @Override
-    public CachedFileStatus mapRow(ResultSet resultSet, int i) throws SQLException {
-      CachedFileStatus cachedFileStatus = new CachedFileStatus();
-      cachedFileStatus.setFid(resultSet.getLong("fid"));
-      cachedFileStatus.setPath(resultSet.getString("path"));
-      cachedFileStatus.setFromTime(resultSet.getLong("from_time"));
-      cachedFileStatus.setLastAccessTime(resultSet.getLong("last_access_time"));
-      cachedFileStatus.setNumAccessed(resultSet.getInt("accessed_num"));
-      return cachedFileStatus;
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/ClusterConfigDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/ClusterConfigDao.java
@@ -17,125 +17,29 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.lang.StringUtils;
 import org.smartdata.model.ClusterConfig;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class ClusterConfigDao {
-  private DataSource dataSource;
+public interface ClusterConfigDao {
+  List<ClusterConfig> getAll();
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<ClusterConfig> getByIds(List<Long> cids);
 
-  public ClusterConfigDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  ClusterConfig getById(long cid);
 
-  public List<ClusterConfig> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM cluster_config", new ClusterConfigRowMapper());
-  }
+  long getCountByName(String name);
 
-  public List<ClusterConfig> getByIds(List<Long> cids) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM cluster_config WHERE cid IN (?)",
-        new Object[]{StringUtils.join(cids, ",")},
-        new ClusterConfigRowMapper());
-  }
+  ClusterConfig getByName(String name);
 
-  public ClusterConfig getById(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM cluster_config WHERE cid = ?",
-        new Object[]{cid}, new ClusterConfigRowMapper());
-  }
+  void delete(long cid);
 
-  public long getCountByName(String name) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(
-        "SELECT COUNT(*) FROM cluster_config WHERE node_name = ?", Long.class, name);
-  }
-
-  public ClusterConfig getByName(String name) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM cluster_config WHERE node_name = ?",
-        new Object[]{name}, new ClusterConfigRowMapper());
-  }
-
-  public void delete(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM cluster_config WHERE cid = ?";
-    jdbcTemplate.update(sql, cid);
-  }
-
-  public long insert(ClusterConfig clusterConfig) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("cluster_config");
-    simpleJdbcInsert.usingGeneratedKeyColumns("cid");
-    long cid = simpleJdbcInsert.executeAndReturnKey(toMap(clusterConfig)).longValue();
-    clusterConfig.setCid(cid);
-    return cid;
-  }
+  long insert(ClusterConfig clusterConfig);
 
   // TODO slove the increment of key
-  public void insert(ClusterConfig[] clusterConfigs) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("cluster_config");
-    simpleJdbcInsert.usingGeneratedKeyColumns("cid");
-    Map<String, Object>[] maps = new Map[clusterConfigs.length];
-    for (int i = 0; i < clusterConfigs.length; i++) {
-      maps[i] = toMap(clusterConfigs[i]);
-    }
-    int[] cids = simpleJdbcInsert.executeBatch(maps);
+  void insert(ClusterConfig[] clusterConfigs);
 
-    for (int i = 0; i < clusterConfigs.length; i++) {
-      clusterConfigs[i].setCid(cids[i]);
-    }
-  }
+  int updateById(int cid, String configPath);
 
-  public int updateById(int cid, String configPath){
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "UPDATE cluster_config SET config_path = ? WHERE cid = ?";
-    return jdbcTemplate.update(sql, configPath, cid);
-  }
-
-
-  public int updateByNodeName(String nodeName, String configPath){
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "UPDATE cluster_config SET config_path = ? WHERE node_name = ?";
-    return jdbcTemplate.update(sql, configPath, nodeName);
-  }
-
-
-  private Map<String, Object> toMap(ClusterConfig clusterConfig) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("cid", clusterConfig.getCid());
-    parameters.put("config_path", clusterConfig.getConfigPath());
-    parameters.put("node_name", clusterConfig.getNodeName());
-    return parameters;
-  }
-
-  class ClusterConfigRowMapper implements RowMapper<ClusterConfig> {
-
-    @Override
-    public ClusterConfig mapRow(ResultSet resultSet, int i) throws SQLException {
-      ClusterConfig clusterConfig = new ClusterConfig();
-      clusterConfig.setCid(resultSet.getLong("cid"));
-      clusterConfig.setConfig_path(resultSet.getString("config_path"));
-      clusterConfig.setNodeName(resultSet.getString("node_name"));
-
-      return clusterConfig;
-    }
-  }
-
+  int updateByNodeName(String nodeName, String configPath);
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/ClusterInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/ClusterInfoDao.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,130 +17,28 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.lang.StringUtils;
 import org.smartdata.model.ClusterInfo;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class ClusterInfoDao {
-  private static final String TABLE_NAME = "cluster_info";
-  private DataSource dataSource;
+public interface ClusterInfoDao {
+  List<ClusterInfo> getAll();
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  ClusterInfo getById(long cid);
 
-  public ClusterInfoDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<ClusterInfo> getByIds(List<Long> cids);
 
-  public List<ClusterInfo> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new ClusterinfoRowMapper());
-  }
+  void delete(long cid);
 
-  public ClusterInfo getById(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE cid = ?",
-        new Object[]{cid},
-        new ClusterinfoRowMapper()).get(0);
-  }
+  long insert(ClusterInfo clusterInfo);
 
-  public List<ClusterInfo> getByIds(List<Long> cids) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE cid IN (?)",
-        new Object[]{StringUtils.join(cids, ",")},
-        new ClusterinfoRowMapper());
-  }
+  void insert(ClusterInfo[] clusterInfos);
 
-  public void delete(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
-    jdbcTemplate.update(sql, cid);
-  }
+  int updateState(long cid, String state);
 
-  public long insert(ClusterInfo clusterInfo) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    simpleJdbcInsert.usingGeneratedKeyColumns("cid");
-    long cid = simpleJdbcInsert.executeAndReturnKey(toMap(clusterInfo)).longValue();
-    clusterInfo.setCid(cid);
-    return cid;
-  }
+  int updateType(long cid, String type);
 
-  public void insert(ClusterInfo[] clusterInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("cluster_info");
-    simpleJdbcInsert.usingGeneratedKeyColumns("cid");
-    Map<String, Object>[] maps = new Map[clusterInfos.length];
-    for (int i = 0; i < clusterInfos.length; i++) {
-      maps[i] = toMap(clusterInfos[i]);
-    }
+  void deleteAll();
 
-    int[] cids = simpleJdbcInsert.executeBatch(maps);
-    for (int i = 0; i < clusterInfos.length; i++) {
-      clusterInfos[i].setCid(cids[i]);
-    }
-  }
-
-  public int updateState(long cid, String state) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET state = ? WHERE cid = ?";
-    return jdbcTemplate.update(sql, state, cid);
-  }
-
-  public int updateType(long cid, String type) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET type = ? WHERE cid = ?";
-    return jdbcTemplate.update(sql, type, cid);
-  }
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.execute(sql);
-  }
-
-  public int getCountByName(String name) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE name = ?";
-    return jdbcTemplate.queryForObject(sql, Integer.class, name);
-  }
-
-  private Map<String, Object> toMap(ClusterInfo clusterInfo) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("cid", clusterInfo.getCid());
-    parameters.put("name", clusterInfo.getName());
-    parameters.put("url", clusterInfo.getUrl());
-    parameters.put("conf_path", clusterInfo.getConfPath());
-    parameters.put("state", clusterInfo.getState());
-    parameters.put("type", clusterInfo.getType());
-
-    return parameters;
-  }
-
-  class ClusterinfoRowMapper implements RowMapper<ClusterInfo> {
-
-    @Override
-    public ClusterInfo mapRow(ResultSet resultSet, int i) throws SQLException {
-      ClusterInfo clusterInfo = new ClusterInfo();
-      clusterInfo.setCid(resultSet.getLong("cid"));
-      clusterInfo.setName(resultSet.getString("name"));
-      clusterInfo.setUrl(resultSet.getString("url"));
-      clusterInfo.setConfPath(resultSet.getString("conf_path"));
-      clusterInfo.setState(resultSet.getString("state"));
-      clusterInfo.setType(resultSet.getString("type"));
-
-      return clusterInfo;
-    }
-  }
+  int getCountByName(String name);
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/CmdletDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/CmdletDao.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,383 +17,62 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.lang.StringUtils;
 import org.smartdata.model.CmdletInfo;
 import org.smartdata.model.CmdletState;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class CmdletDao {
-  private DataSource dataSource;
-  private static final String TABLE_NAME = "cmdlet";
-  private final String terminiatedStates;
+public interface CmdletDao {
+  List<CmdletInfo> getAll();
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<CmdletInfo> getAPageOfCmdlet(long start, long offset,
+                                    List<String> orderBy, List<Boolean> isDesc);
 
-  public CmdletDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-    terminiatedStates = getTerminiatedStatesString();
-  }
+  List<CmdletInfo> getAPageOfCmdlet(long start, long offset);
 
-  public List<CmdletInfo> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new CmdletRowMapper());
-  }
+  List<CmdletInfo> getByIds(List<Long> aids);
 
-  public List<CmdletInfo> getAPageOfCmdlet(long start, long offset,
-      List<String> orderBy, List<Boolean> isDesc) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    boolean ifHasAid = false;
-    StringBuilder sql =
-        new StringBuilder("SELECT * FROM " + TABLE_NAME + " ORDER BY ");
-    for (int i = 0; i < orderBy.size(); i++) {
-      if (orderBy.get(i).equals("cid")) {
-        ifHasAid = true;
-      }
-      sql.append(orderBy.get(i));
-      if (isDesc.size() > i) {
-        if (isDesc.get(i)) {
-          sql.append(" desc ");
-        }
-        sql.append(",");
-      }
-    }
-    if (!ifHasAid) {
-      sql.append("cid,");
-    }
-    //delete the last char
-    sql = new StringBuilder(sql.substring(0, sql.length() - 1));
-    //add limit
-    sql.append(" LIMIT ").append(start).append(",").append(offset).append(";");
-    return jdbcTemplate.query(sql.toString(), new CmdletRowMapper());
-  }
+  CmdletInfo getById(long cid);
 
-  public List<CmdletInfo> getAPageOfCmdlet(long start, long offset) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT * FROM " + TABLE_NAME + " LIMIT " + start + "," + offset + ";";
-    return jdbcTemplate.query(sql, new CmdletRowMapper());
-  }
+  List<CmdletInfo> getByRid(long rid);
 
-  public List<CmdletInfo> getByIds(List<Long> aids) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM " + TABLE_NAME + " WHERE aid IN (?)",
-        new Object[]{StringUtils.join(aids, ",")},
-        new CmdletRowMapper());
-  }
+  long getNumByRid(long rid);
 
-  public CmdletInfo getById(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(
-        "SELECT * FROM " + TABLE_NAME + " WHERE cid = ?",
-        new Object[]{cid},
-        new CmdletRowMapper());
-  }
+  List<CmdletInfo> getByRid(long rid, long start, long offset);
 
-  public List<CmdletInfo> getByRid(long rid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM " + TABLE_NAME + " WHERE rid = ?",
-        new Object[]{rid},
-        new CmdletRowMapper());
-  }
+  List<CmdletInfo> getByRid(long rid, long start, long offset,
+                            List<String> orderBy, List<Boolean> isDesc);
 
-  public long getNumByRid(long rid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(
-        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE rid = ?",
-        new Object[]{rid},
-        Long.class);
-  }
+  List<CmdletInfo> getByState(CmdletState state);
 
-  public List<CmdletInfo> getByRid(long rid, long start, long offset) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT * FROM " + TABLE_NAME + " WHERE rid = " + rid
-        + " LIMIT " + start + "," + offset + ";";
-    return jdbcTemplate.query(sql, new CmdletRowMapper());
-  }
+  int getNumCmdletsInTerminiatedStates();
 
-  public List<CmdletInfo> getByRid(long rid, long start, long offset,
-      List<String> orderBy, List<Boolean> isDesc) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    boolean ifHasAid = false;
-    StringBuilder sql =
-        new StringBuilder("SELECT * FROM " + TABLE_NAME + " WHERE rid = " + rid
-            + " ORDER BY ");
-    for (int i = 0; i < orderBy.size(); i++) {
-      if (orderBy.get(i).equals("cid")) {
-        ifHasAid = true;
-      }
-      sql.append(orderBy.get(i));
-      if (isDesc.size() > i) {
-        if (isDesc.get(i)) {
-          sql.append(" desc ");
-        }
-        sql.append(",");
-      }
-    }
-    if (!ifHasAid) {
-      sql.append("cid,");
-    }
+  List<CmdletInfo> getByCondition(
+      String cidCondition, String ridCondition, CmdletState state);
 
-    //delete the last char
-    sql = new StringBuilder(sql.substring(0, sql.length() - 1));
-    //add limit
-    sql.append(" LIMIT ").append(start).append(",").append(offset).append(";");
-    return jdbcTemplate.query(sql.toString(), new CmdletRowMapper());
-  }
+  void delete(long cid);
 
-  public List<CmdletInfo> getByState(CmdletState state) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM " + TABLE_NAME + " WHERE state = ?",
-        new Object[]{state.getValue()},
-        new CmdletRowMapper());
-  }
+  int[] batchDelete(List<Long> cids);
 
-  public int getNumCmdletsInTerminiatedStates() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String query = "SELECT count(*) FROM " + TABLE_NAME
-        + " WHERE state IN (" + terminiatedStates + ")";
-    return jdbcTemplate.queryForObject(query, Integer.class);
-  }
+  int deleteBeforeTime(long timestamp);
 
-  public List<CmdletInfo> getByCondition(
-      String cidCondition, String ridCondition, CmdletState state) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sqlPrefix = "SELECT * FROM " + TABLE_NAME + " WHERE ";
-    String sqlCid = (cidCondition == null) ? "" : "AND cid " + cidCondition;
-    String sqlRid = (ridCondition == null) ? "" : "AND rid " + ridCondition;
-    String sqlState = (state == null) ? "" : "AND state = " + state.getValue();
-    String sqlFinal = "";
-    if (cidCondition != null || ridCondition != null || state != null) {
-      sqlFinal = sqlPrefix + sqlCid + sqlRid + sqlState;
-      sqlFinal = sqlFinal.replaceFirst("AND ", "");
-    } else {
-      sqlFinal = sqlPrefix.replaceFirst("WHERE ", "");
-    }
-    return jdbcTemplate.query(sqlFinal, new CmdletRowMapper());
-  }
+  int deleteKeepNewCmd(long num);
 
-  public void delete(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
-    jdbcTemplate.update(sql, cid);
-  }
+  void deleteAll();
 
-  public int[] batchDelete(final List<Long> cids) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
-    return jdbcTemplate.batchUpdate(
-            sql,
-            new BatchPreparedStatementSetter() {
-              public void setValues(PreparedStatement ps, int i) throws SQLException {
-                ps.setLong(1, cids.get(i));
-              }
+  void insert(CmdletInfo cmdletInfo);
 
-              public int getBatchSize() {
-                return cids.size();
-              }
-            });
-  }
+  void insert(CmdletInfo[] cmdletInfos);
 
-  public int deleteBeforeTime(long timestamp) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+  int[] replace(CmdletInfo[] cmdletInfos);
 
-    final String querysql = "SELECT cid FROM " + TABLE_NAME
-        + " WHERE  generate_time < ? AND state IN (" + terminiatedStates + ")";
-    List<Long> cids = jdbcTemplate.queryForList(querysql, new Object[]{timestamp}, Long.class);
-    if (cids.size() == 0) {
-      return 0;
-    }
-    final String deleteCmds = "DELETE FROM " + TABLE_NAME
-        + " WHERE generate_time < ? AND state IN (" + terminiatedStates + ")";
-    jdbcTemplate.update(deleteCmds, timestamp);
-    final String deleteActions = "DELETE FROM action WHERE cid IN ("
-        + StringUtils.join(cids, ",") + ")";
-    jdbcTemplate.update(deleteActions);
-    return cids.size();
-  }
+  int update(long cid, int state);
 
-  public int deleteKeepNewCmd (long num) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String queryCids = "SELECT cid FROM " + TABLE_NAME
-        + " WHERE state IN (" + terminiatedStates + ")"
-        + " ORDER BY generate_time DESC LIMIT 100000 OFFSET " + num;
-    List<Long> cids = jdbcTemplate.queryForList(queryCids, Long.class);
-    if (cids.size() == 0) {
-      return 0;
-    }
-    String deleteCids = StringUtils.join(cids, ",");
-    final String deleteCmd = "DELETE FROM " + TABLE_NAME + " WHERE cid IN (" + deleteCids + ")";
-    jdbcTemplate.update(deleteCmd);
-    final String deleteActions = "DELETE FROM action WHERE cid IN (" + deleteCids + ")";
-    jdbcTemplate.update(deleteActions);
-    return cids.size();
-  }
+  int update(long cid, String parameters, int state);
 
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.execute(sql);
-  }
+  int update(CmdletInfo cmdletInfo);
 
-  public void insert(CmdletInfo cmdletInfo) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    simpleJdbcInsert.execute(toMap(cmdletInfo));
-  }
+  int[] update(List<CmdletInfo> cmdletInfos);
 
-  public void insert(CmdletInfo[] cmdletInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    Map<String, Object>[] maps = new Map[cmdletInfos.length];
-    for (int i = 0; i < cmdletInfos.length; i++) {
-      maps[i] = toMap(cmdletInfos[i]);
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public int[] replace(final CmdletInfo[] cmdletInfos) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "REPLACE INTO " + TABLE_NAME
-            + "(cid, "
-            + "rid, "
-            + "aids, "
-            + "state, "
-            + "parameters, "
-            + "generate_time, "
-            + "state_changed_time)"
-            + " VALUES(?, ?, ?, ?, ?, ?, ?)";
-
-    return jdbcTemplate.batchUpdate(
-            sql,
-            new BatchPreparedStatementSetter() {
-              public void setValues(PreparedStatement ps, int i) throws SQLException {
-                ps.setLong(1, cmdletInfos[i].getCid());
-                ps.setLong(2, cmdletInfos[i].getRid());
-                ps.setString(3, StringUtils.join(cmdletInfos[i].getAidsString(), ","));
-                ps.setLong(4, cmdletInfos[i].getState().getValue());
-                ps.setString(5, cmdletInfos[i].getParameters());
-                ps.setLong(6, cmdletInfos[i].getGenerateTime());
-                ps.setLong(7, cmdletInfos[i].getStateChangedTime());
-              }
-              public int getBatchSize() {
-                return cmdletInfos.length;
-              }
-            });
-  }
-
-  public int update(long cid, int state) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql =
-            "UPDATE " + TABLE_NAME + " SET state = ?, state_changed_time = ? WHERE cid = ?";
-    return jdbcTemplate.update(sql, state, System.currentTimeMillis(), cid);
-  }
-
-  public int update(long cid, String parameters, int state) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql =
-        "UPDATE "
-            + TABLE_NAME
-            + " SET parameters = ?, state = ?, state_changed_time = ? WHERE cid = ?";
-    return jdbcTemplate.update(sql, parameters, state, System.currentTimeMillis(), cid);
-  }
-
-  public int update(final CmdletInfo cmdletInfo) {
-    List<CmdletInfo> cmdletInfos = new ArrayList<>();
-    cmdletInfos.add(cmdletInfo);
-    return update(cmdletInfos)[0];
-  }
-
-  public int[] update(final List<CmdletInfo> cmdletInfos) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET  state = ?, state_changed_time = ? WHERE cid = ?";
-    return jdbcTemplate.batchUpdate(
-        sql,
-        new BatchPreparedStatementSetter() {
-          public void setValues(PreparedStatement ps, int i) throws SQLException {
-            ps.setInt(1, cmdletInfos.get(i).getState().getValue());
-            ps.setLong(2, cmdletInfos.get(i).getStateChangedTime());
-            ps.setLong(3, cmdletInfos.get(i).getCid());
-          }
-
-          public int getBatchSize() {
-            return cmdletInfos.size();
-          }
-        });
-  }
-
-  public long getMaxId() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    Long ret = jdbcTemplate.queryForObject("SELECT MAX(cid) FROM " + TABLE_NAME, Long.class);
-    if (ret == null) {
-      return 0;
-    } else {
-      return ret + 1;
-    }
-  }
-
-  private Map<String, Object> toMap(CmdletInfo cmdletInfo) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("cid", cmdletInfo.getCid());
-    parameters.put("rid", cmdletInfo.getRid());
-    parameters.put("aids", StringUtils.join(cmdletInfo.getAidsString(), ","));
-    parameters.put("state", cmdletInfo.getState().getValue());
-    parameters.put("parameters", cmdletInfo.getParameters());
-    parameters.put("generate_time", cmdletInfo.getGenerateTime());
-    parameters.put("state_changed_time", cmdletInfo.getStateChangedTime());
-    return parameters;
-  }
-
-  private String getTerminiatedStatesString() {
-    String finishedState = "";
-    for (CmdletState cmdletState : CmdletState.getTerminalStates()) {
-      finishedState = finishedState + cmdletState.getValue() + ",";
-    }
-    return finishedState.substring(0, finishedState.length() - 1);
-  }
-
-  class CmdletRowMapper implements RowMapper<CmdletInfo> {
-
-    @Override
-    public CmdletInfo mapRow(ResultSet resultSet, int i) throws SQLException {
-      CmdletInfo.Builder builder = CmdletInfo.newBuilder();
-      builder.setCid(resultSet.getLong("cid"));
-      builder.setRid(resultSet.getLong("rid"));
-      builder.setAids(convertStringListToLong(resultSet.getString("aids").split(",")));
-      builder.setState(CmdletState.fromValue((int) resultSet.getByte("state")));
-      builder.setParameters(resultSet.getString("parameters"));
-      builder.setGenerateTime(resultSet.getLong("generate_time"));
-      builder.setStateChangedTime(resultSet.getLong("state_changed_time"));
-      return builder.build();
-    }
-
-    private List<Long> convertStringListToLong(String[] strings) {
-      List<Long> ret = new ArrayList<>();
-      try {
-        for (String s : strings) {
-          ret.add(Long.valueOf(s));
-        }
-      } catch (NumberFormatException e) {
-        // Return empty
-        ret.clear();
-      }
-      return ret;
-    }
-  }
+  long getMaxId();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/DaoProvider.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/DaoProvider.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao;
+
+public interface DaoProvider {
+  RuleDao ruleDao();
+
+  CmdletDao cmdletDao();
+
+  ActionDao actionDao();
+
+  FileInfoDao fileInfoDao();
+
+  CacheFileDao cacheFileDao();
+
+  StorageDao storageDao();
+
+  StorageHistoryDao storageHistoryDao();
+
+  XattrDao xattrDao();
+
+  FileDiffDao fileDiffDao();
+
+  AccessCountDao accessCountDao();
+
+  ClusterConfigDao clusterConfigDao();
+
+  GlobalConfigDao globalConfigDao();
+
+  DataNodeInfoDao dataNodeInfoDao();
+
+  DataNodeStorageInfoDao dataNodeStorageInfoDao();
+
+  BackUpInfoDao backUpInfoDao();
+
+  ClusterInfoDao clusterInfoDao();
+
+  SystemInfoDao systemInfoDao();
+
+  UserInfoDao userInfoDao();
+
+  FileStateDao fileStateDao();
+
+  CompressionFileDao compressionFileDao();
+
+  GeneralDao generalDao();
+
+  SmallFileDao smallFileDao();
+
+  ErasureCodingPolicyDao ecDao();
+
+  WhitelistDao whitelistDao();
+
+  StoragePolicyDao storagePolicyDao();
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/DataNodeInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/DataNodeInfoDao.java
@@ -18,105 +18,22 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.DataNodeInfo;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class DataNodeInfoDao {
-  private DataSource dataSource;
+public interface DataNodeInfoDao {
 
-  private static final String TABLE_NAME = "datanode_info";
+  List<DataNodeInfo> getAll();
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<DataNodeInfo> getByUuid(String uuid);
 
-  public DataNodeInfoDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  void insert(DataNodeInfo dataNodeInfo);
 
-  public List<DataNodeInfo> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
-        new DataNodeInfoRowMapper());
-  }
+  void insert(DataNodeInfo[] dataNodeInfos);
 
-  public List<DataNodeInfo> getByUuid(String uuid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM " + TABLE_NAME + " WHERE uuid = ?",
-        new Object[]{uuid}, new DataNodeInfoRowMapper());
-  }
+  void insert(List<DataNodeInfo> dataNodeInfos);
 
-  public void insert(DataNodeInfo dataNodeInfo) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    simpleJdbcInsert.execute(toMap(dataNodeInfo));
-  }
+  void delete(String uuid);
 
-  public void insert(DataNodeInfo[] dataNodeInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    Map<String, Object>[] maps = new Map[dataNodeInfos.length];
-    for (int i = 0; i < dataNodeInfos.length; i++) {
-      maps[i] = toMap(dataNodeInfos[i]);
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public void insert(List<DataNodeInfo> dataNodeInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    Map<String, Object>[] maps = new Map[dataNodeInfos.size()];
-    for (int i = 0; i < dataNodeInfos.size(); i++) {
-      maps[i] = toMap(dataNodeInfos.get(i));
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public void delete(String uuid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE uuid = ?";
-    jdbcTemplate.update(sql, uuid);
-  }
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.update(sql);
-  }
-
-  private Map<String, Object> toMap(DataNodeInfo dataNodeInfo) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("uuid", dataNodeInfo.getUuid());
-    parameters.put("hostname", dataNodeInfo.getHostname());
-    parameters.put("rpcAddress", dataNodeInfo.getRpcAddress());
-    parameters.put("cache_capacity", dataNodeInfo.getCacheCapacity());
-    parameters.put("cache_used", dataNodeInfo.getCacheUsed());
-    parameters.put("location", dataNodeInfo.getLocation());
-    return parameters;
-  }
-
-  class DataNodeInfoRowMapper implements RowMapper<DataNodeInfo> {
-
-    @Override
-    public DataNodeInfo mapRow(ResultSet resultSet, int i) throws SQLException {
-      return DataNodeInfo.newBuilder()
-          .setUuid(resultSet.getString("uuid"))
-          .setHostName(resultSet.getString("hostname"))
-          .setRpcAddress(resultSet.getString("rpcAddress"))
-          .setCacheCapacity(resultSet.getLong("cache_capacity"))
-          .setCacheUsed(resultSet.getLong("cache_used"))
-          .setLocation(resultSet.getString("location"))
-          .build();
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/DataNodeStorageInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/DataNodeStorageInfoDao.java
@@ -18,117 +18,24 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.DataNodeStorageInfo;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class DataNodeStorageInfoDao {
-  private DataSource dataSource;
+public interface DataNodeStorageInfoDao {
 
-  private static final String TABLE_NAME = "datanode_storage_info";
+  List<DataNodeStorageInfo> getAll();
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<DataNodeStorageInfo> getByUuid(String uuid);
 
-  public DataNodeStorageInfoDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<DataNodeStorageInfo> getBySid(int sid);
 
-  public List<DataNodeStorageInfo> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
-        new DataNodeStorageInfoRowMapper());
-  }
+  void insert(DataNodeStorageInfo dataNodeStorageInfoInfo);
 
-  public List<DataNodeStorageInfo> getByUuid(String uuid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM " + TABLE_NAME + " WHERE uuid = ?",
-        new Object[]{uuid}, new DataNodeStorageInfoRowMapper());
-  }
+  void insert(DataNodeStorageInfo[] dataNodeStorageInfos);
 
-  public List<DataNodeStorageInfo> getBySid(int sid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE sid = ?",
-        new Object[]{sid}, new DataNodeStorageInfoRowMapper());
-  }
+  void insert(List<DataNodeStorageInfo> dataNodeStorageInfos);
 
-  public void insert(DataNodeStorageInfo dataNodeStorageInfoInfo) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    simpleJdbcInsert.execute(toMap(dataNodeStorageInfoInfo));
-  }
+  void delete(String uuid);
 
-  public void insert(DataNodeStorageInfo[] dataNodeStorageInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    Map<String, Object>[] maps = new Map[dataNodeStorageInfos.length];
-    for (int i = 0; i < dataNodeStorageInfos.length; i++) {
-      maps[i] = toMap(dataNodeStorageInfos[i]);
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public void insert(List<DataNodeStorageInfo> dataNodeStorageInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    Map<String, Object>[] maps = new Map[dataNodeStorageInfos.size()];
-    for (int i = 0; i < dataNodeStorageInfos.size(); i++) {
-      maps[i] = toMap(dataNodeStorageInfos.get(i));
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public void delete(String uuid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE uuid = ?";
-    jdbcTemplate.update(sql, uuid);
-  }
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.update(sql);
-  }
-
-  private Map<String, Object> toMap(DataNodeStorageInfo dataNodeStorageInfo) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("uuid", dataNodeStorageInfo.getUuid());
-    parameters.put("sid", dataNodeStorageInfo.getSid());
-    parameters.put("state", dataNodeStorageInfo.getState());
-    parameters.put("storage_id", dataNodeStorageInfo.getStorageId());
-    parameters.put("failed", dataNodeStorageInfo.getFailed());
-    parameters.put("capacity", dataNodeStorageInfo.getCapacity());
-    parameters.put("dfs_used", dataNodeStorageInfo.getDfsUsed());
-    parameters.put("remaining", dataNodeStorageInfo.getRemaining());
-    parameters.put("block_pool_used", dataNodeStorageInfo.getBlockPoolUsed());
-    return parameters;
-  }
-
-  class DataNodeStorageInfoRowMapper implements RowMapper<DataNodeStorageInfo> {
-
-    @Override
-    public DataNodeStorageInfo mapRow(ResultSet resultSet, int i) throws SQLException {
-      return DataNodeStorageInfo.newBuilder()
-          .setUuid(resultSet.getString("uuid"))
-          .setSid(resultSet.getLong("sid"))
-          .setState(resultSet.getLong("state"))
-          .setStorageId(resultSet.getString("storage_id"))
-          .setFailed(resultSet.getLong("failed"))
-          .setCapacity(resultSet.getLong("capacity"))
-          .setDfsUsed(resultSet.getLong("dfs_used"))
-          .setRemaining(resultSet.getLong("remaining"))
-          .setBlockPoolUsed(resultSet.getLong("block_pool_used"))
-          .build();
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/ErasureCodingPolicyDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/ErasureCodingPolicyDao.java
@@ -19,81 +19,19 @@ package org.smartdata.metastore.dao;
 
 import org.smartdata.metastore.MetaStoreException;
 import org.smartdata.model.ErasureCodingPolicyInfo;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class ErasureCodingPolicyDao {
-  private static final String TABLE_NAME = "ec_policy";
-  private static final String ID = "id";
-  private static final String NAME = "policy_name";
-  private DataSource dataSource;
+public interface ErasureCodingPolicyDao {
+  ErasureCodingPolicyInfo getEcPolicyById(byte id) throws MetaStoreException;
 
-  public ErasureCodingPolicyDao(DataSource dataSource) throws MetaStoreException {
-    this.dataSource = dataSource;
-  }
+  ErasureCodingPolicyInfo getEcPolicyByName(String policyName) throws MetaStoreException;
 
-  public ErasureCodingPolicyInfo getEcPolicyById(byte id) throws MetaStoreException {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject
-        ("SELECT * FROM " + TABLE_NAME + " WHERE id=?", new Object[]{id}, new EcPolicyRowMapper());
-  }
+  List<ErasureCodingPolicyInfo> getAllEcPolicies();
 
-  public ErasureCodingPolicyInfo getEcPolicyByName(String policyName) throws MetaStoreException {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM " + TABLE_NAME + " WHERE policy_name=?",
-        new Object[]{policyName}, new EcPolicyRowMapper());
-  }
+  void insert(ErasureCodingPolicyInfo ecPolicy);
 
-  public List<ErasureCodingPolicyInfo> getAllEcPolicies() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new EcPolicyRowMapper());
-  }
+  void insert(List<ErasureCodingPolicyInfo> ecInfos);
 
-  public void insert(ErasureCodingPolicyInfo ecPolicy) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    simpleJdbcInsert.execute(toMap(ecPolicy));
-  }
-
-  public void insert(List<ErasureCodingPolicyInfo> ecInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    Map<String, Object>[] maps = new Map[ecInfos.size()];
-    for (int i = 0; i < ecInfos.size(); i++) {
-      maps[i] = toMap(ecInfos.get(i));
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.execute(sql);
-  }
-
-  private Map<String, Object> toMap(ErasureCodingPolicyInfo ecPolicy) {
-    Map<String, Object> map = new HashMap<>();
-    map.put(ID, ecPolicy.getID());
-    map.put(NAME, ecPolicy.getEcPolicyName());
-    return map;
-  }
-
-  class EcPolicyRowMapper implements RowMapper<ErasureCodingPolicyInfo> {
-    @Override
-    public ErasureCodingPolicyInfo mapRow(ResultSet resultSet, int i) throws SQLException {
-      ErasureCodingPolicyInfo ecPolicy = new ErasureCodingPolicyInfo(resultSet.getByte("id"),
-          resultSet.getString("policy_name"));
-      return ecPolicy;
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileDiffDao.java
@@ -17,314 +17,64 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.lang.StringUtils;
 import org.smartdata.model.FileDiff;
 import org.smartdata.model.FileDiffState;
-import org.smartdata.model.FileDiffType;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class FileDiffDao {
-  private static final String TABLE_NAME = "file_diff";
-  private DataSource dataSource;
-  public String uselessFileDiffStates;
+public interface FileDiffDao {
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  String getUselessFileDiffState();
 
-  public FileDiffDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-    this.uselessFileDiffStates = getUselessFileDiffState();
-  }
+  List<FileDiff> getAll();
 
-  public String getUselessFileDiffState() {
-    List<String> stateValues = new ArrayList<>();
-    for (FileDiffState state: FileDiffState.getUselessFileDiffState()) {
-      stateValues.add(String.valueOf(state.getValue()));
-    }
-    return StringUtils.join(stateValues, ",");
-  }
+  List<FileDiff> getPendingDiff();
 
-  public List<FileDiff> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new FileDiffRowMapper());
-  }
+  List<FileDiff> getByState(FileDiffState fileDiffState);
 
-  public List<FileDiff> getPendingDiff() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM " + TABLE_NAME + " WHERE state = 0", new FileDiffRowMapper());
-  }
+  List<FileDiff> getByState(String prefix, FileDiffState fileDiffState);
 
-  public List<FileDiff> getByState(FileDiffState fileDiffState) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate
-        .query("SELECT * FROM " + TABLE_NAME + " WHERE state = ?",
-            new Object[]{fileDiffState.getValue()}, new FileDiffRowMapper());
-  }
+  List<FileDiff> getPendingDiff(long rid);
 
-  public List<FileDiff> getByState(String prefix, FileDiffState fileDiffState) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate
-        .query(
-            "SELECT * FROM " + TABLE_NAME + " WHERE src LIKE ? and state = ?",
-            new Object[]{prefix + "%", fileDiffState.getValue()},
-            new FileDiffRowMapper());
-  }
+  List<FileDiff> getPendingDiff(String prefix);
 
-  public List<FileDiff> getPendingDiff(long rid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE did = ? and state = 0",
-        new Object[]{rid},
-        new FileDiffRowMapper());
-  }
+  List<FileDiff> getByIds(List<Long> dids);
 
-  public List<FileDiff> getPendingDiff(String prefix) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE src LIKE ? and state = 0",
-        new FileDiffRowMapper(), prefix + "%");
-  }
+  List<FileDiff> getByFileName(String fileName);
 
-  public List<FileDiff> getByIds(List<Long> dids) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE did IN (?)",
-        new Object[]{StringUtils.join(dids, ",")},
-        new FileDiffRowMapper());
-  }
+  List<String> getSyncPath(int size);
 
-  public List<FileDiff> getByFileName(String fileName) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE src = ?",
-        new Object[]{fileName}, new FileDiffRowMapper());
-  }
+  FileDiff getById(long did);
 
-  public List<String> getSyncPath(int size) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    if (size != 0) {
-      jdbcTemplate.setMaxRows(size);
-    }
-    String sql = "SELECT DISTINCT src FROM " + TABLE_NAME + " WHERE state = ?";
-    return jdbcTemplate
-        .queryForList(sql, String.class, FileDiffState.RUNNING.getValue());
-  }
+  void delete(long did);
 
-  public FileDiff getById(long did) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM " + TABLE_NAME + " WHERE did = ?",
-        new Object[]{did}, new FileDiffRowMapper());
-  }
+  int getUselessRecordsNum();
 
-  public void delete(long did) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE did = ?";
-    jdbcTemplate.update(sql, did);
-  }
+  int deleteUselessRecords(int num);
 
-  public int getUselessRecordsNum() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String query = "SELECT count(*) FROM " + TABLE_NAME + " WHERE state IN ("
-        + uselessFileDiffStates + ")";
-    return jdbcTemplate.queryForObject(query, Integer.class);
-  }
+  long insert(FileDiff fileDiff);
 
-  public int deleteUselessRecords(int num) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String queryDids = "SELECT did FROM " + TABLE_NAME + " WHERE state IN ("
-        + uselessFileDiffStates + ") ORDER BY create_time DESC LIMIT 1000 OFFSET " + num;
-    List<Long> dids = jdbcTemplate.queryForList(queryDids, Long.class);
-    if (dids.isEmpty()) {
-      return 0;
-    }
-    String unusedDids = StringUtils.join(dids, ",");
-    final String deleteUnusedFileDiff = "DELETE FROM " + TABLE_NAME + " where did IN ("
-        + unusedDids + ")";
-    jdbcTemplate.update(deleteUnusedFileDiff);
-    return dids.size();
-  }
+  void insert(FileDiff[] fileDiffs);
 
-  public long insert(FileDiff fileDiff) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    simpleJdbcInsert.usingGeneratedKeyColumns("did");
-    // return did
-    long did = simpleJdbcInsert.executeAndReturnKey(toMap(fileDiff)).longValue();
-    fileDiff.setDiffId(did);
-    return did;
-  }
+  Long[] insert(List<FileDiff> fileDiffs);
 
-  public void insert(FileDiff[] fileDiffs) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    Map[] maps = new Map[fileDiffs.length];
-    for (int i = 0; i < fileDiffs.length; i++) {
-      maps[i] = toMap(fileDiffs[i]);
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
+  int[] batchUpdate(
+      List<Long> dids, List<FileDiffState> states,
+      List<String> parameters);
 
-  public Long[] insert(List<FileDiff> fileDiffs) {
-    List<Long> dids = new ArrayList<>();
-    for (FileDiff fileDiff : fileDiffs) {
-      dids.add(insert(fileDiff));
-    }
-    return dids.toArray(new Long[dids.size()]);
-  }
+  int[] batchUpdate(
+      List<Long> dids, FileDiffState state);
 
-  public int[] batchUpdate(
-      final List<Long> dids, final List<FileDiffState> states,
-      final List<String> parameters) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+  int update(long did, FileDiffState state);
 
-    final String sql = "UPDATE " + TABLE_NAME + " SET state = ?, "
-        + "parameters = ? WHERE did = ?";
-    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
-      @Override
-      public void setValues(PreparedStatement ps, int i) throws SQLException {
-        ps.setShort(1, (short) states.get(i).getValue());
-        ps.setString(2, parameters.get(i));
-        ps.setLong(3, dids.get(i));
-      }
+  int update(long did, String src);
 
-      @Override
-      public int getBatchSize() {
-        return dids.size();
-      }
-    });
-  }
+  int update(long did, FileDiffState state,
+             String parameters);
 
-  public int[] batchUpdate(
-      final List<Long> dids, final FileDiffState state) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+  int[] update(FileDiff[] fileDiffs);
 
-    final String sql = "UPDATE " + TABLE_NAME + " SET state = ? "
-        + "WHERE did = ?";
-    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
-      @Override
-      public void setValues(PreparedStatement ps, int i) throws SQLException {
-        ps.setShort(1, (short) state.getValue());
-        ps.setLong(2, dids.get(i));
-      }
+  int update(FileDiff fileDiff);
 
-      @Override
-      public int getBatchSize() {
-        return dids.size();
-      }
-    });
-  }
-
-
-  public int update(long did, FileDiffState state) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET state = ? WHERE did = ?";
-    return jdbcTemplate.update(sql, state.getValue(), did);
-  }
-
-  public int update(long did, String src) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET src = ? WHERE did = ?";
-    return jdbcTemplate.update(sql, src, did);
-  }
-
-  public int update(long did, FileDiffState state,
-       String parameters) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET state = ?, "
-        + "parameters = ? WHERE did = ?";
-    return jdbcTemplate.update(sql, state.getValue(), parameters, did);
-  }
-
-  public int[] update(final FileDiff[] fileDiffs) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET "
-        + "rid = ?, "
-        + "diff_type = ?, "
-        + "src = ?, "
-        + "parameters = ?, "
-        + "state = ?, "
-        + "create_time = ? "
-        + "WHERE did = ?";
-    return jdbcTemplate.batchUpdate(sql,
-        new BatchPreparedStatementSetter() {
-          @Override
-          public void setValues(PreparedStatement ps,
-              int i) throws SQLException {
-            ps.setLong(1, fileDiffs[i].getRuleId());
-            ps.setInt(2, fileDiffs[i].getDiffType().getValue());
-            ps.setString(3, fileDiffs[i].getSrc());
-            ps.setString(4, fileDiffs[i].getParametersJsonString());
-            ps.setInt(5, fileDiffs[i].getState().getValue());
-            ps.setLong(6, fileDiffs[i].getCreateTime());
-            ps.setLong(7, fileDiffs[i].getDiffId());
-          }
-
-          @Override
-          public int getBatchSize() {
-            return fileDiffs.length;
-          }
-        });
-  }
-
-  public int update(final FileDiff fileDiff) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET "
-        + "rid = ?, "
-        + "diff_type = ?, "
-        + "src = ?, "
-        + "parameters = ?, "
-        + "state = ?, "
-        + "create_time = ? "
-        + "WHERE did = ?";
-    return jdbcTemplate.update(sql, fileDiff.getRuleId(),
-        fileDiff.getDiffType().getValue(), fileDiff.getSrc(),
-        fileDiff.getParametersJsonString(), fileDiff.getState().getValue(),
-        fileDiff.getCreateTime(), fileDiff.getDiffId());
-  }
-
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.execute(sql);
-  }
-
-  private Map<String, Object> toMap(FileDiff fileDiff) {
-    // System.out.println(fileDiff.getDiffType());
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("did", fileDiff.getDiffId());
-    parameters.put("rid", fileDiff.getRuleId());
-    parameters.put("diff_type", fileDiff.getDiffType().getValue());
-    parameters.put("src", fileDiff.getSrc());
-    parameters.put("parameters", fileDiff.getParametersJsonString());
-    parameters.put("state", fileDiff.getState().getValue());
-    parameters.put("create_time", fileDiff.getCreateTime());
-    return parameters;
-  }
-
-  class FileDiffRowMapper implements RowMapper<FileDiff> {
-    @Override
-    public FileDiff mapRow(ResultSet resultSet, int i) throws SQLException {
-      FileDiff fileDiff = new FileDiff();
-      fileDiff.setDiffId(resultSet.getLong("did"));
-      fileDiff.setRuleId(resultSet.getLong("rid"));
-      fileDiff.setDiffType(FileDiffType.fromValue((int) resultSet.getByte("diff_type")));
-      fileDiff.setSrc(resultSet.getString("src"));
-      fileDiff.setParametersFromJsonString(resultSet.getString("parameters"));
-      fileDiff.setState(FileDiffState.fromValue((int) resultSet.getByte("state")));
-      fileDiff.setCreateTime(resultSet.getLong("create_time"));
-      return fileDiff;
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,184 +18,41 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.FileInfo;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class FileInfoDao {
+public interface FileInfoDao {
 
-  private DataSource dataSource;
+  List<FileInfo> getAll();
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<FileInfo> getFilesByPrefix(String path);
 
-  public FileInfoDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<FileInfo> getFilesByPrefixInOrder(String path);
 
-  public List<FileInfo> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM file",
-        new FileInfoDao.FileInfoRowMapper());
-  }
+  List<FileInfo> getFilesByPaths(Collection<String> paths);
 
-  public List<FileInfo> getFilesByPrefix(String path) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM file WHERE path LIKE ?",
-        new FileInfoDao.FileInfoRowMapper(), path + "%");
-  }
+  FileInfo getById(long fid);
 
-  public List<FileInfo> getFilesByPrefixInOrder(String path) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM file WHERE path LIKE ? ORDER BY path ASC",
-        new FileInfoDao.FileInfoRowMapper(), path + "%");
-  }
+  FileInfo getByPath(String path);
 
-  public List<FileInfo> getFilesByPaths(Collection<String> paths) {
-    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
-        new NamedParameterJdbcTemplate(dataSource);
-    String sql = "SELECT * FROM file WHERE path IN (:paths)";
-    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-    parameterSource.addValue("paths", paths);
-    return namedParameterJdbcTemplate.query(sql,
-        parameterSource, new FileInfoRowMapper());
-  }
+  Map<String, Long> getPathFids(Collection<String> paths)
+      throws SQLException;
 
-  public FileInfo getById(long fid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM file WHERE fid = ?",
-        new Object[]{fid}, new FileInfoDao.FileInfoRowMapper());
-  }
+  Map<Long, String> getFidPaths(Collection<Long> ids)
+      throws SQLException;
 
-  public FileInfo getByPath(String path) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM file WHERE path = ?",
-        new Object[]{path}, new FileInfoDao.FileInfoRowMapper());
-  }
+  void insert(FileInfo fileInfo);
 
-  public Map<String, Long> getPathFids(Collection<String> paths)
-      throws SQLException {
-    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
-        new NamedParameterJdbcTemplate(dataSource);
-    Map<String, Long> pathToId = new HashMap<>();
-    String sql = "SELECT * FROM file WHERE path IN (:paths)";
-    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-    parameterSource.addValue("paths", paths);
-    List<FileInfo> files = namedParameterJdbcTemplate.query(sql,
-        parameterSource, new FileInfoRowMapper());
-    for (FileInfo file : files) {
-      pathToId.put(file.getPath(), file.getFileId());
-    }
-    return pathToId;
-  }
+  void insert(FileInfo[] fileInfos);
 
-  public Map<Long, String> getFidPaths(Collection<Long> ids)
-      throws SQLException {
-    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
-        new NamedParameterJdbcTemplate(dataSource);
-    Map<Long, String> idToPath = new HashMap<>();
-    String sql = "SELECT * FROM file WHERE fid IN (:ids)";
-    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-    parameterSource.addValue("ids", ids);
-    List<FileInfo> files = namedParameterJdbcTemplate.query(sql,
-        parameterSource, new FileInfoRowMapper());
-    for (FileInfo file : files) {
-      idToPath.put(file.getFileId(), file.getPath());
-    }
-    return idToPath;
-  }
+  int update(String path, int storagePolicy);
 
-  public void insert(FileInfo fileInfo) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("file");
-    simpleJdbcInsert.execute(toMap(fileInfo));
-  }
+  void deleteById(long fid);
 
-  public void insert(FileInfo[] fileInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("file");
-    Map<String, Object>[] maps = new Map[fileInfos.length];
-    for (int i = 0; i < fileInfos.length; i++) {
-      maps[i] = toMap(fileInfos[i]);
-    }
-    simpleJdbcInsert.executeBatch(maps);
-  }
+  void deleteByPath(String path);
 
-  public int update(String path, int storagePolicy) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "UPDATE file SET sid =? WHERE path = ?;";
-    return jdbcTemplate.update(sql, storagePolicy, path);
-  }
-
-  public void deleteById(long fid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM file WHERE fid = ?";
-    jdbcTemplate.update(sql, fid);
-  }
-
-  public void deleteByPath(String path) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM file WHERE path = ?";
-    jdbcTemplate.update(sql, path);
-  }
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM file";
-    jdbcTemplate.execute(sql);
-  }
-
-  private Map<String, Object> toMap(FileInfo fileInfo) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("path", fileInfo.getPath());
-    parameters.put("fid", fileInfo.getFileId());
-    parameters.put("length", fileInfo.getLength());
-    parameters.put("block_replication", fileInfo.getBlockReplication());
-    parameters.put("block_size", fileInfo.getBlocksize());
-    parameters.put("modification_time", fileInfo.getModificationTime());
-    parameters.put("access_time", fileInfo.getAccessTime());
-    parameters.put("is_dir", fileInfo.isdir());
-    parameters.put("sid", fileInfo.getStoragePolicy());
-    parameters
-        .put("owner", fileInfo.getOwner());
-    parameters
-        .put("owner_group", fileInfo.getGroup());
-    parameters.put("permission", fileInfo.getPermission());
-    parameters.put("ec_policy_id", fileInfo.getErasureCodingPolicy());
-    return parameters;
-  }
-
-  class FileInfoRowMapper implements RowMapper<FileInfo> {
-    @Override
-    public FileInfo mapRow(ResultSet resultSet, int i)
-        throws SQLException {
-      FileInfo fileInfo = new FileInfo(resultSet.getString("path"),
-          resultSet.getLong("fid"),
-          resultSet.getLong("length"),
-          resultSet.getBoolean("is_dir"),
-          resultSet.getShort("block_replication"),
-          resultSet.getLong("block_size"),
-          resultSet.getLong("modification_time"),
-          resultSet.getLong("access_time"),
-          resultSet.getShort("permission"),
-          resultSet.getString("owner"),
-          resultSet.getString("owner_group"),
-          resultSet.getByte("sid"),
-          resultSet.getByte("ec_policy_id")
-      );
-      return fileInfo;
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileStateDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileStateDao.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,125 +18,25 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.FileState;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import javax.sql.DataSource;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class FileStateDao {
-  private static final String TABLE_NAME = "file_state";
-  private DataSource dataSource;
+public interface FileStateDao {
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  void insertUpdate(FileState fileState);
 
-  public FileStateDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  int[] batchInsertUpdate(FileState[] fileStates);
 
-  public void insertUpdate(FileState fileState) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "REPLACE INTO " + TABLE_NAME + " (path, type, stage) VALUES (?,?,?)";
-    jdbcTemplate.update(sql, fileState.getPath(), fileState.getFileType().getValue(),
-        fileState.getFileStage().getValue());
-  }
+  FileState getByPath(String path);
 
-  public int[] batchInsertUpdate(final FileState[] fileStates) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "REPLACE INTO " + TABLE_NAME + " (path, type, stage) VALUES (?,?,?)";
-    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
-      @Override
-      public void setValues(PreparedStatement ps,
-          int i) throws SQLException {
-        ps.setString(1, fileStates[i].getPath());
-        ps.setInt(2, fileStates[i].getFileType().getValue());
-        ps.setInt(3, fileStates[i].getFileStage().getValue());
-      }
-      @Override
-      public int getBatchSize() {
-        return fileStates.length;
-      }
-    });
-  }
+  Map<String, FileState> getByPaths(List<String> paths);
 
-  public FileState getByPath(String path) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM " + TABLE_NAME + " WHERE path = ?",
-        new Object[]{path}, new FileStateRowMapper());
-  }
+  List<FileState> getAll();
 
-  public Map<String, FileState> getByPaths(List<String> paths) {
-    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
-        new NamedParameterJdbcTemplate(dataSource);
-    Map<String, FileState> fileStateMap = new HashMap<>();
-    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-    parameterSource.addValue("paths", paths);
-    List<FileState> fileStates = namedParameterJdbcTemplate.query(
-        "SELECT * FROM " + TABLE_NAME + " WHERE path IN (:paths)",
-        parameterSource,
-        new FileStateRowMapper());
-    for (FileState fileState : fileStates) {
-      fileStateMap.put(fileState.getPath(), fileState);
-    }
-    return fileStateMap;
-  }
+  void deleteByPath(String path, boolean recursive);
 
-  public List<FileState> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
-        new FileStateRowMapper());
-  }
+  int[] batchDelete(List<String> paths);
 
-  public void deleteByPath(String path, boolean recursive) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "DELETE FROM " + TABLE_NAME + " WHERE path = ?";
-    jdbcTemplate.update(sql, path);
-    if (recursive) {
-      sql = "DELETE FROM " + TABLE_NAME + " WHERE path LIKE ?";
-      jdbcTemplate.update(sql, path + "/%");
-    }
-  }
-
-  public int[] batchDelete(final List<String> paths) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE path = ?";
-    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
-      @Override
-      public void setValues(PreparedStatement ps, int i) throws SQLException {
-        ps.setString(1, paths.get(i));
-      }
-
-      @Override
-      public int getBatchSize() {
-            return paths.size();
-      }
-    });
-  }
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.execute(sql);
-  }
-
-  class FileStateRowMapper implements RowMapper<FileState> {
-    @Override
-    public FileState mapRow(ResultSet resultSet, int i)
-        throws SQLException {
-      return new FileState(resultSet.getString("path"),
-          FileState.FileType.fromValue(resultSet.getInt("type")),
-          FileState.FileStage.fromValue(resultSet.getInt("stage")));
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/GeneralDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/GeneralDao.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,19 +17,6 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.springframework.jdbc.core.JdbcTemplate;
-
-import javax.sql.DataSource;
-
-public class GeneralDao {
-  private DataSource dataSource;
-
-  public GeneralDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
-
-  public Long queryForLong(String sql) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(sql, Long.class);
-  }
+public interface GeneralDao {
+  Long queryForLong(String sql);
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/GlobalConfigDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/GlobalConfigDao.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,126 +17,30 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.lang.StringUtils;
 import org.smartdata.model.GlobalConfig;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class GlobalConfigDao {
-  private DataSource dataSource;
+public interface GlobalConfigDao {
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<GlobalConfig> getAll();
 
-  public GlobalConfigDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<GlobalConfig> getByIds(List<Long> cid);
 
-  public List<GlobalConfig> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM global_config", new GlobalConfigRowMapper());
-  }
+  GlobalConfig getById(long cid);
 
-  public List<GlobalConfig> getByIds(List<Long> cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query(
-        "SELECT * FROM global_config WHERE cid IN (?)",
-        new Object[] {StringUtils.join(cid, ",")},
-        new GlobalConfigRowMapper());
-  }
+  GlobalConfig getByPropertyName(String propertyName);
 
-  public GlobalConfig getById(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(
-        "SELECT * FROM global_config WHERE cid = ?",
-        new Object[] {cid},
-        new GlobalConfigRowMapper());
-  }
+  void deleteByName(String propertyName);
 
-  public GlobalConfig getByPropertyName(String propertyName) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(
-        "SELECT * FROM global_config WHERE property_name = ?",
-        new Object[] {propertyName},
-        new GlobalConfigRowMapper());
-  }
+  void delete(long cid);
 
-  public void deleteByName(String propertyName) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM global_config WHERE property_name = ?";
-    jdbcTemplate.update(sql, propertyName);
-  }
-
-  public void delete(long cid) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM global_config WHERE cid = ?";
-    jdbcTemplate.update(sql, cid);
-  }
-
-  public long insert(GlobalConfig globalConfig) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("global_config");
-    simpleJdbcInsert.usingGeneratedKeyColumns("cid");
-    long cid = simpleJdbcInsert.executeAndReturnKey(toMaps(globalConfig)).longValue();
-    globalConfig.setCid(cid);
-    return cid;
-  }
+  long insert(GlobalConfig globalConfig);
 
   // TODO slove the increment of key
-  public void insert(GlobalConfig[] globalConfigs) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName("global_config");
-    simpleJdbcInsert.usingGeneratedKeyColumns("cid");
-    Map<String, Object>[] maps = new Map[globalConfigs.length];
-    for (int i = 0; i < globalConfigs.length; i++) {
-      maps[i] = toMaps(globalConfigs[i]);
-    }
+  void insert(GlobalConfig[] globalConfigs);
 
-    int[] cids = simpleJdbcInsert.executeBatch(maps);
-    for (int i = 0; i < globalConfigs.length; i++) {
-      globalConfigs[i].setCid(cids[i]);
-    }
-  }
+  long getCountByName(String name);
 
-  public long getCountByName(String name) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject(
-        "SELECT COUNT(*) FROM global_config WHERE property_name = ?", Long.class, name);
-  }
-
-  public int update(String propertyName, String propertyValue) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE global_config SET property_value = ? WHERE property_name = ?";
-    return jdbcTemplate.update(sql, propertyValue, propertyName);
-  }
-
-  private Map<String, Object> toMaps(GlobalConfig globalConfig) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("cid", globalConfig.getCid());
-    parameters.put("property_name", globalConfig.getPropertyName());
-    parameters.put("property_value", globalConfig.getPropertyValue().toString());
-    return parameters;
-  }
-
-  class GlobalConfigRowMapper implements RowMapper<GlobalConfig> {
-
-    @Override
-    public GlobalConfig mapRow(ResultSet resultSet, int i) throws SQLException {
-      GlobalConfig globalConfig = new GlobalConfig();
-      globalConfig.setCid(resultSet.getLong("cid"));
-      globalConfig.setPropertyName(resultSet.getString("property_name"));
-      globalConfig.setPropertyValue(resultSet.getString("property_value"));
-      return globalConfig;
-    }
-  }
+  int update(String propertyName, String propertyValue);
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/SmallFileDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/SmallFileDao.java
@@ -18,114 +18,23 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.CompactFileState;
-import org.smartdata.model.FileContainerInfo;
 import org.smartdata.model.FileState;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 
-import javax.sql.DataSource;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 
-public class SmallFileDao {
-  private DataSource dataSource;
+public interface SmallFileDao {
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  void insertUpdate(CompactFileState compactFileState);
 
-  public SmallFileDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  int[] batchInsertUpdate(CompactFileState[] fileStates);
 
-  public void insertUpdate(CompactFileState compactFileState) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "REPLACE INTO small_file (path, container_file_path, offset, length)"
-        + " VALUES (?,?,?,?)";
-    jdbcTemplate.update(sql, compactFileState.getPath(),
-        compactFileState.getFileContainerInfo().getContainerFilePath(),
-        compactFileState.getFileContainerInfo().getOffset(),
-        compactFileState.getFileContainerInfo().getLength());
-  }
+  void deleteByPath(String path, boolean recursive);
 
-  public int[] batchInsertUpdate(final CompactFileState[] fileStates) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "REPLACE INTO small_file (path, container_file_path, offset, length)"
-        + " VALUES (?,?,?,?)";
-    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
-      @Override
-      public void setValues(PreparedStatement ps,
-          int i) throws SQLException {
-        ps.setString(1, fileStates[i].getPath());
-        ps.setString(2, fileStates[i].getFileContainerInfo().getContainerFilePath());
-        ps.setLong(3, fileStates[i].getFileContainerInfo().getOffset());
-        ps.setLong(4, fileStates[i].getFileContainerInfo().getLength());
-      }
-      @Override
-      public int getBatchSize() {
-        return fileStates.length;
-      }
-    });
-  }
+  int[] batchDelete(List<String> paths);
 
-  public void deleteByPath(String path, boolean recursive) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "DELETE FROM small_file WHERE path = ?";
-    jdbcTemplate.update(sql, path);
-    if (recursive) {
-      sql = "DELETE FROM small_file WHERE path LIKE ?";
-      jdbcTemplate.update(sql, path + "/%");
-    }
-  }
+  FileState getFileStateByPath(String path);
 
-  public int[] batchDelete(final List<String> paths) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM small_file WHERE path = ?";
-    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
-      @Override
-      public void setValues(PreparedStatement ps, int i) throws SQLException {
-        ps.setString(1, paths.get(i));
-      }
+  List<String> getSmallFilesByContainerFile(String containerFilePath);
 
-      @Override
-      public int getBatchSize() {
-        return paths.size();
-      }
-    });
-  }
-
-  public FileState getFileStateByPath(String path) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.queryForObject("SELECT * FROM small_file WHERE path = ?",
-        new Object[]{path}, new FileStateRowMapper());
-  }
-
-  public List<String> getSmallFilesByContainerFile(String containerFilePath) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT path FROM small_file where container_file_path = ?";
-    return jdbcTemplate.queryForList(sql, String.class, containerFilePath);
-  }
-
-  public List<String> getAllContainerFiles() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT DISTINCT container_file_path FROM small_file";
-    return jdbcTemplate.queryForList(sql, String.class);
-  }
-
-  private class FileStateRowMapper implements RowMapper<FileState> {
-    @Override
-    public FileState mapRow(ResultSet resultSet, int i)
-        throws SQLException {
-      return new CompactFileState(resultSet.getString("path"),
-          new FileContainerInfo(
-              resultSet.getString("container_file_path"),
-              resultSet.getLong("offset"),
-              resultSet.getLong("length"))
-      );
-    }
-  }
+  List<String> getAllContainerFiles();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/StoragePolicyDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/StoragePolicyDao.java
@@ -18,110 +18,24 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.StoragePolicy;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-public class StoragePolicyDao {
-  private DataSource dataSource;
+public interface StoragePolicyDao {
 
-  private static final String TABLE_NAME = "storage_policy";
+  Map<Integer, String> getStoragePolicyIdNameMap();
 
-  private Map<Integer, String> data = null;
+  String getStoragePolicyName(int sid);
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-    this.data = getStoragePolicyFromDB();
-  }
+  Integer getStorageSid(String policyName);
 
-  public StoragePolicyDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-    this.data = getStoragePolicyFromDB();
-  }
+  void insertStoragePolicyTable(StoragePolicy s);
 
-  private Map<Integer, String> getStoragePolicyFromDB() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "SELECT * FROM " + TABLE_NAME;
-    List<StoragePolicy> list = jdbcTemplate.query(sql,
-      new RowMapper<StoragePolicy>() {
-        public StoragePolicy mapRow(ResultSet rs, int rowNum) throws SQLException {
-          return new StoragePolicy(rs.getByte("sid"),
-            rs.getString("policy_name"));
-        }
-      });
-    Map<Integer, String> map = new HashMap<>();
-    for (StoragePolicy s : list) {
-      map.put((int) (s.getSid()), s.getPolicyName());
-    }
-    return map;
-  }
+  void deleteStoragePolicy(int sid);
 
-  public Map<Integer, String> getStoragePolicyIdNameMap() {
-    return this.data;
-  }
+  void deleteStoragePolicy(String policyName);
 
-  public String getStoragePolicyName(int sid) {
-    return this.data.get(sid);
-  }
+  boolean isExist(int sid);
 
-  public Integer getStorageSid(String policyName) {
-    for (Map.Entry<Integer, String> entry : this.data.entrySet()) {
-      if (entry.getValue().equals(policyName)) {
-        return entry.getKey();
-      }
-    }
-    return -1;
-  }
-
-  public synchronized void insertStoragePolicyTable(StoragePolicy s) {
-    if (!isExist(s.getPolicyName())) {
-      JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-      String sql = "INSERT INTO storage_policy (sid, policy_name) VALUES('"
-        + s.getSid() + "','" + s.getPolicyName() + "');";
-      jdbcTemplate.execute(sql);
-      this.data.put((int) (s.getSid()), s.getPolicyName());
-    }
-  }
-
-  public synchronized void deleteStoragePolicy(int sid) {
-    if (isExist(sid)) {
-      JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-      final String sql = "DELETE FROM " + TABLE_NAME + " WHERE sid = ?";
-      jdbcTemplate.update(sql, sid);
-      this.data.remove(sid);
-    }
-  }
-
-  public synchronized void deleteStoragePolicy(String policyName) {
-    Integer sid = getStorageSid(policyName);
-    deleteStoragePolicy(sid);
-  }
-
-  public boolean isExist(int sid) {
-    if (getStoragePolicyName(sid) != null) {
-      return  true;
-    }
-    return false;
-  }
-
-  public boolean isExist(String policyName) {
-    if (getStorageSid(policyName) != -1) {
-      return  true;
-    }
-    return false;
-  }
-
-  class StoragePolicyRowMapper implements RowMapper<StoragePolicy> {
-    @Override
-    public StoragePolicy mapRow(ResultSet resultSet, int i) throws SQLException {
-      return new StoragePolicy(resultSet.getByte("sid"), resultSet.getString("policy_name"));
-    }
-  }
+  boolean isExist(String policyName);
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/SystemInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/SystemInfoDao.java
@@ -17,109 +17,27 @@
  */
 package org.smartdata.metastore.dao;
 
-import org.apache.commons.lang.StringUtils;
 import org.smartdata.model.SystemInfo;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-public class SystemInfoDao {
-  private static final String TABLE_NAME = "sys_info";
-  private DataSource dataSource;
+public interface SystemInfoDao {
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<SystemInfo> getAll();
 
-  public SystemInfoDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  boolean containsProperty(String property);
 
-  public List<SystemInfo> getAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new SystemInfoRowMapper());
-  }
+  SystemInfo getByProperty(String property);
 
-  public boolean containsProperty(String property) {
-    return !list(property).isEmpty();
-  }
+  List<SystemInfo> getByProperties(List<String> properties);
 
-  private List<SystemInfo> list(String property) {
-    return new JdbcTemplate(dataSource)
-        .query(
-            "SELECT * FROM " + TABLE_NAME + " WHERE property = ?",
-            new Object[] {property},
-            new SystemInfoRowMapper());
-  }
+  void delete(String property);
 
-  public SystemInfo getByProperty(String property) {
-    List<SystemInfo> infos = list(property);
-    return infos.isEmpty() ? null : infos.get(0);
-  }
+  void insert(SystemInfo systemInfo);
 
-  public List<SystemInfo> getByProperties(List<String> properties) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE property IN (?)",
-        new Object[]{StringUtils.join(properties, ",")},
-        new SystemInfoRowMapper());
-  }
+  void insert(SystemInfo[] systemInfos);
 
-  public void delete(String property) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE property = ?";
-    jdbcTemplate.update(sql, property);
-  }
+  int update(SystemInfo systemInfo);
 
-  public void insert(SystemInfo systemInfo) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-    simpleJdbcInsert.execute(toMap(systemInfo));
-  }
-
-  public void insert(SystemInfo[] systemInfos) {
-    SimpleJdbcInsert simpleJdbcInsert = new SimpleJdbcInsert(dataSource);
-    simpleJdbcInsert.setTableName(TABLE_NAME);
-
-    Map<String, Object>[] maps = new Map[systemInfos.length];
-    for (int i = 0; i < systemInfos.length; i++){
-      maps[i] = toMap(systemInfos[i]);
-    }
-
-    simpleJdbcInsert.executeBatch(maps);
-  }
-
-  public int update(SystemInfo systemInfo) {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "UPDATE " + TABLE_NAME + " SET value = ? WHERE property = ?";
-    return jdbcTemplate.update(sql, systemInfo.getValue(), systemInfo.getProperty());
-  }
-
-  public void deleteAll() {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    final String sql = "DELETE FROM " + TABLE_NAME;
-    jdbcTemplate.execute(sql);
-  }
-
-  private Map<String, Object> toMap(SystemInfo systemInfo) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("property", systemInfo.getProperty());
-    parameters.put("value", systemInfo.getValue());
-    return parameters;
-  }
-
-  class SystemInfoRowMapper implements RowMapper<SystemInfo> {
-
-    @Override
-    public SystemInfo mapRow(ResultSet resultSet, int i) throws SQLException {
-      return new SystemInfo(resultSet.getString("property"), resultSet.getString("value"));
-    }
-  }
+  void deleteAll();
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/TableAddOpListener.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/TableAddOpListener.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ExecutorService;
 
 public abstract class TableAddOpListener {
   static final Logger LOG = LoggerFactory.getLogger(TableAddOpListener.class);
-  private Set<AccessCountTable> tablesUnderAggregating;
+  private final Set<AccessCountTable> tablesUnderAggregating;
 
   AccessCountTableDeque coarseGrainedTableDeque;
   AccessCountTableAggregator tableAggregator;
@@ -52,7 +52,7 @@ public abstract class TableAddOpListener {
       final List<AccessCountTable> tablesToAggregate =
           fineGrainedTableDeque.getTables(
               lastCoarseGrainedTable.getStartTime(), lastCoarseGrainedTable.getEndTime());
-      if (tablesToAggregate.size() > 0
+      if (!tablesToAggregate.isEmpty()
           && !tablesUnderAggregating.contains(lastCoarseGrainedTable)) {
         tablesUnderAggregating.add(lastCoarseGrainedTable);
         executorService.submit(
@@ -65,7 +65,8 @@ public abstract class TableAddOpListener {
                   tablesUnderAggregating.remove(lastCoarseGrainedTable);
                 } catch (MetaStoreException e) {
                   LOG.error(
-                      "Add AccessCount Table {} error", lastCoarseGrainedTable.getTableName(), e);
+                      "Add AccessCount Table {} error",
+                      lastCoarseGrainedTable.getTableName(), e);
                 }
               }
             });
@@ -85,8 +86,8 @@ public abstract class TableAddOpListener {
 
     @Override
     public AccessCountTable lastCoarseGrainedTableFor(Long endTime) {
-      Long lastEnd = endTime - (endTime % Constants.ONE_MINUTE_IN_MILLIS);
-      Long lastStart = lastEnd - Constants.ONE_MINUTE_IN_MILLIS;
+      long lastEnd = endTime - (endTime % Constants.ONE_MINUTE_IN_MILLIS);
+      long lastStart = lastEnd - Constants.ONE_MINUTE_IN_MILLIS;
       return new AccessCountTable(lastStart, lastEnd);
     }
   }
@@ -101,8 +102,8 @@ public abstract class TableAddOpListener {
 
     @Override
     public AccessCountTable lastCoarseGrainedTableFor(Long endTime) {
-      Long lastEnd = endTime - (endTime % Constants.ONE_HOUR_IN_MILLIS);
-      Long lastStart = lastEnd - Constants.ONE_HOUR_IN_MILLIS;
+      long lastEnd = endTime - (endTime % Constants.ONE_HOUR_IN_MILLIS);
+      long lastStart = lastEnd - Constants.ONE_HOUR_IN_MILLIS;
       return new AccessCountTable(lastStart, lastEnd);
     }
   }
@@ -117,8 +118,8 @@ public abstract class TableAddOpListener {
 
     @Override
     public AccessCountTable lastCoarseGrainedTableFor(Long endTime) {
-      Long lastEnd = endTime - (endTime % Constants.ONE_DAY_IN_MILLIS);
-      Long lastStart = lastEnd - Constants.ONE_DAY_IN_MILLIS;
+      long lastEnd = endTime - (endTime % Constants.ONE_DAY_IN_MILLIS);
+      long lastStart = lastEnd - Constants.ONE_DAY_IN_MILLIS;
       return new AccessCountTable(lastStart, lastEnd);
     }
   }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/TableEvictor.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/TableEvictor.java
@@ -24,7 +24,7 @@ import org.smartdata.metastore.MetaStoreException;
 
 public abstract class TableEvictor {
   public static final Logger LOG = LoggerFactory.getLogger(TableEvictor.class);
-  private MetaStore metaStore;
+  private final MetaStore metaStore;
 
   public TableEvictor(MetaStore metaStore) {
     this.metaStore = metaStore;

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/WhitelistDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/WhitelistDao.java
@@ -1,31 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.smartdata.metastore.dao;
 
-import org.springframework.jdbc.core.JdbcTemplate;
+public interface WhitelistDao {
 
-import javax.sql.DataSource;
+  String getLastFetchedDirs();
 
-public class WhitelistDao {
-    private static final String TABLE_NAME = "whitelist";
-    public static final String DIRS_FIELD = "last_fetched_dirs";
-    private DataSource dataSource;
-
-    public void setDataSource(DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
-
-    public WhitelistDao(DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
-
-    public String getLastFetchedDirs() {
-        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-        String sql = "SELECT * FROM " + TABLE_NAME;
-        return jdbcTemplate.queryForObject(sql, String.class);
-    }
-
-    public void updateTable(String newWhitelist) {
-        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-        final String sql = "UPDATE whitelist SET last_fetched_dirs =?";
-        jdbcTemplate.update(sql, newWhitelist);
-    }
+  void updateTable(String newWhitelist);
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/XattrDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/XattrDao.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,62 +18,16 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.XAttribute;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.JdbcTemplate;
 
-import javax.sql.DataSource;
-
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
-public class XattrDao {
-  private DataSource dataSource;
+public interface XattrDao {
 
-  public void setDataSource(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<XAttribute> getXattrList(Long fid) throws SQLException;
 
-  public XattrDao(DataSource dataSource) {
-    this.dataSource = dataSource;
-  }
+  List<XAttribute> getXattrList(String sql) throws SQLException;
 
-  public List<XAttribute> getXattrList(Long fid) throws SQLException {
-    String sql =
-      String.format("SELECT * FROM xattr WHERE fid = %s;", fid);
-    return getXattrList(sql);
-  }
-
-  public List<XAttribute> getXattrList(String sql) throws SQLException {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    List<XAttribute> list = new LinkedList<>();
-    List<Map<String, Object>> maplist = jdbcTemplate.queryForList(sql);
-    for (Map<String, Object> map : maplist) {
-      list.add(new XAttribute((String) map.get("namespace"),
-        (String) map.get("name"), (byte[]) map.get("value")));
-    }
-    return list;
-  }
-
-  public synchronized boolean insertXattrList(final Long fid, final List<XAttribute> attributes)
-    throws SQLException {
-    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    String sql = "INSERT INTO xattr (fid, namespace, name, value) VALUES (?, ?, ?, ?)";
-    int[] i = jdbcTemplate.batchUpdate(sql,
-      new BatchPreparedStatementSetter() {
-        public void setValues(PreparedStatement ps, int i) throws SQLException {
-          ps.setLong(1, fid);
-          ps.setString(2, attributes.get(i).getNameSpace());
-          ps.setString(3, attributes.get(i).getName());
-          ps.setBytes(4, attributes.get(i).getValue());
-        }
-
-        public int getBatchSize() {
-          return attributes.size();
-        }
-      });
-    return i.length == attributes.size();
-  }
+  boolean insertXattrList(Long fid, List<XAttribute> attributes)
+      throws SQLException;
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultAccessCountDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultAccessCountDao.java
@@ -1,0 +1,199 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.AccessCountDao;
+import org.smartdata.metastore.dao.AccessCountTable;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultAccessCountDao extends AbstractDao implements AccessCountDao {
+  private static final String TABLE_NAME = "access_count_table";
+
+  public DefaultAccessCountDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public void insert(AccessCountTable accessCountTable) {
+    insert(accessCountTable, this::toMap);
+  }
+
+  @Override
+  public void insert(AccessCountTable[] accessCountTables) {
+    insert(accessCountTables, this::toMap);
+  }
+
+  @Override
+  public List<AccessCountTable> getAccessCountTableByName(String name) {
+    String sql = "SELECT * FROM access_count_table WHERE table_name = '" + name + "'";
+    return jdbcTemplate.query(sql, new AccessCountRowMapper());
+  }
+
+  @Override
+  public void delete(Long startTime, Long endTime) {
+    final String sql =
+        String.format(
+            "DELETE FROM access_count_table WHERE start_time >= %s AND end_time <= %s",
+            startTime,
+            endTime);
+    jdbcTemplate.update(sql);
+  }
+
+  @Override
+  public void delete(AccessCountTable table) {
+    final String sql = "DELETE FROM access_count_table WHERE table_name = ?";
+    jdbcTemplate.update(sql, table.getTableName());
+  }
+
+  @Override
+  public List<AccessCountTable> getAllSortedTables() {
+    String sql = "SELECT * FROM access_count_table ORDER BY start_time ASC";
+    return jdbcTemplate.query(sql, new AccessCountRowMapper());
+  }
+
+  @Override
+  public void aggregateTables(
+      AccessCountTable destinationTable, List<AccessCountTable> tablesToAggregate) {
+    String create = AccessCountDao.createAccessCountTableSQL(destinationTable.getTableName());
+    jdbcTemplate.execute(create);
+    String insert =
+        String.format(
+            "INSERT INTO %s SELECT tmp1.%s, tmp1.%s "
+                + "FROM ((SELECT %s, SUM(%s) AS %s FROM(%s) tmp0 "
+                + "GROUP BY %s) AS tmp1 LEFT JOIN file ON file.fid = tmp1.fid);",
+            destinationTable.getTableName(),
+            DefaultAccessCountDao.FILE_FIELD,
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            DefaultAccessCountDao.FILE_FIELD,
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            getUnionStatement(tablesToAggregate),
+            DefaultAccessCountDao.FILE_FIELD);
+    jdbcTemplate.execute(insert);
+  }
+
+  @Override
+  public Map<Long, Integer> getHotFiles(List<AccessCountTable> tables, int topNum)
+      throws SQLException {
+    String statement =
+        String.format(
+            "SELECT %s, SUM(%s) AS %s FROM (%s) tmp WHERE %s IN (SELECT fid FROM file) "
+                + "GROUP BY %s ORDER BY %s DESC LIMIT %s",
+            DefaultAccessCountDao.FILE_FIELD,
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            getUnionStatement(tables),
+            DefaultAccessCountDao.FILE_FIELD,
+            DefaultAccessCountDao.FILE_FIELD,
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            topNum);
+    SqlRowSet sqlRowSet = jdbcTemplate.queryForRowSet(statement);
+    Map<Long, Integer> accessCounts = new HashMap<>();
+    while (sqlRowSet.next()) {
+      accessCounts.put(
+          sqlRowSet.getLong(DefaultAccessCountDao.FILE_FIELD),
+          sqlRowSet.getInt(DefaultAccessCountDao.ACCESSCOUNT_FIELD));
+    }
+    return accessCounts;
+  }
+
+  private String getUnionStatement(List<AccessCountTable> tables) {
+    StringBuilder union = new StringBuilder();
+    Iterator<AccessCountTable> tableIterator = tables.iterator();
+    while (tableIterator.hasNext()) {
+      AccessCountTable table = tableIterator.next();
+      if (tableIterator.hasNext()) {
+        union.append("SELECT * FROM " + table.getTableName() + " UNION ALL ");
+      } else {
+        union.append("SELECT * FROM " + table.getTableName());
+      }
+    }
+    return union.toString();
+  }
+
+  @Override
+  public void createProportionTable(AccessCountTable dest, AccessCountTable source)
+      throws SQLException {
+    double percentage =
+        ((double) dest.getEndTime() - dest.getStartTime())
+            / (source.getEndTime() - source.getStartTime());
+    jdbcTemplate.execute(AccessCountDao.createAccessCountTableSQL(dest.getTableName()));
+    String sql =
+        String.format(
+            "INSERT INTO %s SELECT %s, ROUND(%s.%s * %s) AS %s FROM %s",
+            dest.getTableName(),
+            DefaultAccessCountDao.FILE_FIELD,
+            source.getTableName(),
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            percentage,
+            DefaultAccessCountDao.ACCESSCOUNT_FIELD,
+            source.getTableName());
+    jdbcTemplate.execute(sql);
+  }
+
+  @Override
+  public void updateFid(long fidSrc, long fidDest) throws SQLException {
+    int failedNum = 0;
+    List<AccessCountTable> accessCountTables = getAllSortedTables();
+    for (AccessCountTable table : accessCountTables) {
+      String sql = String.format("update %s set %s=%s where %s=%s", table.getTableName(),
+          DefaultAccessCountDao.FILE_FIELD, fidDest, DefaultAccessCountDao.FILE_FIELD,
+          fidSrc);
+      try {
+        jdbcTemplate.execute(sql);
+      } catch (Exception e) {
+        failedNum++;
+      }
+    }
+    // Otherwise, ignore the exception because table evictor can evict access
+    // count tables, which is not synchronized. Even so, there is no impact on
+    // the measurement for data temperature.
+    if (failedNum == accessCountTables.size()) {
+      // Throw exception if all tables are not updated.
+      throw new SQLException("Failed to update fid!");
+    }
+  }
+
+  private Map<String, Object> toMap(AccessCountTable accessCountTable) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("table_name", accessCountTable.getTableName());
+    parameters.put("start_time", accessCountTable.getStartTime());
+    parameters.put("end_time", accessCountTable.getEndTime());
+    return parameters;
+  }
+
+  private static class AccessCountRowMapper implements RowMapper<AccessCountTable> {
+    @Override
+    public AccessCountTable mapRow(ResultSet resultSet, int i) throws SQLException {
+      return new AccessCountTable(
+          resultSet.getLong("start_time"),
+          resultSet.getLong("end_time"));
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultActionDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultActionDao.java
@@ -1,0 +1,497 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.smartdata.metastore.MetaStoreException;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.ActionDao;
+import org.smartdata.metastore.utils.MetaStoreUtils;
+import org.smartdata.model.ActionInfo;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultActionDao extends AbstractDao implements ActionDao {
+
+  private static final String TABLE_NAME = "action";
+  private static final String RUNNING_TIME = "running_time";
+  private final List<String> tableColumns;
+
+  public DefaultActionDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+    try (Connection conn = dataSource.getConnection()) {
+      tableColumns = MetaStoreUtils.getTableColumns(conn, "action");
+    } catch (SQLException | MetaStoreException e) {
+      throw new RuntimeException(e);
+    }
+    tableColumns.add(RUNNING_TIME);
+  }
+
+  @Override
+  public List<ActionInfo> getAll() {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
+        new ActionRowMapper());
+  }
+
+  @Override
+  public Long getCountOfAction() {
+    String sql = "SELECT COUNT(*) FROM " + TABLE_NAME;
+    return jdbcTemplate.queryForObject(sql, Long.class);
+  }
+
+  @Override
+  public ActionInfo getById(long aid) {
+    return jdbcTemplate.queryForObject(
+        "SELECT * FROM " + TABLE_NAME + " WHERE aid = ?",
+        new Object[]{aid},
+        new ActionRowMapper());
+  }
+
+  @Override
+  public List<ActionInfo> getByIds(List<Long> aids) {
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+        new NamedParameterJdbcTemplate(dataSource);
+    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+    parameterSource.addValue("aids", aids);
+    return namedParameterJdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE aid IN (:aids)",
+        parameterSource,
+        new ActionRowMapper());
+  }
+
+  @Override
+  public List<ActionInfo> getByCid(long cid) {
+    return jdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE cid = ?",
+        new Object[]{cid},
+        new ActionRowMapper());
+  }
+
+  @Override
+  public List<ActionInfo> getByCondition(String aidCondition,
+                                         String cidCondition) {
+    String sqlPrefix = "SELECT * FROM " + TABLE_NAME + " WHERE ";
+    String sqlAid = (aidCondition == null) ? "" : "AND aid " + aidCondition;
+    String sqlCid = (cidCondition == null) ? "" : "AND cid " + cidCondition;
+    String sqlFinal = "";
+    if (aidCondition != null || cidCondition != null) {
+      sqlFinal = sqlPrefix + sqlAid + sqlCid;
+      sqlFinal = sqlFinal.replaceFirst("AND ", "");
+    } else {
+      sqlFinal = sqlPrefix.replaceFirst("WHERE ", "");
+    }
+    return jdbcTemplate.query(sqlFinal, new ActionRowMapper());
+  }
+
+  @Override
+  public List<ActionInfo> getLatestActions(int size) {
+    if (size != 0) {
+      jdbcTemplate.setMaxRows(size);
+    }
+    String sql = "SELECT * FROM " + TABLE_NAME + " ORDER BY aid DESC";
+    return jdbcTemplate.query(sql, new ActionRowMapper());
+  }
+
+  @Override
+  public List<ActionInfo> getLatestActions(String actionName, int size) {
+    if (size != 0) {
+      jdbcTemplate.setMaxRows(size);
+    }
+    String sql = "SELECT * FROM " + TABLE_NAME + " WHERE action_name = ? ORDER BY aid DESC";
+    return jdbcTemplate.query(sql, new ActionRowMapper(), actionName);
+  }
+
+  @Override
+  public List<ActionInfo> getLatestActions(String actionName, int size,
+                                           boolean successful, boolean finished) {
+    if (size != 0) {
+      jdbcTemplate.setMaxRows(size);
+    }
+    String sql =
+        "SELECT * FROM "
+            + TABLE_NAME
+            +
+            " WHERE action_name = ? AND successful = ? AND finished = ? ORDER BY aid DESC";
+    return jdbcTemplate.query(sql, new ActionRowMapper(), actionName, successful, finished);
+  }
+
+  @Override
+  public List<ActionInfo> getLatestActions(String actionName, boolean successful,
+                                           int size) {
+    if (size != 0) {
+      jdbcTemplate.setMaxRows(size);
+    }
+    String sql =
+        "SELECT * FROM "
+            + TABLE_NAME
+            + " WHERE action_name = ? AND successful = ? ORDER BY aid DESC";
+    return jdbcTemplate.query(sql, new ActionRowMapper(), actionName, successful);
+  }
+
+  @Override
+  public List<ActionInfo> getAPageOfAction(long start, long offset, List<String> orderBy,
+                                           List<Boolean> isDesc) {
+    boolean ifHasAid = false;
+    String sql = "SELECT * FROM " + TABLE_NAME + " ORDER BY ";
+
+    for (int i = 0; i < orderBy.size(); i++) {
+      String ob = orderBy.get(i);
+      if (!tableColumns.contains(ob)) {
+        continue;
+      }
+
+      if (ob.equals("aid")) {
+        ifHasAid = true;
+      }
+
+      if (ob.equals(RUNNING_TIME)) {
+        sql = sql + "(finish_time - create_time)";
+      } else {
+        sql = sql + ob;
+      }
+      if (isDesc.size() > i) {
+        if (isDesc.get(i)) {
+          sql = sql + " desc ";
+        }
+        sql = sql + ",";
+      }
+    }
+
+    if (!ifHasAid) {
+      sql = sql + "aid,";
+    }
+
+    //delete the last char
+    sql = sql.substring(0, sql.length() - 1);
+    //add limit
+    sql = sql + " LIMIT " + start + "," + offset + ";";
+    return jdbcTemplate.query(sql, new ActionRowPartMapper());
+  }
+
+  @Override
+  public List<ActionInfo> getAPageOfAction(long start, long offset) {
+    String sql = "SELECT * FROM " + TABLE_NAME + " LIMIT " + start + "," + offset + ";";
+    return jdbcTemplate.query(sql, new ActionRowPartMapper());
+  }
+
+  @Override
+  public List<ActionInfo> searchAction(String path, long start, long offset, List<String> orderBy,
+                                       List<Boolean> isDesc, long[] retTotalNumActions) {
+    List<ActionInfo> ret;
+    boolean ifHasAid = false;
+    String sqlFilter = TABLE_NAME + " WHERE ("
+        + "aid LIKE '%" + path + "%' ESCAPE '/' "
+        + "OR cid LIKE '%" + path + "%' ESCAPE '/' "
+        + "OR args LIKE '%" + path + "%' ESCAPE '/' "
+        + "OR result LIKE '%" + path + "%' ESCAPE '/' "
+        + "OR exec_host LIKE '%" + path + "%' ESCAPE '/' "
+        + "OR progress LIKE '%" + path + "%' ESCAPE '/' "
+        + "OR log LIKE '%" + path + "%' ESCAPE '/' "
+        + "OR action_name LIKE '%" + path + "%' ESCAPE '/')";
+    String sql = "SELECT * FROM " + sqlFilter;
+    String sqlCount = "SELECT count(*) FROM " + sqlFilter + ";";
+    if (orderBy.size() == 0) {
+      sql += " LIMIT " + start + "," + offset + ";";
+      ret = jdbcTemplate.query(sql, new ActionRowMapper());
+    } else {
+      sql += " ORDER BY ";
+
+      for (int i = 0; i < orderBy.size(); i++) {
+        String ob = orderBy.get(i);
+        if (!tableColumns.contains(ob)) {
+          continue;
+        }
+
+        if (ob.equals("aid")) {
+          ifHasAid = true;
+        }
+
+        if (ob.equals(RUNNING_TIME)) {
+          sql = sql + "(finish_time - create_time)";
+        } else {
+          sql = sql + ob;
+        }
+
+        if (isDesc.size() > i) {
+          if (isDesc.get(i)) {
+            sql = sql + " desc ";
+          }
+          sql = sql + ",";
+        }
+      }
+
+      if (!ifHasAid) {
+        sql = sql + "aid,";
+      }
+
+      //delete the last char
+      sql = sql.substring(0, sql.length() - 1);
+      //add limit
+      sql = sql + " LIMIT " + start + "," + offset + ";";
+      ret = jdbcTemplate.query(sql, new ActionRowMapper());
+    }
+    if (retTotalNumActions != null) {
+      retTotalNumActions[0] = jdbcTemplate.queryForObject(sqlCount, Long.class);
+    }
+    return ret;
+  }
+
+  @Override
+  public List<ActionInfo> getLatestActions(String actionType, int size,
+                                           boolean finished) {
+    if (size != 0) {
+      jdbcTemplate.setMaxRows(size);
+    }
+    String sql =
+        "SELECT * FROM " + TABLE_NAME
+            + " WHERE action_name = ? AND finished = ? ORDER BY aid DESC";
+    return jdbcTemplate.query(sql, new ActionRowMapper(), actionType, finished);
+  }
+
+  @Override
+  public void delete(long aid) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE aid = ?";
+    jdbcTemplate.update(sql, aid);
+  }
+
+  @Override
+  public void deleteCmdletActions(long cid) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
+    jdbcTemplate.update(sql, cid);
+  }
+
+  @Override
+  public int[] batchDeleteCmdletActions(final List<Long> cids) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
+    return jdbcTemplate.batchUpdate(
+        sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setLong(1, cids.get(i));
+          }
+
+          public int getBatchSize() {
+            return cids.size();
+          }
+        });
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  @Override
+  public void insert(ActionInfo actionInfo) {
+    insert(actionInfo, this::toMap);
+  }
+
+  @Override
+  public void insert(ActionInfo[] actionInfos) {
+    insert(actionInfos, this::toMap);
+  }
+
+  @Override
+  public int[] replace(final ActionInfo[] actionInfos) {
+    String sql =
+        "REPLACE INTO "
+            + TABLE_NAME
+            + "(aid, "
+            + "cid, "
+            + "action_name, "
+            + "args, "
+            + "result, "
+            + "log, "
+            + "successful, "
+            + "create_time, "
+            + "finished, "
+            + "finish_time, "
+            + "exec_host, "
+            + "progress)"
+            + " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    return jdbcTemplate.batchUpdate(sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps,
+                                int i) throws SQLException {
+            ps.setLong(1, actionInfos[i].getActionId());
+            ps.setLong(2, actionInfos[i].getCmdletId());
+            ps.setString(3, actionInfos[i].getActionName());
+            ps.setString(4, actionInfos[i].getArgsJsonString());
+            ps.setString(5, actionInfos[i].getResult());
+            ps.setString(6, actionInfos[i].getLog());
+            ps.setBoolean(7, actionInfos[i].isSuccessful());
+            ps.setLong(8, actionInfos[i].getCreateTime());
+            ps.setBoolean(9, actionInfos[i].isFinished());
+            ps.setLong(10, actionInfos[i].getFinishTime());
+            ps.setString(11, actionInfos[i].getExecHost());
+            ps.setFloat(12, actionInfos[i].getProgress());
+          }
+
+          public int getBatchSize() {
+            return actionInfos.length;
+          }
+        });
+  }
+
+  @Override
+  public int update(final ActionInfo actionInfo) {
+    return update(new ActionInfo[]{actionInfo})[0];
+  }
+
+  @Override
+  public int[] update(final ActionInfo[] actionInfos) {
+    String sql =
+        "UPDATE "
+            + TABLE_NAME
+            + " SET "
+            + "result = ?, "
+            + "log = ?, "
+            + "successful = ?, "
+            + "create_time = ?, "
+            + "finished = ?, "
+            + "finish_time = ?, "
+            + "exec_host = ?, "
+            + "progress = ? "
+            + "WHERE aid = ?";
+    return jdbcTemplate.batchUpdate(sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps,
+                                int i) throws SQLException {
+            ps.setString(1, actionInfos[i].getResult());
+            ps.setString(2, actionInfos[i].getLog());
+            ps.setBoolean(3, actionInfos[i].isSuccessful());
+            ps.setLong(4, actionInfos[i].getCreateTime());
+            ps.setBoolean(5, actionInfos[i].isFinished());
+            ps.setLong(6, actionInfos[i].getFinishTime());
+            ps.setString(7, actionInfos[i].getExecHost());
+            ps.setFloat(8, actionInfos[i].getProgress());
+            ps.setLong(9, actionInfos[i].getActionId());
+          }
+
+          public int getBatchSize() {
+            return actionInfos.length;
+          }
+        });
+  }
+
+  @Override
+  public long getMaxId() {
+    Long ret = jdbcTemplate
+        .queryForObject("SELECT MAX(aid) FROM " + TABLE_NAME, Long.class);
+    if (ret == null) {
+      return 0;
+    } else {
+      return ret + 1;
+    }
+  }
+
+  private Map<String, Object> toMap(ActionInfo actionInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("aid", actionInfo.getActionId());
+    parameters.put("cid", actionInfo.getCmdletId());
+    parameters.put("action_name", actionInfo.getActionName());
+    parameters.put("args", actionInfo.getArgsJsonString());
+    parameters
+        .put("result", StringEscapeUtils.escapeJava(actionInfo.getResult()));
+    parameters.put("log", StringEscapeUtils.escapeJava(actionInfo.getLog()));
+    parameters.put("successful", actionInfo.isSuccessful());
+    parameters.put("create_time", actionInfo.getCreateTime());
+    parameters.put("finished", actionInfo.isFinished());
+    parameters.put("finish_time", actionInfo.getFinishTime());
+    parameters.put("exec_host", actionInfo.getExecHost());
+    parameters.put("progress", actionInfo.getProgress());
+    return parameters;
+  }
+
+  private static class ActionRowMapper implements RowMapper<ActionInfo> {
+
+    @Override
+    public ActionInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      ActionInfo actionInfo = new ActionInfo();
+      actionInfo.setActionId(resultSet.getLong("aid"));
+      actionInfo.setCmdletId(resultSet.getLong("cid"));
+      actionInfo.setActionName(resultSet.getString("action_name"));
+      actionInfo.setArgsFromJsonString(resultSet.getString("args"));
+      actionInfo.setResult(
+          StringEscapeUtils.unescapeJava(resultSet.getString("result")));
+      actionInfo
+          .setLog(StringEscapeUtils.unescapeJava(resultSet.getString("log")));
+      actionInfo.setSuccessful(resultSet.getBoolean("successful"));
+      actionInfo.setCreateTime(resultSet.getLong("create_time"));
+      actionInfo.setFinished(resultSet.getBoolean("finished"));
+      actionInfo.setFinishTime(resultSet.getLong("finish_time"));
+      actionInfo.setExecHost(resultSet.getString("exec_host"));
+      actionInfo.setProgress(resultSet.getFloat("progress"));
+      return actionInfo;
+    }
+  }
+
+  /**
+   * No need to set result & log. If arg value is too long, it will be
+   * truncated.
+   */
+  private static class ActionRowPartMapper implements RowMapper<ActionInfo> {
+    @Override
+    public ActionInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      ActionInfo actionInfo = new ActionInfo();
+      actionInfo.setActionId(resultSet.getLong("aid"));
+      actionInfo.setCmdletId(resultSet.getLong("cid"));
+      actionInfo.setActionName(resultSet.getString("action_name"));
+      actionInfo.setArgsFromJsonString(resultSet.getString("args"));
+      actionInfo.setArgs(
+          getTruncatedArgs(resultSet.getString("args")));
+      actionInfo.setSuccessful(resultSet.getBoolean("successful"));
+      actionInfo.setCreateTime(resultSet.getLong("create_time"));
+      actionInfo.setFinished(resultSet.getBoolean("finished"));
+      actionInfo.setFinishTime(resultSet.getLong("finish_time"));
+      actionInfo.setExecHost(resultSet.getString("exec_host"));
+      actionInfo.setProgress(resultSet.getFloat("progress"));
+      return actionInfo;
+    }
+
+    public Map<String, String> getTruncatedArgs(String jsonArgs) {
+      Gson gson = new Gson();
+      Map<String, String> args = gson.fromJson(jsonArgs,
+          new TypeToken<Map<String, String>>() {
+          }.getType());
+      for (Map.Entry<String, String> entry : args.entrySet()) {
+        if (entry.getValue().length() > 50) {
+          entry.setValue(entry.getValue().substring(0, 50) + "...");
+        }
+      }
+      return args;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultBackUpInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultBackUpInfoDao.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.BackUpInfoDao;
+import org.smartdata.model.BackUpInfo;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultBackUpInfoDao extends AbstractDao implements BackUpInfoDao {
+  private static final String TABLE_NAME = "backup_file";
+
+  public DefaultBackUpInfoDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<BackUpInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM backup_file", new BackUpInfoRowMapper());
+  }
+
+  @Override
+  public List<BackUpInfo> getByIds(List<Long> rids) {
+    return jdbcTemplate.query("SELECT * FROM backup_file WHERE rid IN (?)",
+        new Object[]{StringUtils.join(rids, ",")},
+        new BackUpInfoRowMapper());
+  }
+
+  @Override
+  public int getCountByRid(int rid) {
+    return jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM backup_file WHERE rid = ?", new Object[rid], Integer.class);
+  }
+
+  @Override
+  public BackUpInfo getByRid(long rid) {
+    return jdbcTemplate.queryForObject("SELECT * FROM backup_file WHERE rid = ?",
+        new Object[]{rid}, new BackUpInfoRowMapper());
+  }
+
+  @Override
+  public List<BackUpInfo> getBySrc(String src) {
+    return jdbcTemplate.query(
+        "SELECT * FROM backup_file WHERE src = ?", new Object[]{src},
+        new BackUpInfoRowMapper());
+  }
+
+  @Override
+  public List<BackUpInfo> getByDest(String dest) {
+    return jdbcTemplate.query(
+        "SELECT * FROM backup_file WHERE dest = ?", new Object[]{dest},
+        new BackUpInfoRowMapper());
+  }
+
+  @Override
+  public void delete(long rid) {
+    final String sql = "DELETE FROM backup_file WHERE rid = ?";
+    jdbcTemplate.update(sql, rid);
+  }
+
+  @Override
+  public void insert(BackUpInfo backUpInfo) {
+    insert(backUpInfo, this::toMap);
+  }
+
+  @Override
+  public void insert(BackUpInfo[] backUpInfos) {
+    insert(backUpInfos, this::toMap);
+  }
+
+  @Override
+  public int update(long rid, long period) {
+    String sql = "UPDATE backup_file SET period = ? WHERE rid = ?";
+    return jdbcTemplate.update(sql, period, rid);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM backup_file";
+    jdbcTemplate.execute(sql);
+  }
+
+  private Map<String, Object> toMap(BackUpInfo backUpInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("rid", backUpInfo.getRid());
+    parameters.put("src", backUpInfo.getSrc());
+    parameters.put("dest", backUpInfo.getDest());
+    parameters.put("period", backUpInfo.getPeriod());
+    return parameters;
+  }
+
+  private static class BackUpInfoRowMapper implements RowMapper<BackUpInfo> {
+
+    @Override
+    public BackUpInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      BackUpInfo backUpInfo = new BackUpInfo();
+      backUpInfo.setRid(resultSet.getLong("rid"));
+      backUpInfo.setSrc(resultSet.getString("src"));
+      backUpInfo.setDest(resultSet.getString("dest"));
+      backUpInfo.setPeriod(resultSet.getLong("period"));
+
+      return backUpInfo;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultCacheFileDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultCacheFileDao.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.CacheFileDao;
+import org.smartdata.metrics.FileAccessEvent;
+import org.smartdata.model.CachedFileStatus;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultCacheFileDao extends AbstractDao implements CacheFileDao {
+  private static final String TABLE_NAME = "cached_file";
+
+  public DefaultCacheFileDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<CachedFileStatus> getAll() {
+    return jdbcTemplate.query("SELECT * FROM cached_file",
+        new CacheFileRowMapper());
+  }
+
+  @Override
+  public CachedFileStatus getById(long fid) {
+    return jdbcTemplate.queryForObject("SELECT * FROM cached_file WHERE fid = ?",
+        new Object[]{fid}, new CacheFileRowMapper());
+  }
+
+  @Override
+  public List<Long> getFids() {
+    String sql = "SELECT fid FROM cached_file";
+    return jdbcTemplate.query(sql,
+        (rs, rowNum) -> rs.getLong("fid"));
+  }
+
+  @Override
+  public void insert(CachedFileStatus cachedFileStatus) {
+    insert(cachedFileStatus, this::toMap);
+  }
+
+  @Override
+  public void insert(long fid, String path, long fromTime,
+                     long lastAccessTime, int numAccessed) {
+    insert(new CachedFileStatus(fid, path,
+        fromTime, lastAccessTime, numAccessed));
+  }
+
+  @Override
+  public void insert(CachedFileStatus[] cachedFileStatusList) {
+    insert(cachedFileStatusList, this::toMap);
+  }
+
+  @Override
+  public int update(Long fid, Long lastAccessTime, Integer numAccessed) {
+    String sql = "UPDATE cached_file SET last_access_time = ?, accessed_num = ? WHERE fid = ?";
+    return jdbcTemplate.update(sql, lastAccessTime, numAccessed, fid);
+  }
+
+  @Override
+  public void update(Map<String, Long> pathToIds,
+                     List<FileAccessEvent> events) {
+    Map<Long, CachedFileStatus> idToStatus = new HashMap<>();
+    List<CachedFileStatus> cachedFileStatuses = getAll();
+    for (CachedFileStatus status : cachedFileStatuses) {
+      idToStatus.put(status.getFid(), status);
+    }
+    Collection<Long> cachedIds = idToStatus.keySet();
+    Collection<Long> needToUpdate = CollectionUtils.intersection(cachedIds, pathToIds.values());
+    if (!needToUpdate.isEmpty()) {
+      Map<Long, Integer> idToCount = new HashMap<>();
+      Map<Long, Long> idToLastTime = new HashMap<>();
+      for (FileAccessEvent event : events) {
+        Long fid = pathToIds.get(event.getPath());
+        if (needToUpdate.contains(fid)) {
+          if (!idToCount.containsKey(fid)) {
+            idToCount.put(fid, 0);
+          }
+          idToCount.put(fid, idToCount.get(fid) + 1);
+          if (!idToLastTime.containsKey(fid)) {
+            idToLastTime.put(fid, event.getTimestamp());
+          }
+          idToLastTime.put(fid, Math.max(event.getTimestamp(), idToLastTime.get(fid)));
+        }
+      }
+      for (Long fid : needToUpdate) {
+        Integer newAccessCount = idToStatus.get(fid).getNumAccessed() + idToCount.get(fid);
+        this.update(fid, idToLastTime.get(fid), newAccessCount);
+      }
+    }
+  }
+
+  @Override
+  public void deleteById(long fid) {
+    final String sql = "DELETE FROM cached_file WHERE fid = ?";
+    jdbcTemplate.update(sql, fid);
+  }
+
+  @Override
+  public void deleteAll() {
+    String sql = "DELETE FROM cached_file";
+    jdbcTemplate.execute(sql);
+  }
+
+  private Map<String, Object> toMap(CachedFileStatus cachedFileStatus) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("fid", cachedFileStatus.getFid());
+    parameters.put("path", cachedFileStatus.getPath());
+    parameters.put("from_time", cachedFileStatus.getFromTime());
+    parameters.put("last_access_time", cachedFileStatus.getLastAccessTime());
+    parameters.put("accessed_num", cachedFileStatus.getNumAccessed());
+    return parameters;
+  }
+
+
+  private static class CacheFileRowMapper implements RowMapper<CachedFileStatus> {
+
+    @Override
+    public CachedFileStatus mapRow(ResultSet resultSet, int i) throws SQLException {
+      CachedFileStatus cachedFileStatus = new CachedFileStatus();
+      cachedFileStatus.setFid(resultSet.getLong("fid"));
+      cachedFileStatus.setPath(resultSet.getString("path"));
+      cachedFileStatus.setFromTime(resultSet.getLong("from_time"));
+      cachedFileStatus.setLastAccessTime(resultSet.getLong("last_access_time"));
+      cachedFileStatus.setNumAccessed(resultSet.getInt("accessed_num"));
+      return cachedFileStatus;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultClusterConfigDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultClusterConfigDao.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.ClusterConfigDao;
+import org.smartdata.model.ClusterConfig;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultClusterConfigDao extends AbstractDao implements ClusterConfigDao {
+  private static final String TABLE_NAME = "cluster_config";
+
+  public DefaultClusterConfigDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<ClusterConfig> getAll() {
+    return jdbcTemplate.query("SELECT * FROM cluster_config", new ClusterConfigRowMapper());
+  }
+
+  @Override
+  public List<ClusterConfig> getByIds(List<Long> cids) {
+    return jdbcTemplate.query("SELECT * FROM cluster_config WHERE cid IN (?)",
+        new Object[]{StringUtils.join(cids, ",")},
+        new ClusterConfigRowMapper());
+  }
+
+  @Override
+  public ClusterConfig getById(long cid) {
+    return jdbcTemplate.queryForObject("SELECT * FROM cluster_config WHERE cid = ?",
+        new Object[]{cid}, new ClusterConfigRowMapper());
+  }
+
+  @Override
+  public long getCountByName(String name) {
+    return jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM cluster_config WHERE node_name = ?", Long.class, name);
+  }
+
+  @Override
+  public ClusterConfig getByName(String name) {
+    return jdbcTemplate.queryForObject("SELECT * FROM cluster_config WHERE node_name = ?",
+        new Object[]{name}, new ClusterConfigRowMapper());
+  }
+
+  @Override
+  public void delete(long cid) {
+    final String sql = "DELETE FROM cluster_config WHERE cid = ?";
+    jdbcTemplate.update(sql, cid);
+  }
+
+  @Override
+  public long insert(ClusterConfig clusterConfig) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    long cid = simpleJdbcInsert.executeAndReturnKey(toMap(clusterConfig)).longValue();
+    clusterConfig.setCid(cid);
+    return cid;
+  }
+
+  // TODO slove the increment of key
+  @Override
+  public void insert(ClusterConfig[] clusterConfigs) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    Map<String, Object>[] maps = new Map[clusterConfigs.length];
+    for (int i = 0; i < clusterConfigs.length; i++) {
+      maps[i] = toMap(clusterConfigs[i]);
+    }
+    int[] cids = simpleJdbcInsert.executeBatch(maps);
+
+    for (int i = 0; i < clusterConfigs.length; i++) {
+      clusterConfigs[i].setCid(cids[i]);
+    }
+  }
+
+  @Override
+  public int updateById(int cid, String configPath) {
+    final String sql = "UPDATE cluster_config SET config_path = ? WHERE cid = ?";
+    return jdbcTemplate.update(sql, configPath, cid);
+  }
+
+  @Override
+  public int updateByNodeName(String nodeName, String configPath) {
+    final String sql = "UPDATE cluster_config SET config_path = ? WHERE node_name = ?";
+    return jdbcTemplate.update(sql, configPath, nodeName);
+  }
+
+  @Override
+  protected SimpleJdbcInsert simpleJdbcInsert() {
+    return super.simpleJdbcInsert()
+        .usingGeneratedKeyColumns("cid");
+  }
+
+  private Map<String, Object> toMap(ClusterConfig clusterConfig) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("cid", clusterConfig.getCid());
+    parameters.put("config_path", clusterConfig.getConfigPath());
+    parameters.put("node_name", clusterConfig.getNodeName());
+    return parameters;
+  }
+
+  private static class ClusterConfigRowMapper implements RowMapper<ClusterConfig> {
+
+    @Override
+    public ClusterConfig mapRow(ResultSet resultSet, int i) throws SQLException {
+      ClusterConfig clusterConfig = new ClusterConfig();
+      clusterConfig.setCid(resultSet.getLong("cid"));
+      clusterConfig.setConfig_path(resultSet.getString("config_path"));
+      clusterConfig.setNodeName(resultSet.getString("node_name"));
+
+      return clusterConfig;
+    }
+  }
+
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultClusterInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultClusterInfoDao.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.ClusterInfoDao;
+import org.smartdata.model.ClusterInfo;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultClusterInfoDao extends AbstractDao implements ClusterInfoDao {
+  private static final String TABLE_NAME = "cluster_info";
+
+  public DefaultClusterInfoDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<ClusterInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new ClusterinfoRowMapper());
+  }
+
+  @Override
+  public ClusterInfo getById(long cid) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE cid = ?",
+        new Object[]{cid},
+        new ClusterinfoRowMapper()).get(0);
+  }
+
+  @Override
+  public List<ClusterInfo> getByIds(List<Long> cids) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE cid IN (?)",
+        new Object[]{StringUtils.join(cids, ",")},
+        new ClusterinfoRowMapper());
+  }
+
+  @Override
+  public void delete(long cid) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
+    jdbcTemplate.update(sql, cid);
+  }
+
+  @Override
+  public long insert(ClusterInfo clusterInfo) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    long cid = simpleJdbcInsert.executeAndReturnKey(toMap(clusterInfo)).longValue();
+    clusterInfo.setCid(cid);
+    return cid;
+  }
+
+  @Override
+  public void insert(ClusterInfo[] clusterInfos) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    Map<String, Object>[] maps = new Map[clusterInfos.length];
+    for (int i = 0; i < clusterInfos.length; i++) {
+      maps[i] = toMap(clusterInfos[i]);
+    }
+
+    int[] cids = simpleJdbcInsert.executeBatch(maps);
+    for (int i = 0; i < clusterInfos.length; i++) {
+      clusterInfos[i].setCid(cids[i]);
+    }
+  }
+
+  @Override
+  public int updateState(long cid, String state) {
+    String sql = "UPDATE " + TABLE_NAME + " SET state = ? WHERE cid = ?";
+    return jdbcTemplate.update(sql, state, cid);
+  }
+
+  @Override
+  public int updateType(long cid, String type) {
+    String sql = "UPDATE " + TABLE_NAME + " SET type = ? WHERE cid = ?";
+    return jdbcTemplate.update(sql, type, cid);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  @Override
+  public int getCountByName(String name) {
+    final String sql = "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE name = ?";
+    return jdbcTemplate.queryForObject(sql, Integer.class, name);
+  }
+
+  @Override
+  protected SimpleJdbcInsert simpleJdbcInsert() {
+    return super.simpleJdbcInsert()
+        .usingGeneratedKeyColumns("cid");
+  }
+
+  private Map<String, Object> toMap(ClusterInfo clusterInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("cid", clusterInfo.getCid());
+    parameters.put("name", clusterInfo.getName());
+    parameters.put("url", clusterInfo.getUrl());
+    parameters.put("conf_path", clusterInfo.getConfPath());
+    parameters.put("state", clusterInfo.getState());
+    parameters.put("type", clusterInfo.getType());
+
+    return parameters;
+  }
+
+  private static class ClusterinfoRowMapper implements RowMapper<ClusterInfo> {
+
+    @Override
+    public ClusterInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      ClusterInfo clusterInfo = new ClusterInfo();
+      clusterInfo.setCid(resultSet.getLong("cid"));
+      clusterInfo.setName(resultSet.getString("name"));
+      clusterInfo.setUrl(resultSet.getString("url"));
+      clusterInfo.setConfPath(resultSet.getString("conf_path"));
+      clusterInfo.setState(resultSet.getString("state"));
+      clusterInfo.setType(resultSet.getString("type"));
+
+      return clusterInfo;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultCmdletDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultCmdletDao.java
@@ -1,0 +1,390 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.CmdletDao;
+import org.smartdata.model.CmdletInfo;
+import org.smartdata.model.CmdletState;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultCmdletDao extends AbstractDao implements CmdletDao {
+  private static final String TABLE_NAME = "cmdlet";
+  private final String terminatedStates;
+
+  public DefaultCmdletDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+    terminatedStates = getTerminatedStatesString();
+  }
+
+  @Override
+  public List<CmdletInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new CmdletRowMapper());
+  }
+
+  @Override
+  public List<CmdletInfo> getAPageOfCmdlet(long start, long offset,
+                                           List<String> orderBy, List<Boolean> isDesc) {
+    boolean ifHasAid = false;
+    StringBuilder sql =
+        new StringBuilder("SELECT * FROM " + TABLE_NAME + " ORDER BY ");
+    for (int i = 0; i < orderBy.size(); i++) {
+      if (orderBy.get(i).equals("cid")) {
+        ifHasAid = true;
+      }
+      sql.append(orderBy.get(i));
+      if (isDesc.size() > i) {
+        if (isDesc.get(i)) {
+          sql.append(" desc ");
+        }
+        sql.append(",");
+      }
+    }
+    if (!ifHasAid) {
+      sql.append("cid,");
+    }
+    //delete the last char
+    sql = new StringBuilder(sql.substring(0, sql.length() - 1));
+    //add limit
+    sql.append(" LIMIT ").append(start).append(",").append(offset).append(";");
+    return jdbcTemplate.query(sql.toString(), new CmdletRowMapper());
+  }
+
+  @Override
+  public List<CmdletInfo> getAPageOfCmdlet(long start, long offset) {
+    String sql = "SELECT * FROM " + TABLE_NAME + " LIMIT " + start + "," + offset + ";";
+    return jdbcTemplate.query(sql, new CmdletRowMapper());
+  }
+
+  @Override
+  public List<CmdletInfo> getByIds(List<Long> aids) {
+    return jdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE aid IN (?)",
+        new Object[]{StringUtils.join(aids, ",")},
+        new CmdletRowMapper());
+  }
+
+  @Override
+  public CmdletInfo getById(long cid) {
+    return jdbcTemplate.queryForObject(
+        "SELECT * FROM " + TABLE_NAME + " WHERE cid = ?",
+        new Object[]{cid},
+        new CmdletRowMapper());
+  }
+
+  @Override
+  public List<CmdletInfo> getByRid(long rid) {
+    return jdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE rid = ?",
+        new Object[]{rid},
+        new CmdletRowMapper());
+  }
+
+  @Override
+  public long getNumByRid(long rid) {
+    return jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE rid = ?",
+        new Object[]{rid},
+        Long.class);
+  }
+
+  @Override
+  public List<CmdletInfo> getByRid(long rid, long start, long offset) {
+    String sql = "SELECT * FROM " + TABLE_NAME + " WHERE rid = " + rid
+        + " LIMIT " + start + "," + offset + ";";
+    return jdbcTemplate.query(sql, new CmdletRowMapper());
+  }
+
+  @Override
+  public List<CmdletInfo> getByRid(long rid, long start, long offset,
+                                   List<String> orderBy, List<Boolean> isDesc) {
+    boolean ifHasAid = false;
+    StringBuilder sql =
+        new StringBuilder("SELECT * FROM " + TABLE_NAME + " WHERE rid = " + rid
+            + " ORDER BY ");
+    for (int i = 0; i < orderBy.size(); i++) {
+      if (orderBy.get(i).equals("cid")) {
+        ifHasAid = true;
+      }
+      sql.append(orderBy.get(i));
+      if (isDesc.size() > i) {
+        if (isDesc.get(i)) {
+          sql.append(" desc ");
+        }
+        sql.append(",");
+      }
+    }
+    if (!ifHasAid) {
+      sql.append("cid,");
+    }
+
+    //delete the last char
+    sql = new StringBuilder(sql.substring(0, sql.length() - 1));
+    //add limit
+    sql.append(" LIMIT ").append(start).append(",").append(offset).append(";");
+    return jdbcTemplate.query(sql.toString(), new CmdletRowMapper());
+  }
+
+  @Override
+  public List<CmdletInfo> getByState(CmdletState state) {
+    return jdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE state = ?",
+        new Object[]{state.getValue()},
+        new CmdletRowMapper());
+  }
+
+  @Override
+  public int getNumCmdletsInTerminiatedStates() {
+    String query = "SELECT count(*) FROM " + TABLE_NAME
+        + " WHERE state IN (" + terminatedStates + ")";
+    return jdbcTemplate.queryForObject(query, Integer.class);
+  }
+
+  @Override
+  public List<CmdletInfo> getByCondition(
+      String cidCondition, String ridCondition, CmdletState state) {
+    String sqlPrefix = "SELECT * FROM " + TABLE_NAME + " WHERE ";
+    String sqlCid = (cidCondition == null) ? "" : "AND cid " + cidCondition;
+    String sqlRid = (ridCondition == null) ? "" : "AND rid " + ridCondition;
+    String sqlState = (state == null) ? "" : "AND state = " + state.getValue();
+    String sqlFinal = "";
+    if (cidCondition != null || ridCondition != null || state != null) {
+      sqlFinal = sqlPrefix + sqlCid + sqlRid + sqlState;
+      sqlFinal = sqlFinal.replaceFirst("AND ", "");
+    } else {
+      sqlFinal = sqlPrefix.replaceFirst("WHERE ", "");
+    }
+    return jdbcTemplate.query(sqlFinal, new CmdletRowMapper());
+  }
+
+  @Override
+  public void delete(long cid) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
+    jdbcTemplate.update(sql, cid);
+  }
+
+  @Override
+  public int[] batchDelete(final List<Long> cids) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE cid = ?";
+    return jdbcTemplate.batchUpdate(
+        sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setLong(1, cids.get(i));
+          }
+
+          public int getBatchSize() {
+            return cids.size();
+          }
+        });
+  }
+
+  @Override
+  public int deleteBeforeTime(long timestamp) {
+
+    final String querysql = "SELECT cid FROM " + TABLE_NAME
+        + " WHERE  generate_time < ? AND state IN (" + terminatedStates + ")";
+    List<Long> cids = jdbcTemplate.queryForList(querysql, new Object[]{timestamp}, Long.class);
+    if (cids.isEmpty()) {
+      return 0;
+    }
+    final String deleteCmds = "DELETE FROM " + TABLE_NAME
+        + " WHERE generate_time < ? AND state IN (" + terminatedStates + ")";
+    jdbcTemplate.update(deleteCmds, timestamp);
+    final String deleteActions = "DELETE FROM action WHERE cid IN ("
+        + StringUtils.join(cids, ",") + ")";
+    jdbcTemplate.update(deleteActions);
+    return cids.size();
+  }
+
+  @Override
+  public int deleteKeepNewCmd(long num) {
+    final String queryCids = "SELECT cid FROM " + TABLE_NAME
+        + " WHERE state IN (" + terminatedStates + ")"
+        + " ORDER BY generate_time DESC LIMIT 100000 OFFSET " + num;
+    List<Long> cids = jdbcTemplate.queryForList(queryCids, Long.class);
+    if (cids.isEmpty()) {
+      return 0;
+    }
+    String deleteCids = StringUtils.join(cids, ",");
+    final String deleteCmd = "DELETE FROM " + TABLE_NAME + " WHERE cid IN (" + deleteCids + ")";
+    jdbcTemplate.update(deleteCmd);
+    final String deleteActions = "DELETE FROM action WHERE cid IN (" + deleteCids + ")";
+    jdbcTemplate.update(deleteActions);
+    return cids.size();
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  @Override
+  public void insert(CmdletInfo cmdletInfo) {
+    insert(cmdletInfo, this::toMap);
+  }
+
+  @Override
+  public void insert(CmdletInfo[] cmdletInfos) {
+    insert(cmdletInfos, this::toMap);
+  }
+
+  @Override
+  public int[] replace(final CmdletInfo[] cmdletInfos) {
+    String sql = "REPLACE INTO " + TABLE_NAME
+        + "(cid, "
+        + "rid, "
+        + "aids, "
+        + "state, "
+        + "parameters, "
+        + "generate_time, "
+        + "state_changed_time)"
+        + " VALUES(?, ?, ?, ?, ?, ?, ?)";
+
+    return jdbcTemplate.batchUpdate(
+        sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setLong(1, cmdletInfos[i].getCid());
+            ps.setLong(2, cmdletInfos[i].getRid());
+            ps.setString(3, StringUtils.join(cmdletInfos[i].getAidsString(), ","));
+            ps.setLong(4, cmdletInfos[i].getState().getValue());
+            ps.setString(5, cmdletInfos[i].getParameters());
+            ps.setLong(6, cmdletInfos[i].getGenerateTime());
+            ps.setLong(7, cmdletInfos[i].getStateChangedTime());
+          }
+
+          public int getBatchSize() {
+            return cmdletInfos.length;
+          }
+        });
+  }
+
+  @Override
+  public int update(long cid, int state) {
+    String sql =
+        "UPDATE " + TABLE_NAME + " SET state = ?, state_changed_time = ? WHERE cid = ?";
+    return jdbcTemplate.update(sql, state, System.currentTimeMillis(), cid);
+  }
+
+  @Override
+  public int update(long cid, String parameters, int state) {
+    String sql =
+        "UPDATE "
+            + TABLE_NAME
+            + " SET parameters = ?, state = ?, state_changed_time = ? WHERE cid = ?";
+    return jdbcTemplate.update(sql, parameters, state, System.currentTimeMillis(), cid);
+  }
+
+  @Override
+  public int update(final CmdletInfo cmdletInfo) {
+    List<CmdletInfo> cmdletInfos = new ArrayList<>();
+    cmdletInfos.add(cmdletInfo);
+    return update(cmdletInfos)[0];
+  }
+
+  @Override
+  public int[] update(final List<CmdletInfo> cmdletInfos) {
+    String sql = "UPDATE " + TABLE_NAME + " SET  state = ?, state_changed_time = ? WHERE cid = ?";
+    return jdbcTemplate.batchUpdate(
+        sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setInt(1, cmdletInfos.get(i).getState().getValue());
+            ps.setLong(2, cmdletInfos.get(i).getStateChangedTime());
+            ps.setLong(3, cmdletInfos.get(i).getCid());
+          }
+
+          public int getBatchSize() {
+            return cmdletInfos.size();
+          }
+        });
+  }
+
+  @Override
+  public long getMaxId() {
+    Long ret = jdbcTemplate.queryForObject("SELECT MAX(cid) FROM " + TABLE_NAME, Long.class);
+    if (ret == null) {
+      return 0;
+    } else {
+      return ret + 1;
+    }
+  }
+
+  private Map<String, Object> toMap(CmdletInfo cmdletInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("cid", cmdletInfo.getCid());
+    parameters.put("rid", cmdletInfo.getRid());
+    parameters.put("aids", StringUtils.join(cmdletInfo.getAidsString(), ","));
+    parameters.put("state", cmdletInfo.getState().getValue());
+    parameters.put("parameters", cmdletInfo.getParameters());
+    parameters.put("generate_time", cmdletInfo.getGenerateTime());
+    parameters.put("state_changed_time", cmdletInfo.getStateChangedTime());
+    return parameters;
+  }
+
+  private String getTerminatedStatesString() {
+    String finishedState = "";
+    for (CmdletState cmdletState : CmdletState.getTerminalStates()) {
+      finishedState = finishedState + cmdletState.getValue() + ",";
+    }
+    return finishedState.substring(0, finishedState.length() - 1);
+  }
+
+  private static class CmdletRowMapper implements RowMapper<CmdletInfo> {
+
+    @Override
+    public CmdletInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      CmdletInfo.Builder builder = CmdletInfo.newBuilder();
+      builder.setCid(resultSet.getLong("cid"));
+      builder.setRid(resultSet.getLong("rid"));
+      builder.setAids(convertStringListToLong(resultSet.getString("aids").split(",")));
+      builder.setState(CmdletState.fromValue((int) resultSet.getByte("state")));
+      builder.setParameters(resultSet.getString("parameters"));
+      builder.setGenerateTime(resultSet.getLong("generate_time"));
+      builder.setStateChangedTime(resultSet.getLong("state_changed_time"));
+      return builder.build();
+    }
+
+    private List<Long> convertStringListToLong(String[] strings) {
+      List<Long> ret = new ArrayList<>();
+      try {
+        for (String s : strings) {
+          ret.add(Long.valueOf(s));
+        }
+      } catch (NumberFormatException e) {
+        // Return empty
+        ret.clear();
+      }
+      return ret;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultCompressionFileDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultCompressionFileDao.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.CompressionFileDao;
+import org.smartdata.model.CompressionFileState;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CompressionFileDao.
+ */
+public class DefaultCompressionFileDao extends AbstractDao implements CompressionFileDao {
+  private static final String TABLE_NAME = "compression_file";
+
+  public DefaultCompressionFileDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public void insert(CompressionFileState compressionInfo) {
+    insert(compressionInfo, this::toMap);
+  }
+
+  @Override
+  public void insertUpdate(CompressionFileState compressionInfo) {
+    Gson gson = new Gson();
+    String sql = "REPLACE INTO " + TABLE_NAME
+        + "(path, buffer_size, compression_impl, "
+        + "original_length, compressed_length, originalPos, compressedPos)"
+        + " VALUES(?,?,?,?,?,?,?);";
+    jdbcTemplate.update(sql, compressionInfo.getPath(),
+        compressionInfo.getBufferSize(),
+        compressionInfo.getCompressionImpl(),
+        compressionInfo.getOriginalLength(),
+        compressionInfo.getCompressedLength(),
+        gson.toJson(compressionInfo.getOriginalPos()),
+        gson.toJson(compressionInfo.getCompressedPos()));
+  }
+
+  @Override
+  public void deleteByPath(String filePath) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE path = ?";
+    jdbcTemplate.update(sql, filePath);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  @Override
+  public List<CompressionFileState> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
+        new CompressFileRowMapper());
+  }
+
+  @Override
+  public CompressionFileState getInfoByPath(String filePath) {
+    return jdbcTemplate.queryForObject("SELECT * FROM " + TABLE_NAME + " WHERE path = ?",
+        new Object[]{filePath}, new CompressFileRowMapper());
+  }
+
+  private Map<String, Object> toMap(CompressionFileState compressionInfo) {
+    Gson gson = new Gson();
+    Map<String, Object> parameters = new HashMap<>();
+    Long[] originalPos = compressionInfo.getOriginalPos();
+    Long[] compressedPos = compressionInfo.getCompressedPos();
+    String originalPosGson = gson.toJson(originalPos);
+    String compressedPosGson = gson.toJson(compressedPos);
+    parameters.put("path", compressionInfo.getPath());
+    parameters.put("buffer_size", compressionInfo.getBufferSize());
+    parameters.put("compression_impl", compressionInfo.getCompressionImpl());
+    parameters.put("original_length", compressionInfo.getOriginalLength());
+    parameters.put("compressed_length", compressionInfo.getCompressedLength());
+    parameters.put("originalPos", originalPosGson);
+    parameters.put("compressedPos", compressedPosGson);
+    return parameters;
+  }
+
+  private static class CompressFileRowMapper implements RowMapper<CompressionFileState> {
+    @Override
+    public CompressionFileState mapRow(ResultSet resultSet, int i) throws SQLException {
+      Gson gson = new Gson();
+      String originalPosGson = resultSet.getString("originalPos");
+      String compressedPosGson = resultSet.getString("compressedPos");
+      Long[] originalPos = gson.fromJson(originalPosGson, new TypeToken<Long[]>() {
+      }.getType());
+      Long[] compressedPos = gson.fromJson(compressedPosGson, new TypeToken<Long[]>() {
+      }.getType());
+      CompressionFileState compressionInfo =
+          CompressionFileState.newBuilder()
+              .setFileName(resultSet.getString("path"))
+              .setBufferSize(resultSet.getInt("buffer_size"))
+              .setCompressImpl(resultSet.getString("compression_impl"))
+              .setOriginalLength(resultSet.getLong("original_length"))
+              .setCompressedLength(resultSet.getLong("compressed_length"))
+              .setOriginalPos(originalPos)
+              .setCompressedPos(compressedPos)
+              .build();
+      return compressionInfo;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultDaoProvider.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultDaoProvider.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.DBPool;
+import org.smartdata.metastore.dao.AccessCountDao;
+import org.smartdata.metastore.dao.ActionDao;
+import org.smartdata.metastore.dao.BackUpInfoDao;
+import org.smartdata.metastore.dao.CacheFileDao;
+import org.smartdata.metastore.dao.ClusterConfigDao;
+import org.smartdata.metastore.dao.ClusterInfoDao;
+import org.smartdata.metastore.dao.CmdletDao;
+import org.smartdata.metastore.dao.CompressionFileDao;
+import org.smartdata.metastore.dao.DaoProvider;
+import org.smartdata.metastore.dao.DataNodeInfoDao;
+import org.smartdata.metastore.dao.DataNodeStorageInfoDao;
+import org.smartdata.metastore.dao.ErasureCodingPolicyDao;
+import org.smartdata.metastore.dao.FileDiffDao;
+import org.smartdata.metastore.dao.FileInfoDao;
+import org.smartdata.metastore.dao.FileStateDao;
+import org.smartdata.metastore.dao.GeneralDao;
+import org.smartdata.metastore.dao.GlobalConfigDao;
+import org.smartdata.metastore.dao.RuleDao;
+import org.smartdata.metastore.dao.SmallFileDao;
+import org.smartdata.metastore.dao.StorageDao;
+import org.smartdata.metastore.dao.StorageHistoryDao;
+import org.smartdata.metastore.dao.StoragePolicyDao;
+import org.smartdata.metastore.dao.SystemInfoDao;
+import org.smartdata.metastore.dao.UserInfoDao;
+import org.smartdata.metastore.dao.WhitelistDao;
+import org.smartdata.metastore.dao.XattrDao;
+
+import javax.sql.DataSource;
+
+public class DefaultDaoProvider implements DaoProvider {
+  private final DataSource dataSource;
+
+  public DefaultDaoProvider(DBPool dbPool) {
+    this.dataSource = dbPool.getDataSource();
+  }
+
+  @Override
+  public RuleDao ruleDao() {
+    return new DefaultRuleDao(dataSource);
+  }
+
+  @Override
+  public CmdletDao cmdletDao() {
+    return new DefaultCmdletDao(dataSource);
+  }
+
+  @Override
+  public ActionDao actionDao() {
+    return new DefaultActionDao(dataSource);
+  }
+
+  @Override
+  public FileInfoDao fileInfoDao() {
+    return new DefaultFileInfoDao(dataSource);
+  }
+
+  @Override
+  public CacheFileDao cacheFileDao() {
+    return new DefaultCacheFileDao(dataSource);
+  }
+
+  @Override
+  public StorageDao storageDao() {
+    return new DefaultStorageDao(dataSource);
+  }
+
+  @Override
+  public StorageHistoryDao storageHistoryDao() {
+    return new DefaultStorageHistoryDao(dataSource);
+  }
+
+  @Override
+  public XattrDao xattrDao() {
+    return new DefaultXattrDao(dataSource);
+  }
+
+  @Override
+  public FileDiffDao fileDiffDao() {
+    return new DefaultFileDiffDao(dataSource);
+  }
+
+  @Override
+  public AccessCountDao accessCountDao() {
+    return new DefaultAccessCountDao(dataSource);
+  }
+
+  @Override
+  public ClusterConfigDao clusterConfigDao() {
+    return new DefaultClusterConfigDao(dataSource);
+  }
+
+  @Override
+  public GlobalConfigDao globalConfigDao() {
+    return new DefaultGlobalConfigDao(dataSource);
+  }
+
+  @Override
+  public DataNodeInfoDao dataNodeInfoDao() {
+    return new DefaultDataNodeInfoDao(dataSource);
+  }
+
+  @Override
+  public DataNodeStorageInfoDao dataNodeStorageInfoDao() {
+    return new DefaultDataNodeStorageInfoDao(dataSource);
+  }
+
+  @Override
+  public BackUpInfoDao backUpInfoDao() {
+    return new DefaultBackUpInfoDao(dataSource);
+  }
+
+  @Override
+  public ClusterInfoDao clusterInfoDao() {
+    return new DefaultClusterInfoDao(dataSource);
+  }
+
+  @Override
+  public SystemInfoDao systemInfoDao() {
+    return new DefaultSystemInfoDao(dataSource);
+  }
+
+  @Override
+  public UserInfoDao userInfoDao() {
+    return new DefaultUserInfoDao(dataSource);
+  }
+
+  @Override
+  public FileStateDao fileStateDao() {
+    return new DefaultFileStateDao(dataSource);
+  }
+
+  @Override
+  public CompressionFileDao compressionFileDao() {
+    return new DefaultCompressionFileDao(dataSource);
+  }
+
+  @Override
+  public GeneralDao generalDao() {
+    return new DefaultGeneralDao(dataSource);
+  }
+
+  @Override
+  public SmallFileDao smallFileDao() {
+    return new DefaultSmallFileDao(dataSource);
+  }
+
+  @Override
+  public ErasureCodingPolicyDao ecDao() {
+    return new DefaultErasureCodingPolicyDao(dataSource);
+  }
+
+  @Override
+  public WhitelistDao whitelistDao() {
+    return new DefaultWhitelistDao(dataSource);
+  }
+
+  @Override
+  public StoragePolicyDao storagePolicyDao() {
+    return new DefaultStoragePolicyDao(dataSource);
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultDataNodeInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultDataNodeInfoDao.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.DataNodeInfoDao;
+import org.smartdata.model.DataNodeInfo;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultDataNodeInfoDao extends AbstractDao implements DataNodeInfoDao {
+  private static final String TABLE_NAME = "datanode_info";
+
+  public DefaultDataNodeInfoDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<DataNodeInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
+        new DataNodeInfoRowMapper());
+  }
+
+  @Override
+  public List<DataNodeInfo> getByUuid(String uuid) {
+    return jdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE uuid = ?",
+        new Object[]{uuid}, new DataNodeInfoRowMapper());
+  }
+
+  @Override
+  public void insert(DataNodeInfo dataNodeInfo) {
+    insert(dataNodeInfo, this::toMap);
+  }
+
+  @Override
+  public void insert(DataNodeInfo[] dataNodeInfos) {
+    insert(dataNodeInfos, this::toMap);
+  }
+
+  @Override
+  public void insert(List<DataNodeInfo> dataNodeInfos) {
+    insert(dataNodeInfos, this::toMap);
+  }
+
+  @Override
+  public void delete(String uuid) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE uuid = ?";
+    jdbcTemplate.update(sql, uuid);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.update(sql);
+  }
+
+  private Map<String, Object> toMap(DataNodeInfo dataNodeInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("uuid", dataNodeInfo.getUuid());
+    parameters.put("hostname", dataNodeInfo.getHostname());
+    parameters.put("rpcAddress", dataNodeInfo.getRpcAddress());
+    parameters.put("cache_capacity", dataNodeInfo.getCacheCapacity());
+    parameters.put("cache_used", dataNodeInfo.getCacheUsed());
+    parameters.put("location", dataNodeInfo.getLocation());
+    return parameters;
+  }
+
+  private static class DataNodeInfoRowMapper implements RowMapper<DataNodeInfo> {
+
+    @Override
+    public DataNodeInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      return DataNodeInfo.newBuilder()
+          .setUuid(resultSet.getString("uuid"))
+          .setHostName(resultSet.getString("hostname"))
+          .setRpcAddress(resultSet.getString("rpcAddress"))
+          .setCacheCapacity(resultSet.getLong("cache_capacity"))
+          .setCacheUsed(resultSet.getLong("cache_used"))
+          .setLocation(resultSet.getString("location"))
+          .build();
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultDataNodeStorageInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultDataNodeStorageInfoDao.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.DataNodeStorageInfoDao;
+import org.smartdata.model.DataNodeStorageInfo;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultDataNodeStorageInfoDao extends AbstractDao implements DataNodeStorageInfoDao {
+  private static final String TABLE_NAME = "datanode_storage_info";
+
+  public DefaultDataNodeStorageInfoDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<DataNodeStorageInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
+        new DataNodeStorageInfoRowMapper());
+  }
+
+  @Override
+  public List<DataNodeStorageInfo> getByUuid(String uuid) {
+    return jdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE uuid = ?",
+        new Object[]{uuid}, new DataNodeStorageInfoRowMapper());
+  }
+
+  @Override
+  public List<DataNodeStorageInfo> getBySid(int sid) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE sid = ?",
+        new Object[]{sid}, new DataNodeStorageInfoRowMapper());
+  }
+
+  @Override
+  public void insert(DataNodeStorageInfo dataNodeStorageInfo) {
+    insert(dataNodeStorageInfo, this::toMap);
+  }
+
+  @Override
+  public void insert(DataNodeStorageInfo[] dataNodeStorageInfos) {
+    insert(dataNodeStorageInfos, this::toMap);
+  }
+
+  @Override
+  public void insert(List<DataNodeStorageInfo> dataNodeStorageInfos) {
+    insert(dataNodeStorageInfos, this::toMap);
+  }
+
+  @Override
+  public void delete(String uuid) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE uuid = ?";
+    jdbcTemplate.update(sql, uuid);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.update(sql);
+  }
+
+  private Map<String, Object> toMap(DataNodeStorageInfo dataNodeStorageInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("uuid", dataNodeStorageInfo.getUuid());
+    parameters.put("sid", dataNodeStorageInfo.getSid());
+    parameters.put("state", dataNodeStorageInfo.getState());
+    parameters.put("storage_id", dataNodeStorageInfo.getStorageId());
+    parameters.put("failed", dataNodeStorageInfo.getFailed());
+    parameters.put("capacity", dataNodeStorageInfo.getCapacity());
+    parameters.put("dfs_used", dataNodeStorageInfo.getDfsUsed());
+    parameters.put("remaining", dataNodeStorageInfo.getRemaining());
+    parameters.put("block_pool_used", dataNodeStorageInfo.getBlockPoolUsed());
+    return parameters;
+  }
+
+  private static class DataNodeStorageInfoRowMapper implements RowMapper<DataNodeStorageInfo> {
+
+    @Override
+    public DataNodeStorageInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      return DataNodeStorageInfo.newBuilder()
+          .setUuid(resultSet.getString("uuid"))
+          .setSid(resultSet.getLong("sid"))
+          .setState(resultSet.getLong("state"))
+          .setStorageId(resultSet.getString("storage_id"))
+          .setFailed(resultSet.getLong("failed"))
+          .setCapacity(resultSet.getLong("capacity"))
+          .setDfsUsed(resultSet.getLong("dfs_used"))
+          .setRemaining(resultSet.getLong("remaining"))
+          .setBlockPoolUsed(resultSet.getLong("block_pool_used"))
+          .build();
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultErasureCodingPolicyDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultErasureCodingPolicyDao.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.ErasureCodingPolicyDao;
+import org.smartdata.model.ErasureCodingPolicyInfo;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultErasureCodingPolicyDao extends AbstractDao implements ErasureCodingPolicyDao {
+  private static final String TABLE_NAME = "ec_policy";
+  private static final String ID = "id";
+  private static final String NAME = "policy_name";
+
+  public DefaultErasureCodingPolicyDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public ErasureCodingPolicyInfo getEcPolicyById(byte id) {
+    return jdbcTemplate.queryForObject
+        ("SELECT * FROM " + TABLE_NAME + " WHERE id=?", new Object[]{id},
+            new EcPolicyRowMapper());
+  }
+
+  @Override
+  public ErasureCodingPolicyInfo getEcPolicyByName(String policyName) {
+    return jdbcTemplate.queryForObject("SELECT * FROM " + TABLE_NAME + " WHERE policy_name=?",
+        new Object[]{policyName}, new EcPolicyRowMapper());
+  }
+
+  @Override
+  public List<ErasureCodingPolicyInfo> getAllEcPolicies() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new EcPolicyRowMapper());
+  }
+
+  @Override
+  public void insert(ErasureCodingPolicyInfo ecPolicy) {
+    insert(ecPolicy, this::toMap);
+  }
+
+  @Override
+  public void insert(List<ErasureCodingPolicyInfo> ecInfos) {
+    insert(ecInfos, this::toMap);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  private Map<String, Object> toMap(ErasureCodingPolicyInfo ecPolicy) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(ID, ecPolicy.getID());
+    map.put(NAME, ecPolicy.getEcPolicyName());
+    return map;
+  }
+
+  private static class EcPolicyRowMapper implements RowMapper<ErasureCodingPolicyInfo> {
+    @Override
+    public ErasureCodingPolicyInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      ErasureCodingPolicyInfo ecPolicy = new ErasureCodingPolicyInfo(resultSet.getByte("id"),
+          resultSet.getString("policy_name"));
+      return ecPolicy;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileDiffDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileDiffDao.java
@@ -1,0 +1,323 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.FileDiffDao;
+import org.smartdata.model.FileDiff;
+import org.smartdata.model.FileDiffState;
+import org.smartdata.model.FileDiffType;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+import javax.sql.DataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultFileDiffDao extends AbstractDao implements FileDiffDao {
+  private static final String TABLE_NAME = "file_diff";
+  public String uselessFileDiffStates;
+
+  public DefaultFileDiffDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+    this.uselessFileDiffStates = getUselessFileDiffState();
+  }
+
+  @Override
+  public String getUselessFileDiffState() {
+    List<String> stateValues = new ArrayList<>();
+    for (FileDiffState state : FileDiffState.getUselessFileDiffState()) {
+      stateValues.add(String.valueOf(state.getValue()));
+    }
+    return StringUtils.join(stateValues, ",");
+  }
+
+  @Override
+  public List<FileDiff> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new FileDiffRowMapper());
+  }
+
+  @Override
+  public List<FileDiff> getPendingDiff() {
+    return jdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE state = 0", new FileDiffRowMapper());
+  }
+
+  @Override
+  public List<FileDiff> getByState(FileDiffState fileDiffState) {
+    return jdbcTemplate
+        .query("SELECT * FROM " + TABLE_NAME + " WHERE state = ?",
+            new Object[]{fileDiffState.getValue()}, new FileDiffRowMapper());
+  }
+
+  @Override
+  public List<FileDiff> getByState(String prefix, FileDiffState fileDiffState) {
+    return jdbcTemplate
+        .query(
+            "SELECT * FROM " + TABLE_NAME + " WHERE src LIKE ? and state = ?",
+            new Object[]{prefix + "%", fileDiffState.getValue()},
+            new FileDiffRowMapper());
+  }
+
+  @Override
+  public List<FileDiff> getPendingDiff(long rid) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE did = ? and state = 0",
+        new Object[]{rid},
+        new FileDiffRowMapper());
+  }
+
+  @Override
+  public List<FileDiff> getPendingDiff(String prefix) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE src LIKE ? and state = 0",
+        new FileDiffRowMapper(), prefix + "%");
+  }
+
+  @Override
+  public List<FileDiff> getByIds(List<Long> dids) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE did IN (?)",
+        new Object[]{StringUtils.join(dids, ",")},
+        new FileDiffRowMapper());
+  }
+
+  @Override
+  public List<FileDiff> getByFileName(String fileName) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE src = ?",
+        new Object[]{fileName}, new FileDiffRowMapper());
+  }
+
+  @Override
+  public List<String> getSyncPath(int size) {
+    if (size != 0) {
+      jdbcTemplate.setMaxRows(size);
+    }
+    String sql = "SELECT DISTINCT src FROM " + TABLE_NAME + " WHERE state = ?";
+    return jdbcTemplate
+        .queryForList(sql, String.class, FileDiffState.RUNNING.getValue());
+  }
+
+  @Override
+  public FileDiff getById(long did) {
+    return jdbcTemplate.queryForObject("SELECT * FROM " + TABLE_NAME + " WHERE did = ?",
+        new Object[]{did}, new FileDiffRowMapper());
+  }
+
+  @Override
+  public void delete(long did) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE did = ?";
+    jdbcTemplate.update(sql, did);
+  }
+
+  @Override
+  public int getUselessRecordsNum() {
+    final String query = "SELECT count(*) FROM " + TABLE_NAME + " WHERE state IN ("
+        + uselessFileDiffStates + ")";
+    return jdbcTemplate.queryForObject(query, Integer.class);
+  }
+
+  @Override
+  public int deleteUselessRecords(int num) {
+    final String queryDids = "SELECT did FROM " + TABLE_NAME + " WHERE state IN ("
+        + uselessFileDiffStates + ") ORDER BY create_time DESC LIMIT 1000 OFFSET " + num;
+    List<Long> dids = jdbcTemplate.queryForList(queryDids, Long.class);
+    if (dids.isEmpty()) {
+      return 0;
+    }
+    String unusedDids = StringUtils.join(dids, ",");
+    final String deleteUnusedFileDiff = "DELETE FROM " + TABLE_NAME + " where did IN ("
+        + unusedDids + ")";
+    jdbcTemplate.update(deleteUnusedFileDiff);
+    return dids.size();
+  }
+
+  @Override
+  public long insert(FileDiff fileDiff) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    simpleJdbcInsert.usingGeneratedKeyColumns("did");
+    // return did
+    long did = simpleJdbcInsert.executeAndReturnKey(toMap(fileDiff)).longValue();
+    fileDiff.setDiffId(did);
+    return did;
+  }
+
+  @Override
+  public void insert(FileDiff[] fileDiffs) {
+    insert(fileDiffs, this::toMap);
+  }
+
+  @Override
+  public Long[] insert(List<FileDiff> fileDiffs) {
+    List<Long> dids = new ArrayList<>();
+    for (FileDiff fileDiff : fileDiffs) {
+      dids.add(insert(fileDiff));
+    }
+    return dids.toArray(new Long[dids.size()]);
+  }
+
+  @Override
+  public int[] batchUpdate(
+      final List<Long> dids, final List<FileDiffState> states,
+      final List<String> parameters) {
+
+    final String sql = "UPDATE " + TABLE_NAME + " SET state = ?, "
+        + "parameters = ? WHERE did = ?";
+    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps, int i) throws SQLException {
+        ps.setShort(1, (short) states.get(i).getValue());
+        ps.setString(2, parameters.get(i));
+        ps.setLong(3, dids.get(i));
+      }
+
+      @Override
+      public int getBatchSize() {
+        return dids.size();
+      }
+    });
+  }
+
+  @Override
+  public int[] batchUpdate(
+      final List<Long> dids, final FileDiffState state) {
+
+    final String sql = "UPDATE " + TABLE_NAME + " SET state = ? "
+        + "WHERE did = ?";
+    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps, int i) throws SQLException {
+        ps.setShort(1, (short) state.getValue());
+        ps.setLong(2, dids.get(i));
+      }
+
+      @Override
+      public int getBatchSize() {
+        return dids.size();
+      }
+    });
+  }
+
+
+  @Override
+  public int update(long did, FileDiffState state) {
+    String sql = "UPDATE " + TABLE_NAME + " SET state = ? WHERE did = ?";
+    return jdbcTemplate.update(sql, state.getValue(), did);
+  }
+
+  @Override
+  public int update(long did, String src) {
+    String sql = "UPDATE " + TABLE_NAME + " SET src = ? WHERE did = ?";
+    return jdbcTemplate.update(sql, src, did);
+  }
+
+  @Override
+  public int update(long did, FileDiffState state,
+                    String parameters) {
+    String sql = "UPDATE " + TABLE_NAME + " SET state = ?, "
+        + "parameters = ? WHERE did = ?";
+    return jdbcTemplate.update(sql, state.getValue(), parameters, did);
+  }
+
+  @Override
+  public int[] update(final FileDiff[] fileDiffs) {
+    String sql = "UPDATE " + TABLE_NAME + " SET "
+        + "rid = ?, "
+        + "diff_type = ?, "
+        + "src = ?, "
+        + "parameters = ?, "
+        + "state = ?, "
+        + "create_time = ? "
+        + "WHERE did = ?";
+    return jdbcTemplate.batchUpdate(sql,
+        new BatchPreparedStatementSetter() {
+          @Override
+          public void setValues(PreparedStatement ps,
+                                int i) throws SQLException {
+            ps.setLong(1, fileDiffs[i].getRuleId());
+            ps.setInt(2, fileDiffs[i].getDiffType().getValue());
+            ps.setString(3, fileDiffs[i].getSrc());
+            ps.setString(4, fileDiffs[i].getParametersJsonString());
+            ps.setInt(5, fileDiffs[i].getState().getValue());
+            ps.setLong(6, fileDiffs[i].getCreateTime());
+            ps.setLong(7, fileDiffs[i].getDiffId());
+          }
+
+          @Override
+          public int getBatchSize() {
+            return fileDiffs.length;
+          }
+        });
+  }
+
+  @Override
+  public int update(final FileDiff fileDiff) {
+    String sql = "UPDATE " + TABLE_NAME + " SET "
+        + "rid = ?, "
+        + "diff_type = ?, "
+        + "src = ?, "
+        + "parameters = ?, "
+        + "state = ?, "
+        + "create_time = ? "
+        + "WHERE did = ?";
+    return jdbcTemplate.update(sql, fileDiff.getRuleId(),
+        fileDiff.getDiffType().getValue(), fileDiff.getSrc(),
+        fileDiff.getParametersJsonString(), fileDiff.getState().getValue(),
+        fileDiff.getCreateTime(), fileDiff.getDiffId());
+  }
+
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  private Map<String, Object> toMap(FileDiff fileDiff) {
+    // System.out.println(fileDiff.getDiffType());
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("did", fileDiff.getDiffId());
+    parameters.put("rid", fileDiff.getRuleId());
+    parameters.put("diff_type", fileDiff.getDiffType().getValue());
+    parameters.put("src", fileDiff.getSrc());
+    parameters.put("parameters", fileDiff.getParametersJsonString());
+    parameters.put("state", fileDiff.getState().getValue());
+    parameters.put("create_time", fileDiff.getCreateTime());
+    return parameters;
+  }
+
+  private static class FileDiffRowMapper implements RowMapper<FileDiff> {
+    @Override
+    public FileDiff mapRow(ResultSet resultSet, int i) throws SQLException {
+      FileDiff fileDiff = new FileDiff();
+      fileDiff.setDiffId(resultSet.getLong("did"));
+      fileDiff.setRuleId(resultSet.getLong("rid"));
+      fileDiff.setDiffType(FileDiffType.fromValue((int) resultSet.getByte("diff_type")));
+      fileDiff.setSrc(resultSet.getString("src"));
+      fileDiff.setParametersFromJsonString(resultSet.getString("parameters"));
+      fileDiff.setState(FileDiffState.fromValue((int) resultSet.getByte("state")));
+      fileDiff.setCreateTime(resultSet.getLong("create_time"));
+      return fileDiff;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.FileInfoDao;
+import org.smartdata.model.FileInfo;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
+
+  private static final String TABLE_NAME = "file";
+
+  public DefaultFileInfoDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<FileInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM file",
+        new DefaultFileInfoDao.FileInfoRowMapper());
+  }
+
+  @Override
+  public List<FileInfo> getFilesByPrefix(String path) {
+    return jdbcTemplate.query("SELECT * FROM file WHERE path LIKE ?",
+        new DefaultFileInfoDao.FileInfoRowMapper(), path + "%");
+  }
+
+  @Override
+  public List<FileInfo> getFilesByPrefixInOrder(String path) {
+    return jdbcTemplate.query("SELECT * FROM file WHERE path LIKE ? ORDER BY path ASC",
+        new DefaultFileInfoDao.FileInfoRowMapper(), path + "%");
+  }
+
+  @Override
+  public List<FileInfo> getFilesByPaths(Collection<String> paths) {
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+        new NamedParameterJdbcTemplate(dataSource);
+    String sql = "SELECT * FROM file WHERE path IN (:paths)";
+    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+    parameterSource.addValue("paths", paths);
+    return namedParameterJdbcTemplate.query(sql,
+        parameterSource, new FileInfoRowMapper());
+  }
+
+  @Override
+  public FileInfo getById(long fid) {
+    return jdbcTemplate.queryForObject("SELECT * FROM file WHERE fid = ?",
+        new Object[]{fid}, new DefaultFileInfoDao.FileInfoRowMapper());
+  }
+
+  @Override
+  public FileInfo getByPath(String path) {
+    return jdbcTemplate.queryForObject("SELECT * FROM file WHERE path = ?",
+        new Object[]{path}, new DefaultFileInfoDao.FileInfoRowMapper());
+  }
+
+  @Override
+  public Map<String, Long> getPathFids(Collection<String> paths)
+      throws SQLException {
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+        new NamedParameterJdbcTemplate(dataSource);
+    Map<String, Long> pathToId = new HashMap<>();
+    String sql = "SELECT * FROM file WHERE path IN (:paths)";
+    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+    parameterSource.addValue("paths", paths);
+    List<FileInfo> files = namedParameterJdbcTemplate.query(sql,
+        parameterSource, new FileInfoRowMapper());
+    for (FileInfo file : files) {
+      pathToId.put(file.getPath(), file.getFileId());
+    }
+    return pathToId;
+  }
+
+  @Override
+  public Map<Long, String> getFidPaths(Collection<Long> ids)
+      throws SQLException {
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+        new NamedParameterJdbcTemplate(dataSource);
+    Map<Long, String> idToPath = new HashMap<>();
+    String sql = "SELECT * FROM file WHERE fid IN (:ids)";
+    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+    parameterSource.addValue("ids", ids);
+    List<FileInfo> files = namedParameterJdbcTemplate.query(sql,
+        parameterSource, new FileInfoRowMapper());
+    for (FileInfo file : files) {
+      idToPath.put(file.getFileId(), file.getPath());
+    }
+    return idToPath;
+  }
+
+  @Override
+  public void insert(FileInfo fileInfo) {
+    insert(fileInfo, this::toMap);
+  }
+
+  @Override
+  public void insert(FileInfo[] fileInfos) {
+    insert(fileInfos, this::toMap);
+  }
+
+  @Override
+  public int update(String path, int storagePolicy) {
+    final String sql = "UPDATE file SET sid =? WHERE path = ?;";
+    return jdbcTemplate.update(sql, storagePolicy, path);
+  }
+
+  @Override
+  public void deleteById(long fid) {
+    final String sql = "DELETE FROM file WHERE fid = ?";
+    jdbcTemplate.update(sql, fid);
+  }
+
+  @Override
+  public void deleteByPath(String path) {
+    final String sql = "DELETE FROM file WHERE path = ?";
+    jdbcTemplate.update(sql, path);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM file";
+    jdbcTemplate.execute(sql);
+  }
+
+  private Map<String, Object> toMap(FileInfo fileInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("path", fileInfo.getPath());
+    parameters.put("fid", fileInfo.getFileId());
+    parameters.put("length", fileInfo.getLength());
+    parameters.put("block_replication", fileInfo.getBlockReplication());
+    parameters.put("block_size", fileInfo.getBlocksize());
+    parameters.put("modification_time", fileInfo.getModificationTime());
+    parameters.put("access_time", fileInfo.getAccessTime());
+    parameters.put("is_dir", fileInfo.isdir());
+    parameters.put("sid", fileInfo.getStoragePolicy());
+    parameters
+        .put("owner", fileInfo.getOwner());
+    parameters
+        .put("owner_group", fileInfo.getGroup());
+    parameters.put("permission", fileInfo.getPermission());
+    parameters.put("ec_policy_id", fileInfo.getErasureCodingPolicy());
+    return parameters;
+  }
+
+  private static class FileInfoRowMapper implements RowMapper<FileInfo> {
+    @Override
+    public FileInfo mapRow(ResultSet resultSet, int i)
+        throws SQLException {
+      return new FileInfo(resultSet.getString("path"),
+          resultSet.getLong("fid"),
+          resultSet.getLong("length"),
+          resultSet.getBoolean("is_dir"),
+          resultSet.getShort("block_replication"),
+          resultSet.getLong("block_size"),
+          resultSet.getLong("modification_time"),
+          resultSet.getLong("access_time"),
+          resultSet.getShort("permission"),
+          resultSet.getString("owner"),
+          resultSet.getString("owner_group"),
+          resultSet.getByte("sid"),
+          resultSet.getByte("ec_policy_id")
+      );
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileStateDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileStateDao.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.FileStateDao;
+import org.smartdata.model.FileState;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultFileStateDao extends AbstractDao implements FileStateDao {
+  private static final String TABLE_NAME = "file_state";
+
+  public DefaultFileStateDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public void insertUpdate(FileState fileState) {
+    String sql = "REPLACE INTO " + TABLE_NAME + " (path, type, stage) VALUES (?,?,?)";
+    jdbcTemplate.update(sql, fileState.getPath(), fileState.getFileType().getValue(),
+        fileState.getFileStage().getValue());
+  }
+
+  @Override
+  public int[] batchInsertUpdate(final FileState[] fileStates) {
+    String sql = "REPLACE INTO " + TABLE_NAME + " (path, type, stage) VALUES (?,?,?)";
+    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps,
+                            int i) throws SQLException {
+        ps.setString(1, fileStates[i].getPath());
+        ps.setInt(2, fileStates[i].getFileType().getValue());
+        ps.setInt(3, fileStates[i].getFileStage().getValue());
+      }
+
+      @Override
+      public int getBatchSize() {
+        return fileStates.length;
+      }
+    });
+  }
+
+  @Override
+  public FileState getByPath(String path) {
+    return jdbcTemplate.queryForObject("SELECT * FROM " + TABLE_NAME + " WHERE path = ?",
+        new Object[]{path}, new FileStateRowMapper());
+  }
+
+  @Override
+  public Map<String, FileState> getByPaths(List<String> paths) {
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+        new NamedParameterJdbcTemplate(dataSource);
+    Map<String, FileState> fileStateMap = new HashMap<>();
+    MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+    parameterSource.addValue("paths", paths);
+    List<FileState> fileStates = namedParameterJdbcTemplate.query(
+        "SELECT * FROM " + TABLE_NAME + " WHERE path IN (:paths)",
+        parameterSource,
+        new FileStateRowMapper());
+    for (FileState fileState : fileStates) {
+      fileStateMap.put(fileState.getPath(), fileState);
+    }
+    return fileStateMap;
+  }
+
+  @Override
+  public List<FileState> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME,
+        new FileStateRowMapper());
+  }
+
+  @Override
+  public void deleteByPath(String path, boolean recursive) {
+    String sql = "DELETE FROM " + TABLE_NAME + " WHERE path = ?";
+    jdbcTemplate.update(sql, path);
+    if (recursive) {
+      sql = "DELETE FROM " + TABLE_NAME + " WHERE path LIKE ?";
+      jdbcTemplate.update(sql, path + "/%");
+    }
+  }
+
+  @Override
+  public int[] batchDelete(final List<String> paths) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE path = ?";
+    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps, int i) throws SQLException {
+        ps.setString(1, paths.get(i));
+      }
+
+      @Override
+      public int getBatchSize() {
+        return paths.size();
+      }
+    });
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  private static class FileStateRowMapper implements RowMapper<FileState> {
+    @Override
+    public FileState mapRow(ResultSet resultSet, int i)
+        throws SQLException {
+      return new FileState(resultSet.getString("path"),
+          FileState.FileType.fromValue(resultSet.getInt("type")),
+          FileState.FileStage.fromValue(resultSet.getInt("stage")));
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultGeneralDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultGeneralDao.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.GeneralDao;
+
+import javax.sql.DataSource;
+
+public class DefaultGeneralDao extends AbstractDao implements GeneralDao {
+  public DefaultGeneralDao(DataSource dataSource) {
+    super(dataSource, "");
+  }
+
+  @Override
+  public Long queryForLong(String sql) {
+    return jdbcTemplate.queryForObject(sql, Long.class);
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultGlobalConfigDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultGlobalConfigDao.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.GlobalConfigDao;
+import org.smartdata.model.GlobalConfig;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultGlobalConfigDao extends AbstractDao implements GlobalConfigDao {
+  private static final String TABLE_NAME = "global_config";
+
+  public DefaultGlobalConfigDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<GlobalConfig> getAll() {
+    return jdbcTemplate.query("SELECT * FROM global_config", new GlobalConfigRowMapper());
+  }
+
+  @Override
+  public List<GlobalConfig> getByIds(List<Long> cid) {
+    return jdbcTemplate.query(
+        "SELECT * FROM global_config WHERE cid IN (?)",
+        new Object[]{StringUtils.join(cid, ",")},
+        new GlobalConfigRowMapper());
+  }
+
+  @Override
+  public GlobalConfig getById(long cid) {
+    return jdbcTemplate.queryForObject(
+        "SELECT * FROM global_config WHERE cid = ?",
+        new Object[]{cid},
+        new GlobalConfigRowMapper());
+  }
+
+  @Override
+  public GlobalConfig getByPropertyName(String propertyName) {
+    return jdbcTemplate.queryForObject(
+        "SELECT * FROM global_config WHERE property_name = ?",
+        new Object[]{propertyName},
+        new GlobalConfigRowMapper());
+  }
+
+  @Override
+  public void deleteByName(String propertyName) {
+    final String sql = "DELETE FROM global_config WHERE property_name = ?";
+    jdbcTemplate.update(sql, propertyName);
+  }
+
+  @Override
+  public void delete(long cid) {
+    final String sql = "DELETE FROM global_config WHERE cid = ?";
+    jdbcTemplate.update(sql, cid);
+  }
+
+  @Override
+  public long insert(GlobalConfig globalConfig) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    long cid = simpleJdbcInsert.executeAndReturnKey(toMaps(globalConfig)).longValue();
+    globalConfig.setCid(cid);
+    return cid;
+  }
+
+  // TODO slove the increment of key
+  @Override
+  public void insert(GlobalConfig[] globalConfigs) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    Map<String, Object>[] maps = new Map[globalConfigs.length];
+    for (int i = 0; i < globalConfigs.length; i++) {
+      maps[i] = toMaps(globalConfigs[i]);
+    }
+
+    int[] cids = simpleJdbcInsert.executeBatch(maps);
+    for (int i = 0; i < globalConfigs.length; i++) {
+      globalConfigs[i].setCid(cids[i]);
+    }
+  }
+
+  @Override
+  public long getCountByName(String name) {
+    return jdbcTemplate.queryForObject(
+        "SELECT COUNT(*) FROM global_config WHERE property_name = ?", Long.class, name);
+  }
+
+  @Override
+  public int update(String propertyName, String propertyValue) {
+    String sql = "UPDATE global_config SET property_value = ? WHERE property_name = ?";
+    return jdbcTemplate.update(sql, propertyValue, propertyName);
+  }
+
+  @Override
+  protected SimpleJdbcInsert simpleJdbcInsert() {
+    return super.simpleJdbcInsert()
+        .usingGeneratedKeyColumns("cid");
+  }
+
+  private Map<String, Object> toMaps(GlobalConfig globalConfig) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("cid", globalConfig.getCid());
+    parameters.put("property_name", globalConfig.getPropertyName());
+    parameters.put("property_value", globalConfig.getPropertyValue());
+    return parameters;
+  }
+
+  private static class GlobalConfigRowMapper implements RowMapper<GlobalConfig> {
+
+    @Override
+    public GlobalConfig mapRow(ResultSet resultSet, int i) throws SQLException {
+      GlobalConfig globalConfig = new GlobalConfig();
+      globalConfig.setCid(resultSet.getLong("cid"));
+      globalConfig.setPropertyName(resultSet.getString("property_name"));
+      globalConfig.setPropertyValue(resultSet.getString("property_value"));
+      return globalConfig;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultRuleDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultRuleDao.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.RuleDao;
+import org.smartdata.model.RuleInfo;
+import org.smartdata.model.RuleState;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultRuleDao extends AbstractDao implements RuleDao {
+  private static final String TABLE_NAME = "rule";
+
+  public DefaultRuleDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<RuleInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM rule",
+        new RuleRowMapper());
+  }
+
+  @Override
+  public RuleInfo getById(long id) {
+    return jdbcTemplate.queryForObject("SELECT * FROM rule WHERE id = ?",
+        new Object[]{id}, new RuleRowMapper());
+  }
+
+  @Override
+  public List<RuleInfo> getAPageOfRule(long start, long offset, List<String> orderBy,
+                                       List<Boolean> isDesc) {
+    boolean ifHasAid = false;
+    String sql = "SELECT * FROM rule ORDER BY ";
+
+    for (int i = 0; i < orderBy.size(); i++) {
+      if (orderBy.get(i).equals("rid")) {
+        ifHasAid = true;
+      }
+      sql = sql + orderBy.get(i);
+      if (isDesc.size() > i) {
+        if (isDesc.get(i)) {
+          sql = sql + " desc ";
+        }
+        sql = sql + ",";
+      }
+    }
+
+    if (!ifHasAid) {
+      sql = sql + "rid,";
+    }
+
+    sql = sql.substring(0, sql.length() - 1);
+    sql = sql + " LIMIT " + start + "," + offset + ";";
+    return jdbcTemplate.query(sql, new RuleRowMapper());
+  }
+
+  @Override
+  public List<RuleInfo> getAPageOfRule(long start, long offset) {
+    String sql = "SELECT * FROM rule LIMIT " + start + "," + offset + ";";
+    return jdbcTemplate.query(sql, new RuleRowMapper());
+  }
+
+  @Override
+  public long insert(RuleInfo ruleInfo) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    simpleJdbcInsert.usingGeneratedKeyColumns("id");
+    long id = simpleJdbcInsert.executeAndReturnKey(toMap(ruleInfo)).longValue();
+    ruleInfo.setId(id);
+    return id;
+  }
+
+  @Override
+  public int update(long ruleId, long lastCheckTime, long checkedCount, int cmdletsGen) {
+    String sql =
+        "UPDATE rule SET last_check_time = ?, checked_count = ?, "
+            + "generated_cmdlets = ? WHERE id = ?";
+    return jdbcTemplate.update(sql, lastCheckTime, checkedCount, cmdletsGen, ruleId);
+  }
+
+  @Override
+  public int update(long ruleId, int rs, long lastCheckTime, long checkedCount, int cmdletsGen) {
+    String sql =
+        "UPDATE rule SET state = ?, last_check_time = ?, checked_count = ?, "
+            + "generated_cmdlets = ? WHERE id = ?";
+    return jdbcTemplate.update(sql, rs, lastCheckTime, checkedCount, cmdletsGen, ruleId);
+  }
+
+  @Override
+  public int update(long ruleId, int rs) {
+    String sql = "UPDATE rule SET state = ? WHERE id = ?";
+    return jdbcTemplate.update(sql, rs, ruleId);
+  }
+
+  @Override
+  public void delete(long id) {
+    final String sql = "DELETE FROM rule WHERE id = ?";
+    jdbcTemplate.update(sql, id);
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM rule";
+    jdbcTemplate.update(sql);
+  }
+
+  private Map<String, Object> toMap(RuleInfo ruleInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    if (ruleInfo.getSubmitTime() == 0) {
+      ruleInfo.setSubmitTime(System.currentTimeMillis());
+    }
+    parameters.put("submit_time", ruleInfo.getSubmitTime());
+    parameters.put("rule_text", ruleInfo.getRuleText());
+    parameters.put("state", ruleInfo.getState().getValue());
+    parameters.put("checked_count", ruleInfo.getNumChecked());
+    parameters.put("generated_cmdlets", ruleInfo.getNumCmdsGen());
+    parameters.put("last_check_time", ruleInfo.getLastCheckTime());
+    return parameters;
+  }
+
+  private static class RuleRowMapper implements RowMapper<RuleInfo> {
+
+    @Override
+    public RuleInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      RuleInfo ruleInfo = new RuleInfo();
+      ruleInfo.setId(resultSet.getLong("id"));
+      ruleInfo.setSubmitTime(resultSet.getLong("submit_time"));
+      ruleInfo.setRuleText(resultSet.getString("rule_text"));
+      ruleInfo.setState(RuleState.fromValue((int) resultSet.getByte("state")));
+      ruleInfo.setNumChecked(resultSet.getLong("checked_count"));
+      ruleInfo.setNumCmdsGen(resultSet.getLong("generated_cmdlets"));
+      ruleInfo.setLastCheckTime(resultSet.getLong("last_check_time"));
+      return ruleInfo;
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultSmallFileDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultSmallFileDao.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.SmallFileDao;
+import org.smartdata.model.CompactFileState;
+import org.smartdata.model.FileContainerInfo;
+import org.smartdata.model.FileState;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class DefaultSmallFileDao extends AbstractDao implements SmallFileDao {
+  private static final String TABLE_NAME = "small_file";
+
+  public DefaultSmallFileDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public void insertUpdate(CompactFileState compactFileState) {
+    String sql = "REPLACE INTO small_file (path, container_file_path, offset, length)"
+        + " VALUES (?,?,?,?)";
+    jdbcTemplate.update(sql, compactFileState.getPath(),
+        compactFileState.getFileContainerInfo().getContainerFilePath(),
+        compactFileState.getFileContainerInfo().getOffset(),
+        compactFileState.getFileContainerInfo().getLength());
+  }
+
+  @Override
+  public int[] batchInsertUpdate(final CompactFileState[] fileStates) {
+    String sql = "REPLACE INTO small_file (path, container_file_path, offset, length)"
+        + " VALUES (?,?,?,?)";
+    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps,
+                            int i) throws SQLException {
+        ps.setString(1, fileStates[i].getPath());
+        ps.setString(2, fileStates[i].getFileContainerInfo().getContainerFilePath());
+        ps.setLong(3, fileStates[i].getFileContainerInfo().getOffset());
+        ps.setLong(4, fileStates[i].getFileContainerInfo().getLength());
+      }
+
+      @Override
+      public int getBatchSize() {
+        return fileStates.length;
+      }
+    });
+  }
+
+  @Override
+  public void deleteByPath(String path, boolean recursive) {
+    String sql = "DELETE FROM small_file WHERE path = ?";
+    jdbcTemplate.update(sql, path);
+    if (recursive) {
+      sql = "DELETE FROM small_file WHERE path LIKE ?";
+      jdbcTemplate.update(sql, path + "/%");
+    }
+  }
+
+  @Override
+  public int[] batchDelete(final List<String> paths) {
+    final String sql = "DELETE FROM small_file WHERE path = ?";
+    return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+      @Override
+      public void setValues(PreparedStatement ps, int i) throws SQLException {
+        ps.setString(1, paths.get(i));
+      }
+
+      @Override
+      public int getBatchSize() {
+        return paths.size();
+      }
+    });
+  }
+
+  @Override
+  public FileState getFileStateByPath(String path) {
+    return jdbcTemplate.queryForObject("SELECT * FROM small_file WHERE path = ?",
+        new Object[]{path}, new FileStateRowMapper());
+  }
+
+  @Override
+  public List<String> getSmallFilesByContainerFile(String containerFilePath) {
+    String sql = "SELECT path FROM small_file where container_file_path = ?";
+    return jdbcTemplate.queryForList(sql, String.class, containerFilePath);
+  }
+
+  @Override
+  public List<String> getAllContainerFiles() {
+    String sql = "SELECT DISTINCT container_file_path FROM small_file";
+    return jdbcTemplate.queryForList(sql, String.class);
+  }
+
+  private static class FileStateRowMapper implements RowMapper<FileState> {
+    @Override
+    public FileState mapRow(ResultSet resultSet, int i)
+        throws SQLException {
+      return new CompactFileState(resultSet.getString("path"),
+          new FileContainerInfo(
+              resultSet.getString("container_file_path"),
+              resultSet.getLong("offset"),
+              resultSet.getLong("length"))
+      );
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultStorageDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultStorageDao.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.StorageDao;
+import org.smartdata.model.StorageCapacity;
+import org.smartdata.model.StoragePolicy;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultStorageDao extends AbstractDao implements StorageDao {
+  private static final String TABLE_NAME = "storage";
+
+  public DefaultStorageDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public Map<String, StorageCapacity> getStorageTablesItem() {
+    String sql = "SELECT * FROM storage";
+    List<StorageCapacity> list = jdbcTemplate.query(sql,
+        new StorageCapacityRowMapper());
+    Map<String, StorageCapacity> map = new HashMap<>();
+    for (StorageCapacity s : list) {
+      map.put(s.getType(), s);
+    }
+    return map;
+  }
+
+  @Override
+  public Map<Integer, String> getStoragePolicyIdNameMap() throws SQLException {
+    String sql = "SELECT * FROM storage_policy";
+    List<StoragePolicy> list = jdbcTemplate.query(sql,
+        (rs, rowNum) -> new StoragePolicy(
+            rs.getByte("sid"),
+            rs.getString("policy_name")));
+    Map<Integer, String> map = new HashMap<>();
+    for (StoragePolicy s : list) {
+      map.put((int) (s.getSid()), s.getPolicyName());
+    }
+    return map;
+  }
+
+  @Override
+  public StorageCapacity getStorageCapacity(String type) {
+    String sql = "SELECT * FROM storage WHERE type = ?";
+    return jdbcTemplate.queryForObject(sql, new Object[]{type},
+        new StorageCapacityRowMapper());
+  }
+
+  @Override
+  public String getStoragePolicyName(int sid) {
+    String sql = "SELECT policy_name FROM storage_policy WHERE sid = ?";
+    return jdbcTemplate.queryForObject(sql, new Object[]{sid}, String.class);
+  }
+
+  @Override
+  public synchronized void insertStoragePolicyTable(StoragePolicy s) {
+    String sql = "INSERT INTO storage_policy (sid, policy_name) VALUES('"
+        + s.getSid() + "','" + s.getPolicyName() + "');";
+    jdbcTemplate.execute(sql);
+  }
+
+  @Override
+  public int updateFileStoragePolicy(String path,
+                                     Integer policyId) throws SQLException {
+    String sql = String.format(
+        "UPDATE file SET sid = %d WHERE path = '%s';",
+        policyId, path);
+    return jdbcTemplate.update(sql);
+  }
+
+  @Override
+  public void insertUpdateStoragesTable(final StorageCapacity[] storages)
+      throws SQLException {
+    if (storages.length == 0) {
+      return;
+    }
+    final Long curr = System.currentTimeMillis();
+    String sql = "REPLACE INTO storage (type, time_stamp, capacity, free) VALUES (?,?,?,?);";
+    jdbcTemplate.batchUpdate(sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps,
+                                int i) throws SQLException {
+            ps.setString(1, storages[i].getType());
+            if (storages[i].getTimeStamp() == null) {
+              ps.setLong(2, curr);
+            } else {
+              ps.setLong(2, storages[i].getTimeStamp());
+            }
+            ps.setLong(3, storages[i].getCapacity());
+            ps.setLong(4, storages[i].getFree());
+          }
+
+          public int getBatchSize() {
+            return storages.length;
+          }
+        });
+  }
+
+  @Override
+  public int getCountOfStorageType(String type) {
+    String sql = "SELECT COUNT(*) FROM storage WHERE type = ?";
+    return jdbcTemplate.queryForObject(sql, Integer.class, type);
+  }
+
+  @Override
+  public void deleteStorage(String storageType) {
+    final String sql = "DELETE FROM storage WHERE type = ?";
+    jdbcTemplate.update(sql, storageType);
+  }
+
+  @Override
+  public synchronized boolean updateStoragesTable(String type, Long timeStamp,
+                                                  Long capacity, Long free) throws SQLException {
+    String sql = null;
+    String sqlPrefix = "UPDATE storage SET";
+    String sqlCapacity = (capacity != null) ? ", capacity = '"
+        + capacity + "' " : null;
+    String sqlFree = (free != null) ? ", free = '" + free + "' " : null;
+    String sqlTimeStamp = (timeStamp != null) ? ", time_stamp = " + timeStamp + " " : null;
+    String sqlSuffix = "WHERE type = '" + type + "';";
+    if (capacity != null || free != null) {
+      sql = sqlPrefix + sqlCapacity + sqlFree + sqlTimeStamp + sqlSuffix;
+      sql = sql.replaceFirst(",", "");
+    }
+    return jdbcTemplate.update(sql) == 1;
+  }
+
+  @Override
+  public synchronized boolean updateStoragesTable(String type,
+                                                  Long capacity, Long free) throws SQLException {
+    return updateStoragesTable(type, System.currentTimeMillis(), capacity, free);
+  }
+
+  private static class StorageCapacityRowMapper implements RowMapper<StorageCapacity> {
+    @Override
+    public StorageCapacity mapRow(ResultSet resultSet, int i)
+        throws SQLException {
+      return new StorageCapacity(
+          resultSet.getString("type"),
+          resultSet.getLong("time_stamp"),
+          resultSet.getLong("capacity"),
+          resultSet.getLong("free"));
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultStorageHistoryDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultStorageHistoryDao.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.StorageHistoryDao;
+import org.smartdata.model.StorageCapacity;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class DefaultStorageHistoryDao extends AbstractDao implements StorageHistoryDao {
+  private static final String TABLE_NAME = "storage_hist";
+
+  public DefaultStorageHistoryDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public void insertStorageHistTable(final StorageCapacity[] storages, final long interval)
+      throws SQLException {
+    if (storages.length == 0) {
+      return;
+    }
+    final Long curr = System.currentTimeMillis();
+    String sql = "INSERT INTO storage_hist (type, time_stamp, capacity, free) VALUES (?,?,?,?);";
+    jdbcTemplate.batchUpdate(sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps,
+                                int i) throws SQLException {
+            ps.setString(1, storages[i].getType() + "-" + interval);
+            if (storages[i].getTimeStamp() == null) {
+              ps.setLong(2, curr);
+            } else {
+              ps.setLong(2, storages[i].getTimeStamp());
+            }
+            ps.setLong(3, storages[i].getCapacity());
+            ps.setLong(4, storages[i].getFree());
+          }
+
+          public int getBatchSize() {
+            return storages.length;
+          }
+        });
+  }
+
+  @Override
+  public List<StorageCapacity> getStorageHistoryData(String type, long interval,
+                                                     long startTime, long endTime) {
+    String sql = "SELECT * FROM storage_hist WHERE type = ? AND "
+        + "time_stamp BETWEEN ? AND ?";
+    List<StorageCapacity> data = jdbcTemplate.query(sql,
+        new Object[]{type + "-" + interval, startTime, endTime},
+        new StorageHistoryRowMapper());
+    for (StorageCapacity sc : data) {
+      sc.setType(type);
+    }
+    return data;
+  }
+
+  @Override
+  public int getNumberOfStorageHistoryData(String type, long interval) {
+    String sql = "SELECT COUNT(*) FROM storage_hist WHERE type = ?";
+    return jdbcTemplate.queryForObject(sql, new Object[]{type + "-" + interval}, Integer.class);
+  }
+
+  @Override
+  public void deleteOldRecords(String type, long interval, long beforTimeStamp) {
+    String sql = "DELETE FROM storage_hist WHERE type = ? AND time_stamp <= ?";
+    jdbcTemplate.update(sql, type + "-" + interval, beforTimeStamp);
+  }
+
+  private static class StorageHistoryRowMapper implements RowMapper<StorageCapacity> {
+    @Override
+    public StorageCapacity mapRow(ResultSet resultSet, int i) throws SQLException {
+      return new StorageCapacity(resultSet.getString("type"),
+          resultSet.getLong("time_stamp"),
+          resultSet.getLong("capacity"), resultSet.getLong("free"));
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultStoragePolicyDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultStoragePolicyDao.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.StoragePolicyDao;
+import org.smartdata.model.StoragePolicy;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultStoragePolicyDao extends AbstractDao implements StoragePolicyDao {
+  private static final String TABLE_NAME = "storage_policy";
+
+  private Map<Integer, String> data = null;
+
+  public DefaultStoragePolicyDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+    this.data = getStoragePolicyFromDB();
+  }
+
+  private Map<Integer, String> getStoragePolicyFromDB() {
+    String sql = "SELECT * FROM " + TABLE_NAME;
+    List<StoragePolicy> list = jdbcTemplate.query(sql, new StoragePolicyRowMapper());
+    Map<Integer, String> map = new HashMap<>();
+    for (StoragePolicy s : list) {
+      map.put((int) (s.getSid()), s.getPolicyName());
+    }
+    return map;
+  }
+
+  @Override
+  public Map<Integer, String> getStoragePolicyIdNameMap() {
+    return this.data;
+  }
+
+  @Override
+  public String getStoragePolicyName(int sid) {
+    return this.data.get(sid);
+  }
+
+  @Override
+  public Integer getStorageSid(String policyName) {
+    for (Map.Entry<Integer, String> entry : this.data.entrySet()) {
+      if (entry.getValue().equals(policyName)) {
+        return entry.getKey();
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  public synchronized void insertStoragePolicyTable(StoragePolicy s) {
+    if (!isExist(s.getPolicyName())) {
+      String sql = "INSERT INTO storage_policy (sid, policy_name) VALUES('"
+          + s.getSid() + "','" + s.getPolicyName() + "');";
+      jdbcTemplate.execute(sql);
+      this.data.put((int) (s.getSid()), s.getPolicyName());
+    }
+  }
+
+  @Override
+  public synchronized void deleteStoragePolicy(int sid) {
+    if (isExist(sid)) {
+      final String sql = "DELETE FROM " + TABLE_NAME + " WHERE sid = ?";
+      jdbcTemplate.update(sql, sid);
+      this.data.remove(sid);
+    }
+  }
+
+  @Override
+  public synchronized void deleteStoragePolicy(String policyName) {
+    Integer sid = getStorageSid(policyName);
+    deleteStoragePolicy(sid);
+  }
+
+  @Override
+  public boolean isExist(int sid) {
+    if (getStoragePolicyName(sid) != null) {
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isExist(String policyName) {
+    return getStorageSid(policyName) != -1;
+  }
+
+  private static class StoragePolicyRowMapper implements RowMapper<StoragePolicy> {
+    @Override
+    public StoragePolicy mapRow(ResultSet resultSet, int i) throws SQLException {
+      return new StoragePolicy(
+          resultSet.getByte("sid"),
+          resultSet.getString("policy_name"));
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultSystemInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultSystemInfoDao.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.SystemInfoDao;
+import org.smartdata.model.SystemInfo;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultSystemInfoDao extends AbstractDao implements SystemInfoDao {
+  private static final String TABLE_NAME = "sys_info";
+
+  public DefaultSystemInfoDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<SystemInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new SystemInfoRowMapper());
+  }
+
+  @Override
+  public boolean containsProperty(String property) {
+    return !list(property).isEmpty();
+  }
+
+  private List<SystemInfo> list(String property) {
+    return new JdbcTemplate(dataSource)
+        .query(
+            "SELECT * FROM " + TABLE_NAME + " WHERE property = ?",
+            new Object[]{property},
+            new SystemInfoRowMapper());
+  }
+
+  @Override
+  public SystemInfo getByProperty(String property) {
+    List<SystemInfo> infos = list(property);
+    return infos.isEmpty() ? null : infos.get(0);
+  }
+
+  @Override
+  public List<SystemInfo> getByProperties(List<String> properties) {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME + " WHERE property IN (?)",
+        new Object[]{StringUtils.join(properties, ",")},
+        new SystemInfoRowMapper());
+  }
+
+  @Override
+  public void delete(String property) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE property = ?";
+    jdbcTemplate.update(sql, property);
+  }
+
+  @Override
+  public void insert(SystemInfo systemInfo) {
+    insert(systemInfo, this::toMap);
+  }
+
+  @Override
+  public void insert(SystemInfo[] systemInfos) {
+    insert(systemInfos, this::toMap);
+  }
+
+  @Override
+  public int update(SystemInfo systemInfo) {
+    String sql = "UPDATE " + TABLE_NAME + " SET value = ? WHERE property = ?";
+    return jdbcTemplate.update(sql, systemInfo.getValue(), systemInfo.getProperty());
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  private Map<String, Object> toMap(SystemInfo systemInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("property", systemInfo.getProperty());
+    parameters.put("value", systemInfo.getValue());
+    return parameters;
+  }
+
+  private static class SystemInfoRowMapper implements RowMapper<SystemInfo> {
+
+    @Override
+    public SystemInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      return new SystemInfo(
+          resultSet.getString("property"),
+          resultSet.getString("value"));
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultUserInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultUserInfoDao.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.UserInfoDao;
+import org.smartdata.model.UserInfo;
+import org.smartdata.utils.StringUtil;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultUserInfoDao extends AbstractDao implements UserInfoDao {
+  private static final String TABLE_NAME = "user_info";
+
+  public DefaultUserInfoDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<UserInfo> getAll() {
+    return jdbcTemplate.query("SELECT * FROM " + TABLE_NAME, new UserInfoRowMapper());
+  }
+
+  @Override
+  public boolean containsUserName(String name) {
+    return !list(name).isEmpty();
+  }
+
+  private List<UserInfo> list(String name) {
+    return new JdbcTemplate(dataSource)
+        .query(
+            "SELECT * FROM " + TABLE_NAME + " WHERE user_name = ?",
+            new Object[]{name},
+            new UserInfoRowMapper());
+  }
+
+  @Override
+  public UserInfo getByUserName(String name) {
+    List<UserInfo> infos = list(name);
+    return infos.isEmpty() ? null : infos.get(0);
+  }
+
+  @Override
+  public void delete(String name) {
+    final String sql = "DELETE FROM " + TABLE_NAME + " WHERE user_name = ?";
+    jdbcTemplate.update(sql, name);
+  }
+
+  @Override
+  public void insert(UserInfo userInfo) {
+    UserInfo userWithCachedPassword = new UserInfo(
+        userInfo.getUserName(),
+        StringUtil.toSHA512String(userInfo.getUserPassword()));
+    insert(userWithCachedPassword, this::toMap);
+  }
+
+  @Override
+  public boolean authentic(UserInfo userInfo) {
+    UserInfo origin = getByUserName(userInfo.getUserName());
+    return origin.equals(userInfo);
+  }
+
+  @Override
+  public int newPassword(UserInfo userInfo) {
+    String sql = "UPDATE " + TABLE_NAME + " SET user_password = ? WHERE user_name = ?";
+    return jdbcTemplate.update(sql, StringUtil.toSHA512String(userInfo.getUserPassword()),
+        userInfo.getUserName());
+  }
+
+  @Override
+  public void deleteAll() {
+    final String sql = "DELETE FROM " + TABLE_NAME;
+    jdbcTemplate.execute(sql);
+  }
+
+  private Map<String, Object> toMap(UserInfo userInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("user_name", userInfo.getUserName());
+    parameters.put("user_password", userInfo.getUserPassword());
+    return parameters;
+  }
+
+  private static class UserInfoRowMapper implements RowMapper<UserInfo> {
+
+    @Override
+    public UserInfo mapRow(ResultSet resultSet, int i) throws SQLException {
+      return new UserInfo(
+          resultSet.getString("user_name"),
+          resultSet.getString("user_password"));
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultWhitelistDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultWhitelistDao.java
@@ -1,0 +1,26 @@
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.WhitelistDao;
+
+import javax.sql.DataSource;
+
+public class DefaultWhitelistDao extends AbstractDao implements WhitelistDao {
+  private static final String TABLE_NAME = "whitelist";
+
+  public DefaultWhitelistDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public String getLastFetchedDirs() {
+    String sql = "SELECT * FROM " + TABLE_NAME;
+    return jdbcTemplate.queryForObject(sql, String.class);
+  }
+
+  @Override
+  public void updateTable(String newWhitelist) {
+    final String sql = "UPDATE whitelist SET last_fetched_dirs =?";
+    jdbcTemplate.update(sql, newWhitelist);
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultXattrDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultXattrDao.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.dao.impl;
+
+import org.smartdata.metastore.dao.AbstractDao;
+import org.smartdata.metastore.dao.XattrDao;
+import org.smartdata.model.XAttribute;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+
+import javax.sql.DataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultXattrDao extends AbstractDao implements XattrDao {
+  private static final String TABLE_NAME = "xattr";
+
+  public DefaultXattrDao(DataSource dataSource) {
+    super(dataSource, TABLE_NAME);
+  }
+
+  @Override
+  public List<XAttribute> getXattrList(Long fid) throws SQLException {
+    String sql =
+        String.format("SELECT * FROM xattr WHERE fid = %s;", fid);
+    return getXattrList(sql);
+  }
+
+  @Override
+  public List<XAttribute> getXattrList(String sql) throws SQLException {
+    List<XAttribute> list = new LinkedList<>();
+    List<Map<String, Object>> maplist = jdbcTemplate.queryForList(sql);
+    for (Map<String, Object> map : maplist) {
+      list.add(new XAttribute((String) map.get("namespace"),
+          (String) map.get("name"), (byte[]) map.get("value")));
+    }
+    return list;
+  }
+
+  @Override
+  public synchronized boolean insertXattrList(final Long fid, final List<XAttribute> attributes)
+      throws SQLException {
+    String sql = "INSERT INTO xattr (fid, namespace, name, value) VALUES (?, ?, ?, ?)";
+    int[] i = jdbcTemplate.batchUpdate(sql,
+        new BatchPreparedStatementSetter() {
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setLong(1, fid);
+            ps.setString(2, attributes.get(i).getNameSpace());
+            ps.setString(3, attributes.get(i).getName());
+            ps.setBytes(4, attributes.get(i).getValue());
+          }
+
+          public int getBatchSize() {
+            return attributes.size();
+          }
+        });
+    return i.length == attributes.size();
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManager.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManager.java
@@ -1,0 +1,26 @@
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.db;
+
+public interface DBManager {
+
+    void initializeDatabase() throws Exception;
+
+    void clearDatabase() throws Exception;
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManager.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManager.java
@@ -1,4 +1,3 @@
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,7 +19,7 @@ package org.smartdata.metastore.db;
 
 public interface DBManager {
 
-    void initializeDatabase() throws Exception;
+  void initializeDatabase() throws Exception;
 
-    void clearDatabase() throws Exception;
+  void clearDatabase() throws Exception;
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManagerFactory.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManagerFactory.java
@@ -1,0 +1,42 @@
+package org.smartdata.metastore.db;
+
+import org.apache.hadoop.conf.Configuration;
+import org.smartdata.metastore.DBPool;
+import org.smartdata.metastore.MetaStoreException;
+
+import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_DB_URL_KEY;
+import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_CHANGELOG_PATH_DEFAULT;
+import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_CHANGELOG_PATH_KEY;
+import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_LABELS_DEFAULT;
+import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_LABELS_KEY;
+import static org.smartdata.metastore.utils.MetaStoreUtils.isOldMySql;
+
+public class DBManagerFactory {
+    public static final String OLD_MYSQL_LABEL = "old_mysql";
+
+    public DBManager createDbManager(DBPool dbPool, Configuration conf) throws MetaStoreException {
+        String changelogPath = conf.get(
+                SMART_METASTORE_MIGRATION_CHANGELOG_PATH_KEY,
+                SMART_METASTORE_MIGRATION_CHANGELOG_PATH_DEFAULT);
+
+        String labels = conf.get(
+                SMART_METASTORE_MIGRATION_LABELS_KEY,
+                SMART_METASTORE_MIGRATION_LABELS_DEFAULT);
+
+        String dbUrl = conf.get(SMART_METASTORE_DB_URL_KEY);
+        if (isOldMySql(dbPool, dbUrl)) {
+            labels = appendToLabels(labels, OLD_MYSQL_LABEL);
+        }
+
+        return new LiquibaseDBManager(dbPool, changelogPath, labels);
+    }
+
+    private String appendToLabels(String currentLabels, String label) {
+        if (currentLabels.isEmpty()) {
+            return label;
+        }
+
+        return String.format("(%s) OR %s", currentLabels, label);
+    }
+
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManagerFactory.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/db/DBManagerFactory.java
@@ -1,42 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.smartdata.metastore.db;
 
 import org.apache.hadoop.conf.Configuration;
 import org.smartdata.metastore.DBPool;
-import org.smartdata.metastore.MetaStoreException;
 
-import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_DB_URL_KEY;
 import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_CHANGELOG_PATH_DEFAULT;
 import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_CHANGELOG_PATH_KEY;
 import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_LABELS_DEFAULT;
 import static org.smartdata.conf.SmartConfKeys.SMART_METASTORE_MIGRATION_LABELS_KEY;
-import static org.smartdata.metastore.utils.MetaStoreUtils.isOldMySql;
 
 public class DBManagerFactory {
-    public static final String OLD_MYSQL_LABEL = "old_mysql";
+  public DBManager createDbManager(DBPool dbPool, Configuration conf) {
+    String changelogPath = conf.get(
+        SMART_METASTORE_MIGRATION_CHANGELOG_PATH_KEY,
+        SMART_METASTORE_MIGRATION_CHANGELOG_PATH_DEFAULT);
 
-    public DBManager createDbManager(DBPool dbPool, Configuration conf) throws MetaStoreException {
-        String changelogPath = conf.get(
-                SMART_METASTORE_MIGRATION_CHANGELOG_PATH_KEY,
-                SMART_METASTORE_MIGRATION_CHANGELOG_PATH_DEFAULT);
+    String labels = conf.get(
+        SMART_METASTORE_MIGRATION_LABELS_KEY,
+        SMART_METASTORE_MIGRATION_LABELS_DEFAULT);
 
-        String labels = conf.get(
-                SMART_METASTORE_MIGRATION_LABELS_KEY,
-                SMART_METASTORE_MIGRATION_LABELS_DEFAULT);
-
-        String dbUrl = conf.get(SMART_METASTORE_DB_URL_KEY);
-        if (isOldMySql(dbPool, dbUrl)) {
-            labels = appendToLabels(labels, OLD_MYSQL_LABEL);
-        }
-
-        return new LiquibaseDBManager(dbPool, changelogPath, labels);
-    }
-
-    private String appendToLabels(String currentLabels, String label) {
-        if (currentLabels.isEmpty()) {
-            return label;
-        }
-
-        return String.format("(%s) OR %s", currentLabels, label);
-    }
-
+    return new LiquibaseDBManager(dbPool, changelogPath, labels);
+  }
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/db/LiquibaseDBManager.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/db/LiquibaseDBManager.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.db;
+
+import liquibase.command.CommandScope;
+import liquibase.command.core.DropAllCommandStep;
+import liquibase.command.core.UpdateCommandStep;
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import org.smartdata.metastore.DBPool;
+
+import java.sql.Connection;
+
+public class LiquibaseDBManager implements DBManager {
+    private final DBPool pool;
+    private final String changelogPath;
+    private final String labelFilterExpr;
+
+    public LiquibaseDBManager(DBPool pool, String changelogPath, String labelFilterExpr) {
+        this.pool = pool;
+        this.changelogPath = changelogPath;
+        this.labelFilterExpr = labelFilterExpr;
+    }
+
+    @Override
+    public void initializeDatabase() throws Exception {
+        try (Connection connection = pool.getConnection();
+             JdbcConnection jdbcConnection = new JdbcConnection(connection)) {
+            Database db = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(jdbcConnection);
+
+            new CommandScope(UpdateCommandStep.COMMAND_NAME)
+                    .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, db)
+                    .addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, changelogPath)
+                    .addArgumentValue(UpdateCommandStep.LABEL_FILTER_ARG, labelFilterExpr)
+                    .execute();
+        }
+    }
+
+    @Override
+    public void clearDatabase() throws Exception {
+        try (Connection connection = pool.getConnection();
+             JdbcConnection jdbcConnection = new JdbcConnection(connection)) {
+            Database db = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(jdbcConnection);
+
+            new CommandScope(DropAllCommandStep.COMMAND_NAME)
+                    .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, db)
+                    .execute();
+        }
+    }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/utils/MetaStoreUtils.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/utils/MetaStoreUtils.java
@@ -23,9 +23,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.conf.SmartConf;
 import org.smartdata.conf.SmartConfKeys;
+import org.smartdata.metastore.DBPool;
 import org.smartdata.metastore.DruidPool;
 import org.smartdata.metastore.MetaStore;
 import org.smartdata.metastore.MetaStoreException;
+import org.smartdata.metastore.db.DBManager;
+import org.smartdata.metastore.db.DBManagerFactory;
 import org.smartdata.utils.StringUtil;
 
 import java.io.File;
@@ -33,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -63,10 +67,8 @@ public class MetaStoreUtils {
         "PERFORMANCE_SCHEMA"
       };
   static final Logger LOG = LoggerFactory.getLogger(MetaStoreUtils.class);
-  private static int characterTakeUpBytes = 1;
-  private static final String defaultPassword = "ssm@123";
 
-  public static final String TABLESET[] = new String[]{
+  public static final String[] TABLESET = new String[]{
             "access_count_table",
             "blank_access_count_info",
             "cached_file",
@@ -94,24 +96,11 @@ public class MetaStoreUtils {
             "whitelist"
   };
 
-  public static Connection createConnection(String url,
-      String userName, String password)
-      throws ClassNotFoundException, SQLException {
-    if (url.startsWith(SQLITE_URL_PREFIX)) {
-      Class.forName("org.sqlite.JDBC");
-    } else if (url.startsWith(MYSQL_URL_PREFIX)) {
-      Class.forName("com.mysql.jdbc.Driver");
-    }
-    Connection conn = DriverManager.getConnection(url, userName, password);
-    return conn;
-  }
-
   public static Connection createConnection(String driver, String url,
       String userName,
       String password) throws ClassNotFoundException, SQLException {
     Class.forName(driver);
-    Connection conn = DriverManager.getConnection(url, userName, password);
-    return conn;
+    return DriverManager.getConnection(url, userName, password);
   }
 
   public static Connection createSqliteConnection(String dbFilePath)
@@ -124,7 +113,7 @@ public class MetaStoreUtils {
     }
   }
 
-  public static int getTableSetNum(Connection conn, String tableSet[]) throws MetaStoreException {
+  public static int getTableSetNum(Connection conn, String[] tableSet) throws MetaStoreException {
     String tables = "('" + StringUtils.join(tableSet, "','") + "')";
     try {
       String url = conn.getMetaData().getURL();
@@ -154,316 +143,6 @@ public class MetaStoreUtils {
     }
   }
 
-  public static void initializeDataBase(
-      Connection conn) throws MetaStoreException {
-    ArrayList<String> tableList = new ArrayList<>();
-    for (String table: TABLESET) {
-      tableList.add("DROP TABLE IF EXISTS " + table);
-    }
-    String deleteExistingTables[] = tableList.toArray(new String[tableList.size()]);
-    String password = StringUtil.toSHA512String(defaultPassword);
-    String createEmptyTables[] =
-        new String[] {
-          "CREATE TABLE access_count_table (\n"
-              + "  table_name varchar(255) PRIMARY KEY,\n"
-              + "  start_time bigint(20) NOT NULL,\n"
-              + "  end_time bigint(20) NOT NULL\n"
-              + ") ;",
-          "CREATE TABLE blank_access_count_info (\n"
-              + "  fid bigint(20) NOT NULL,\n"
-              + "  count bigint(20) NOT NULL\n"
-              + ");",
-          "CREATE TABLE cached_file (\n"
-              + "  fid bigint(20) NOT NULL,\n"
-              + "  path varchar(1000) NOT NULL,\n"
-              + "  from_time bigint(20) NOT NULL,\n"
-              + "  last_access_time bigint(20) NOT NULL,\n"
-              + "  accessed_num int(11) NOT NULL\n"
-              + ");",
-          "CREATE INDEX cached_file_fid_idx ON cached_file (fid);",
-          "CREATE INDEX cached_file_path_idx ON cached_file (path);",
-          "CREATE TABLE ec_policy (\n"
-              + "  id tinyint(1) NOT NULL PRIMARY KEY,\n"
-              + "  policy_name varchar(255) NOT NULL\n"
-              + ");",
-          "CREATE TABLE file (\n"
-              + "  path varchar(1000) NOT NULL,\n"
-              + "  fid bigint(20) NOT NULL,\n"
-              + "  length bigint(20) DEFAULT NULL,\n"
-              + "  block_replication smallint(6) DEFAULT NULL,\n"
-              + "  block_size bigint(20) DEFAULT NULL,\n"
-              + "  modification_time bigint(20) DEFAULT NULL,\n"
-              + "  access_time bigint(20) DEFAULT NULL,\n"
-              + "  is_dir tinyint(1) DEFAULT NULL,\n"
-              + "  sid tinyint(4) DEFAULT NULL,\n"
-              + "  owner varchar(255) DEFAULT NULL,\n"
-              + "  owner_group varchar(255) DEFAULT NULL,\n"
-              + "  permission smallint(6) DEFAULT NULL,\n"
-              + "  ec_policy_id tinyint(1) DEFAULT NULL\n"
-              + ");",
-          "CREATE INDEX file_fid_idx ON file (fid);",
-          "CREATE INDEX file_path_idx ON file (path);",
-          "CREATE TABLE storage (\n"
-              + "  type varchar(32) PRIMARY KEY,\n"
-              + "  time_stamp bigint(20) DEFAULT NULL,\n"
-              + "  capacity bigint(20) NOT NULL,\n"
-              + "  free bigint(20) NOT NULL\n"
-              + ");",
-          "CREATE TABLE storage_hist (\n" // Keep this compatible with Table 'storage'
-              + "  type varchar(64),\n"
-              + "  time_stamp bigint(20) DEFAULT NULL,\n"
-              + "  capacity bigint(20) NOT NULL,\n"
-              + "  free bigint(20) NOT NULL\n"
-              + ");",
-          "CREATE INDEX type_idx ON storage_hist (type);",
-          "CREATE INDEX time_stamp_idx ON storage_hist (time_stamp);",
-          "CREATE TABLE storage_policy (\n"
-              + "  sid tinyint(4) PRIMARY KEY,\n"
-              + "  policy_name varchar(64) DEFAULT NULL\n"
-              + ");",
-          "INSERT INTO storage_policy VALUES ('0', 'UNDEF');",
-          "INSERT INTO storage_policy VALUES ('2', 'COLD');",
-          "INSERT INTO storage_policy VALUES ('5', 'WARM');",
-          "INSERT INTO storage_policy VALUES ('7', 'HOT');",
-          "INSERT INTO storage_policy VALUES ('10', 'ONE_SSD');",
-          "INSERT INTO storage_policy VALUES ('12', 'ALL_SSD');",
-          "INSERT INTO storage_policy VALUES ('15', 'LAZY_PERSIST');",
-          "CREATE TABLE xattr (\n"
-              + "  fid bigint(20) NOT NULL,\n"
-              + "  namespace varchar(255) NOT NULL,\n"
-              + "  name varchar(255) NOT NULL,\n"
-              + "  value blob NOT NULL\n"
-              + ");",
-          "CREATE INDEX xattr_fid_idx ON xattr (fid);",
-          "CREATE TABLE datanode_info (\n"
-              + "  uuid varchar(64) PRIMARY KEY,\n"
-              + "  hostname varchar(255) NOT NULL,\n"
-              + // DatanodeInfo
-              "  rpcAddress varchar(21) DEFAULT NULL,\n"
-              + "  cache_capacity bigint(20) DEFAULT NULL,\n"
-              + "  cache_used bigint(20) DEFAULT NULL,\n"
-              + "  location varchar(255) DEFAULT NULL\n"
-              + ");",
-          "CREATE TABLE datanode_storage_info (\n"
-              + "  uuid varchar(64) NOT NULL,\n"
-              + "  sid tinyint(4) NOT NULL,\n"
-              + // storage type
-              "  state tinyint(4) NOT NULL,\n"
-              + // DatanodeStorage.state
-              "  storage_id varchar(64) NOT NULL,\n"
-              + // StorageReport ...
-              "  failed tinyint(1) DEFAULT NULL,\n"
-              + "  capacity bigint(20) DEFAULT NULL,\n"
-              + "  dfs_used bigint(20) DEFAULT NULL,\n"
-              + "  remaining bigint(20) DEFAULT NULL,\n"
-              + "  block_pool_used bigint(20) DEFAULT NULL\n"
-              + ");",
-          "CREATE TABLE rule (\n"
-              + "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-              + "  name varchar(255) DEFAULT NULL,\n"
-              + "  state tinyint(4) NOT NULL,\n"
-              + "  rule_text varchar(4096) NOT NULL,\n"
-              + "  submit_time bigint(20) NOT NULL,\n"
-              + "  last_check_time bigint(20) DEFAULT NULL,\n"
-              + "  checked_count int(11) NOT NULL,\n"
-              + "  generated_cmdlets int(11) NOT NULL\n"
-              + ");",
-          "CREATE TABLE cmdlet (\n"
-              + "  cid INTEGER PRIMARY KEY,\n"
-              + "  rid INTEGER NOT NULL,\n"
-              + "  aids varchar(4096) NOT NULL,\n"
-              + "  state tinyint(4) NOT NULL,\n"
-              + "  parameters varchar(4096) NOT NULL,\n"
-              + "  generate_time bigint(20) NOT NULL,\n"
-              + "  state_changed_time bigint(20) NOT NULL\n"
-              + ");",
-          "CREATE TABLE action (\n"
-              + "  aid INTEGER PRIMARY KEY,\n"
-              + "  cid INTEGER NOT NULL,\n"
-              + "  action_name varchar(4096) NOT NULL,\n"
-              + "  args text NOT NULL,\n"
-              + "  result mediumtext NOT NULL,\n"
-              + "  log longtext NOT NULL,\n"
-              + "  successful tinyint(4) NOT NULL,\n"
-              + "  create_time bigint(20) NOT NULL,\n"
-              + "  finished tinyint(4) NOT NULL,\n"
-              + "  finish_time bigint(20) NOT NULL,\n"
-              + "  exec_host varchar(255),\n"
-              + "  progress float NOT NULL\n"
-              + ");",
-          "CREATE TABLE file_diff (\n"
-              + "  did INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-              + "  rid INTEGER NOT NULL,\n"
-              + "  diff_type varchar(4096) NOT NULL,\n"
-              + "  src varchar(1000) NOT NULL,\n"
-              + "  parameters varchar(4096) NOT NULL,\n"
-              + "  state tinyint(4) NOT NULL,\n"
-              + "  create_time bigint(20) NOT NULL\n"
-              + ");",
-          "CREATE INDEX file_diff_idx ON file_diff (src);",
-          "CREATE TABLE global_config (\n"
-              + " cid INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-              + " property_name varchar(512) NOT NULL UNIQUE,\n"
-              + " property_value varchar(3072) NOT NULL\n"
-              + ");",
-          "CREATE TABLE cluster_config (\n"
-              + " cid INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-              + " node_name varchar(512) NOT NULL UNIQUE,\n"
-              + " config_path varchar(3072) NOT NULL\n"
-              + ");",
-          "CREATE TABLE sys_info (\n"
-              + "  property varchar(512) PRIMARY KEY,\n"
-              + "  value varchar(4096) NOT NULL\n"
-              + ");",
-          "CREATE TABLE user_info (\n"
-              + "  user_name varchar(20) PRIMARY KEY,\n"
-              + "  user_password varchar(256) NOT NULL\n"
-              + ");",
-          "INSERT INTO user_info VALUES('admin','" + password + "');",
-          "CREATE TABLE cluster_info (\n"
-              + "  cid INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-              + "  name varchar(512) NOT NULL UNIQUE,\n"
-              + "  url varchar(4096) NOT NULL,\n"
-              + "  conf_path varchar(4096) NOT NULL,\n"
-              + "  state varchar(64) NOT NULL,\n"
-              + // ClusterState
-              "  type varchar(64) NOT NULL\n"
-              + // ClusterType
-              ");",
-          "CREATE TABLE backup_file (\n"
-              + " rid bigint(20) NOT NULL,\n"
-              + " src varchar(4096) NOT NULL,\n"
-              + " dest varchar(4096) NOT NULL,\n"
-              + " period bigint(20) NOT NULL\n"
-              + ");",
-          "CREATE INDEX backup_file_rid_idx ON backup_file (rid);",
-          "CREATE TABLE file_state (\n"
-              + " path varchar(512) PRIMARY KEY,\n"
-              + " type tinyint(4) NOT NULL,\n"
-              + " stage tinyint(4) NOT NULL\n"
-              + ");",
-          "CREATE TABLE compression_file (\n"
-              + " path varchar(512) PRIMARY KEY,\n"
-              + " buffer_size int(11) NOT NULL,\n"
-              + " compression_impl varchar(64) NOT NULL,\n"
-              + " original_length bigint(20) NOT NULL,\n"
-              + " compressed_length bigint(20) NOT NULL,\n"
-              + " originalPos text NOT NULL,\n"
-              + " compressedPos text NOT NULL\n"
-              + ");",
-          "CREATE TABLE small_file (\n"
-              + "path varchar(1000) NOT NULL PRIMARY KEY,\n"
-              + "container_file_path varchar(4096) NOT NULL,\n"
-              + "offset bigint(20) NOT NULL,\n"
-              + "length bigint(20) NOT NULL\n"
-              + ");",
-          "CREATE TABLE whitelist (\n"
-              + "last_fetched_dirs varchar(4096) NOT NULL\n"
-              + ");",
-          "INSERT INTO whitelist VALUES( '' );"
-        };
-    try {
-      for (String s : deleteExistingTables) {
-        // Drop table if exists
-        LOG.debug(s);
-        executeSql(conn, s);
-      }
-      // Handle mysql related features
-      String url = conn.getMetaData().getURL();
-      boolean mysql = url.startsWith(MetaStoreUtils.MYSQL_URL_PREFIX);
-      boolean mysqlOldRelease = false;
-      if (mysql) {
-        // Mysql version number
-        double mysqlVersion =
-            conn.getMetaData().getDatabaseMajorVersion()
-                + conn.getMetaData().getDatabaseMinorVersion() * 0.1;
-        LOG.debug("Mysql Version Number {}", mysqlVersion);
-        if (mysqlVersion < 5.5) {
-          LOG.error("Required Mysql version >= 5.5, but current is " + mysqlVersion);
-          throw new MetaStoreException("Mysql version " + mysqlVersion + " is below requirement!");
-        } else if (mysqlVersion < 5.7 && mysqlVersion >= 5.5) {
-          mysqlOldRelease = true;
-        }
-      }
-      if (mysqlOldRelease) {
-        // Enable dynamic file format to avoid index length limit 767
-        executeSql(conn, "SET GLOBAL innodb_file_format=barracuda;");
-        executeSql(conn, "SET GLOBAL innodb_file_per_table=true;");
-        executeSql(conn, "SET GLOBAL innodb_large_prefix = ON;");
-      }
-      for (String s : createEmptyTables) {
-        // Solve mysql and sqlite sql difference
-        s = sqlCompatibility(mysql, mysqlOldRelease, s);
-        LOG.debug(s);
-        executeSql(conn, s);
-      }
-    } catch (Exception e) {
-      throw new MetaStoreException(e);
-    }
-  }
-
-  /**
-   * * Solve SQL compatibility problem caused by mysql and sqlite. * Note that mysql 5.6 or earlier
-   * cannot support index length larger than 767. * Meanwhile, sqlite's keywords are a little
-   * different from mysql.
-   *
-   * @param mysql boolean
-   * @param mysqlOldRelease boolean mysql version is earlier than 5.6
-   * @param sql String sql
-   * @return converted sql
-   */
-  private static String sqlCompatibility(boolean mysql, boolean mysqlOldRelease, String sql) {
-    if (mysql) {
-      // path/src index should be set to less than 767
-      // to avoid "Specified key was too long" in
-      // Mysql 5.6 or previous version
-      if (mysqlOldRelease) {
-        // Fix index size 767 in mysql 5.6 or previous version
-        int maxLong = 767 / characterTakeUpBytes;
-        if (sql.startsWith("CREATE INDEX")
-            && (sql.contains("path") || sql.contains("src"))) {
-          // Index longer than maxLong
-          sql = sql.replace(");", "(" + maxLong + "));");
-        } else if (sql.contains("PRIMARY KEY") || sql.contains("UNIQUE")) {
-          // Primary key longer than maxLong
-          Pattern p = Pattern.compile("(\\d{3,})(.{2,15})(PRIMARY|UNIQUE)");
-          Matcher m = p.matcher(sql);
-          if (m.find()) {
-            if (Integer.valueOf(m.group(1)) > maxLong) {
-              // Make this table dynamic
-              sql = sql.replace(");", ") ROW_FORMAT=DYNAMIC ENGINE=INNODB;");
-              LOG.debug(sql);
-            }
-          }
-        }
-      }
-      // Replace AUTOINCREMENT with AUTO_INCREMENT
-      if (sql.contains("AUTOINCREMENT")) {
-        sql = sql.replace("AUTOINCREMENT", "AUTO_INCREMENT");
-      }
-    }
-    return sql;
-  }
-
-  public static void executeSql(Connection conn, String sql)
-      throws MetaStoreException {
-    try {
-      Statement s = conn.createStatement();
-      s.execute(sql);
-    } catch (Exception e) {
-      LOG.error("SQL execution error " + sql);
-      throw new MetaStoreException(e);
-    }
-  }
-
-  public static boolean supportsBatchUpdates(Connection conn) {
-    try {
-      return conn.getMetaData().supportsBatchUpdates();
-    } catch (Exception e) {
-      return false;
-    }
-  }
-
   public static void formatDatabase(SmartConf conf) throws MetaStoreException {
     getDBAdapter(conf).formatDataBase();
   }
@@ -475,17 +154,13 @@ public class MetaStoreUtils {
   public static String getMysqlDBName(String url) throws SQLException {
     NonRegisteringDriver nonRegisteringDriver = new NonRegisteringDriver();
     Properties properties = nonRegisteringDriver.parseURL(url, null);
-    return properties.getProperty(nonRegisteringDriver.DBNAME_PROPERTY_KEY);
+    return properties.getProperty(NonRegisteringDriver.DBNAME_PROPERTY_KEY);
   }
 
   public static MetaStore getDBAdapter(
           SmartConf conf) throws MetaStoreException {
     URL pathUrl = ClassLoader.getSystemResource("");
     String path = pathUrl.getPath();
-
-    characterTakeUpBytes = conf.getInt(
-      SmartConfKeys.SMART_METASTORE_CHARACTER_TAKEUP_BYTES_KEY,
-      SmartConfKeys.SMART_METASTORE_CHARACTER_TAKEUP_BYTES_DEFAULT);
 
     String fileName = "druid.xml";
     String expectedCpPath = path + fileName;
@@ -504,7 +179,7 @@ public class MetaStoreUtils {
         }
 
         String purl = p.getProperty("url");
-        if (purl == null || purl.length() == 0) {
+        if (purl == null || purl.isEmpty()) {
           purl = getDefaultSqliteDB(); // For testing
           p.setProperty("url", purl);
           LOG.warn("Database URL not specified, using " + purl);
@@ -541,7 +216,9 @@ public class MetaStoreUtils {
             LOG.info("\t" + key + " = " + p.getProperty(key));
           }
         }
-        return new MetaStore(new DruidPool(p));
+        DruidPool druidPool = new DruidPool(p);
+        DBManager dbManager = new DBManagerFactory().createDbManager(druidPool, conf);
+        return new MetaStore(druidPool, dbManager);
       } catch (Exception e) {
         if (e instanceof InvalidPropertiesFormatException) {
           throw new MetaStoreException(
@@ -574,7 +251,9 @@ public class MetaStoreUtils {
     for (String key : p.stringPropertyNames()) {
       LOG.info("\t" + key + " = " + p.getProperty(key));
     }
-    return new MetaStore(new DruidPool(p));
+    DruidPool druidPool = new DruidPool(p);
+    DBManager dbManager = new DBManagerFactory().createDbManager(druidPool, conf);
+    return new MetaStore(druidPool, dbManager);
   }
 
   public static Integer getKey(Map<Integer, String> map, String value) {
@@ -609,65 +288,38 @@ public class MetaStoreUtils {
   }
 
   /**
-   * This default behavior provided here is mainly for convenience.
-   *
-   * @return
+   * Returns if current DBMS is MySQL of version below 5.7.
+   * @throws MetaStoreException if version of MySQL is below 5.5.
    */
-  private static String getDefaultSqliteDB() throws MetaStoreException {
+  public static boolean isOldMySql(DBPool dbPool, String dbUrl) throws MetaStoreException {
+    if (!dbUrl.startsWith(MYSQL_URL_PREFIX)) {
+      return false;
+    }
+
+    try (Connection connection = dbPool.getConnection()) {
+      DatabaseMetaData connectionMetaData = connection.getMetaData();
+
+      double mysqlVersion =
+              connectionMetaData.getDatabaseMajorVersion()
+                      + connectionMetaData.getDatabaseMinorVersion() * 0.1;
+
+      if (mysqlVersion < 5.5) {
+        LOG.error("Required Mysql version >= 5.5, but current is " + mysqlVersion);
+        throw new MetaStoreException("Mysql version " + mysqlVersion + " is below requirement!");
+      }
+      return mysqlVersion < 5.7;
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * This default behavior provided here is mainly for convenience.
+   */
+  private static String getDefaultSqliteDB() {
     String absFilePath = System.getProperty("user.home")
-        + "/smart-test-default.db";
-    File file = new File(absFilePath);
-    if (file.exists()) {
-      return MetaStoreUtils.SQLITE_URL_PREFIX + absFilePath;
-    }
-    try {
-      Connection conn = MetaStoreUtils.createSqliteConnection(absFilePath);
-      MetaStoreUtils.initializeDataBase(conn);
-      conn.close();
-    } catch (Exception e) {
-      throw new MetaStoreException(e);
-    }
+            + "/smart-test-default.db";
     return MetaStoreUtils.SQLITE_URL_PREFIX + absFilePath;
-  }
-
-  public static void dropAllTablesSqlite(
-      Connection conn) throws MetaStoreException {
-    try {
-      Statement s = conn.createStatement();
-      ResultSet rs = s.executeQuery("SELECT tbl_name FROM sqlite_master;");
-      List<String> list = new ArrayList<>();
-      while (rs.next()) {
-        list.add(rs.getString(1));
-      }
-      for (String tb : list) {
-        if (!"sqlite_sequence".equals(tb)) {
-          s.execute("DROP TABLE IF EXISTS '" + tb + "';");
-        }
-      }
-    } catch (Exception e) {
-      throw new MetaStoreException(e);
-    }
-  }
-
-  public static void dropAllTablesMysql(Connection conn,
-      String url) throws MetaStoreException {
-    try {
-      Statement stat = conn.createStatement();
-      String dbName = getMysqlDBName(url);
-      LOG.info("Drop All tables of Current DBname: " + dbName);
-      ResultSet rs = stat.executeQuery("SELECT TABLE_NAME FROM "
-          + "INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '" + dbName + "';");
-      List<String> tbList = new ArrayList<>();
-      while (rs.next()) {
-        tbList.add(rs.getString(1));
-      }
-      for (String tb : tbList) {
-        LOG.info(tb);
-        stat.execute("DROP TABLE IF EXISTS " + tb + ";");
-      }
-    } catch (Exception e) {
-      throw new MetaStoreException(e);
-    }
   }
 }
 

--- a/smart-metastore/src/main/resources/db/changelog/changelog-1.init-db.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-1.init-db.xml
@@ -8,7 +8,15 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
         http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd">
-    <changeSet id="2023.09.28_1" author="tmanasyan">
+    <changeSet id="2023.09.28_000" author="tmanasyan" labels="old_mysql" failOnError="false">
+        <sql dbms="mysql, mariadb">
+            SET GLOBAL innodb_file_format=barracuda;
+            SET GLOBAL innodb_file_per_table=true;
+            SET GLOBAL innodb_large_prefix = ON;
+        </sql>
+    </changeSet>
+
+    <changeSet id="2023.09.28_001" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="access_count_table"/>
@@ -27,7 +35,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_2" author="tmanasyan">
+    <changeSet id="2023.09.28_002" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="blank_access_count_info"/>
@@ -43,7 +51,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_3" author="tmanasyan">
+    <changeSet id="2023.09.28_003" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="cached_file"/>
@@ -68,7 +76,16 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_4" author="tmanasyan">
+    <changeSet id="2023.09.28_0031" author="tmanasyan" labels="old_mysql">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="cached_file"/>
+        </preConditions>
+        <sql dbms="mysql, mariadb">
+            ALTER TABLE cached_file ROW_FORMAT= DYNAMIC ENGINE=INNODB;
+        </sql>
+    </changeSet>
+
+    <changeSet id="2023.09.28_004" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="cached_file_fid_idx"/>
@@ -79,7 +96,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="2023.09.28_5" author="tmanasyan">
+    <changeSet id="2023.09.28_005" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="cached_file_path_idx"/>
@@ -90,14 +107,14 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="2023.09.28_6" author="tmanasyan">
+    <changeSet id="2023.09.28_006" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="ec_policy"/>
             </not>
         </preConditions>
         <createTable tableName="ec_policy">
-            <column name="id" type="BIT">
+            <column name="id" type="TINYINT">
                 <constraints nullable="false" primaryKey="true"/>
             </column>
             <column name="policy_name" type="VARCHAR(255)">
@@ -106,7 +123,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_7" author="tmanasyan">
+    <changeSet id="2023.09.28_007" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="file"/>
@@ -133,7 +150,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_8" author="tmanasyan">
+    <changeSet id="2023.09.28_008" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="file_fid_idx"/>
@@ -144,7 +161,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="2023.09.28_9" author="tmanasyan">
+    <changeSet id="2023.09.28_009" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="file_path_idx"/>
@@ -153,9 +170,12 @@
         <createIndex indexName="file_path_idx" tableName="file">
             <column name="path"/>
         </createIndex>
+        <modifySql dbms="mysql, mariadb" labels="old_mysql">
+            <replace replace="`path`" with="`path`(767)"/>
+        </modifySql>
     </changeSet>
 
-    <changeSet id="2023.09.28_10" author="tmanasyan">
+    <changeSet id="2023.09.28_010" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="storage"/>
@@ -175,7 +195,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_11" author="tmanasyan">
+    <changeSet id="2023.09.28_011" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="storage_hist"/>
@@ -193,7 +213,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_12" author="tmanasyan">
+    <changeSet id="2023.09.28_012" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="type_idx"/>
@@ -204,7 +224,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="2023.09.28_13" author="tmanasyan">
+    <changeSet id="2023.09.28_013" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="time_stamp_idx"/>
@@ -215,7 +235,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="2023.09.28_14" author="tmanasyan">
+    <changeSet id="2023.09.28_014" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="storage_policy"/>
@@ -229,7 +249,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_15" author="tmanasyan">
+    <changeSet id="2023.09.28_015" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <tableIsEmpty tableName="storage_policy"/>
         </preConditions>
@@ -263,7 +283,7 @@
         </insert>
     </changeSet>
 
-    <changeSet id="2023.09.28_16" author="tmanasyan">
+    <changeSet id="2023.09.28_016" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="xattr"/>
@@ -285,7 +305,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_17" author="tmanasyan">
+    <changeSet id="2023.09.28_017" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="xattr_fid_idx"/>
@@ -296,7 +316,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="2023.09.28_18" author="tmanasyan">
+    <changeSet id="2023.09.28_018" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="datanode_info"/>
@@ -316,7 +336,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_19" author="tmanasyan">
+    <changeSet id="2023.09.28_019" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="datanode_storage_info"/>
@@ -343,7 +363,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_20" author="tmanasyan">
+    <changeSet id="2023.09.28_020" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="rule"/>
@@ -373,7 +393,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_21" author="tmanasyan">
+    <changeSet id="2023.09.28_021" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="cmdlet"/>
@@ -404,7 +424,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_22" author="tmanasyan">
+    <changeSet id="2023.09.28_022" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="action"/>
@@ -448,7 +468,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_23" author="tmanasyan">
+    <changeSet id="2023.09.28_023" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="file_diff"/>
@@ -479,7 +499,16 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_24" author="tmanasyan">
+    <changeSet id="2023.09.28_0231" author="tmanasyan" labels="old_mysql">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="file_diff"/>
+        </preConditions>
+        <sql dbms="mysql, mariadb">
+            ALTER TABLE file_diff ROW_FORMAT= DYNAMIC ENGINE=INNODB;
+        </sql>
+    </changeSet>
+
+    <changeSet id="2023.09.28_024" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="file_diff_idx"/>
@@ -488,9 +517,12 @@
         <createIndex indexName="file_diff_idx" tableName="file_diff">
             <column name="src"/>
         </createIndex>
+        <modifySql dbms="mysql, mariadb" labels="old_mysql">
+            <replace replace="`src`" with="`src`(767)"/>
+        </modifySql>
     </changeSet>
 
-    <changeSet id="2023.09.28_25" author="tmanasyan">
+    <changeSet id="2023.09.28_025" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="global_config"/>
@@ -509,7 +541,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_26" author="tmanasyan">
+    <changeSet id="2023.09.28_026" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="cluster_config"/>
@@ -528,7 +560,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_27" author="tmanasyan">
+    <changeSet id="2023.09.28_027" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="sys_info"/>
@@ -544,7 +576,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_28" author="tmanasyan">
+    <changeSet id="2023.09.28_028" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="user_info"/>
@@ -560,17 +592,18 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_29" author="tmanasyan">
+    <changeSet id="2023.09.28_029" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <tableIsEmpty tableName="user_info"/>
         </preConditions>
         <insert tableName="user_info">
             <column name="user_name" value="admin"/>
-            <column name="user_password" value="f2400ad74fe868714eee7e6f4f5b1bb98b140dc43cd8cb44970345c93d87fb80e7419f2a17cc6a1571776da21d321befb266b552ee09923ea2d4e82f32ad65fa"/>
+            <column name="user_password"
+                    value="f2400ad74fe868714eee7e6f4f5b1bb98b140dc43cd8cb44970345c93d87fb80e7419f2a17cc6a1571776da21d321befb266b552ee09923ea2d4e82f32ad65fa"/>
         </insert>
     </changeSet>
 
-    <changeSet id="2023.09.28_30" author="tmanasyan">
+    <changeSet id="2023.09.28_030" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="cluster_info"/>
@@ -598,7 +631,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_31" author="tmanasyan">
+    <changeSet id="2023.09.28_031" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="backup_file"/>
@@ -620,7 +653,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_32" author="tmanasyan">
+    <changeSet id="2023.09.28_032" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="backup_file_rid_idx"/>
@@ -631,7 +664,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="2023.09.28_33" author="tmanasyan">
+    <changeSet id="2023.09.28_033" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="file_state"/>
@@ -650,7 +683,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_34" author="tmanasyan">
+    <changeSet id="2023.09.28_034" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="compression_file"/>
@@ -681,7 +714,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_35" author="tmanasyan">
+    <changeSet id="2023.09.28_035" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="small_file"/>
@@ -701,9 +734,12 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
+        <modifySql dbms="mysql, mariadb" labels="old_mysql">
+            <replace replace="(`path`))" with="(`path`)) ROW_FORMAT=DYNAMIC ENGINE=INNODB;"/>
+        </modifySql>
     </changeSet>
 
-    <changeSet id="2023.09.28_36" author="tmanasyan">
+    <changeSet id="2023.09.28_036" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="whitelist"/>
@@ -716,20 +752,12 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="2023.09.28_37" author="tmanasyan">
+    <changeSet id="2023.09.28_037" author="tmanasyan">
         <preConditions onFail="MARK_RAN">
             <tableIsEmpty tableName="whitelist"/>
         </preConditions>
         <insert tableName="whitelist">
             <column name="last_fetched_dirs" value=""/>
         </insert>
-    </changeSet>
-
-    <changeSet id="2023.09.28_38" author="tmanasyan" labels="old_mysql">
-        <sql dbms="mysql, mariadb">
-            SET GLOBAL innodb_file_format=barracuda;
-            SET GLOBAL innodb_file_per_table=true;
-            SET GLOBAL innodb_large_prefix = ON;
-        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/smart-metastore/src/main/resources/db/changelog/changelog-1.init-db.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-1.init-db.xml
@@ -1,0 +1,735 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd">
+    <changeSet id="2023.09.28_1" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="access_count_table"/>
+            </not>
+        </preConditions>
+        <createTable tableName="access_count_table">
+            <column name="table_name" type="VARCHAR(255)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="start_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="end_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_2" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="blank_access_count_info"/>
+            </not>
+        </preConditions>
+        <createTable tableName="blank_access_count_info">
+            <column name="fid" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="count" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_3" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="cached_file"/>
+            </not>
+        </preConditions>
+        <createTable tableName="cached_file">
+            <column name="fid" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="path" type="VARCHAR(1000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="from_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_access_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="accessed_num" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_4" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="cached_file_fid_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="cached_file_fid_idx" tableName="cached_file">
+            <column name="fid"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_5" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="cached_file_path_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="cached_file_path_idx" tableName="cached_file">
+            <column name="path"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_6" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="ec_policy"/>
+            </not>
+        </preConditions>
+        <createTable tableName="ec_policy">
+            <column name="id" type="BIT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="policy_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_7" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="file"/>
+            </not>
+        </preConditions>
+        <createTable tableName="file">
+            <column name="path" type="VARCHAR(1000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="fid" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="length" type="BIGINT"/>
+            <column name="block_replication" type="SMALLINT"/>
+            <column name="block_size" type="BIGINT"/>
+            <column name="modification_time" type="BIGINT"/>
+            <column name="access_time" type="BIGINT"/>
+            <column name="is_dir" type="BIT"/>
+            <column name="sid" type="TINYINT"/>
+            <column name="owner" type="VARCHAR(255)"/>
+            <column name="owner_group" type="VARCHAR(255)"/>
+            <column name="permission" type="SMALLINT"/>
+            <column name="ec_policy_id" type="BIT"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_8" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="file_fid_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="file_fid_idx" tableName="file">
+            <column name="fid"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_9" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="file_path_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="file_path_idx" tableName="file">
+            <column name="path"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_10" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="storage"/>
+            </not>
+        </preConditions>
+        <createTable tableName="storage">
+            <column name="type" type="VARCHAR(32)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="time_stamp" type="BIGINT"/>
+            <column name="capacity" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="free" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_11" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="storage_hist"/>
+            </not>
+        </preConditions>
+        <createTable tableName="storage_hist">
+            <column name="type" type="VARCHAR(64)"/>
+            <column name="time_stamp" type="BIGINT"/>
+            <column name="capacity" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="free" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_12" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="type_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="type_idx" tableName="storage_hist">
+            <column name="type"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_13" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="time_stamp_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="time_stamp_idx" tableName="storage_hist">
+            <column name="time_stamp"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_14" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="storage_policy"/>
+            </not>
+        </preConditions>
+        <createTable tableName="storage_policy">
+            <column name="sid" type="TINYINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="policy_name" type="VARCHAR(64)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_15" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <tableIsEmpty tableName="storage_policy"/>
+        </preConditions>
+        <insert tableName="storage_policy">
+            <column name="sid" value="0"/>
+            <column name="policy_name" value="UNDEF"/>
+        </insert>
+        <insert tableName="storage_policy">
+            <column name="sid" value="2"/>
+            <column name="policy_name" value="COLD"/>
+        </insert>
+        <insert tableName="storage_policy">
+            <column name="sid" value="5"/>
+            <column name="policy_name" value="WARM"/>
+        </insert>
+        <insert tableName="storage_policy">
+            <column name="sid" value="7"/>
+            <column name="policy_name" value="HOT"/>
+        </insert>
+        <insert tableName="storage_policy">
+            <column name="sid" value="10"/>
+            <column name="policy_name" value="ONE_SSD"/>
+        </insert>
+        <insert tableName="storage_policy">
+            <column name="sid" value="12"/>
+            <column name="policy_name" value="ALL_SSD"/>
+        </insert>
+        <insert tableName="storage_policy">
+            <column name="sid" value="15"/>
+            <column name="policy_name" value="LAZY_PERSIST"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="2023.09.28_16" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="xattr"/>
+            </not>
+        </preConditions>
+        <createTable tableName="xattr">
+            <column name="fid" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="namespace" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="BLOB">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_17" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="xattr_fid_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="xattr_fid_idx" tableName="xattr">
+            <column name="fid"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_18" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="datanode_info"/>
+            </not>
+        </preConditions>
+        <createTable tableName="datanode_info">
+            <column name="uuid" type="VARCHAR(64)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="hostname" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="rpcAddress" type="VARCHAR(21)"/>
+            <column name="cache_capacity" type="BIGINT"/>
+            <column name="cache_used" type="BIGINT"/>
+            <column name="location" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_19" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="datanode_storage_info"/>
+            </not>
+        </preConditions>
+        <createTable tableName="datanode_storage_info">
+            <column name="uuid" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sid" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="state" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="storage_id" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="failed" type="BIT"/>
+            <column name="capacity" type="BIGINT"/>
+            <column name="dfs_used" type="BIGINT"/>
+            <column name="remaining" type="BIGINT"/>
+            <column name="block_pool_used" type="BIGINT"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_20" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="rule"/>
+            </not>
+        </preConditions>
+        <createTable tableName="rule">
+            <column autoIncrement="true" name="id" type="INT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="state" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="rule_text" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="submit_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_check_time" type="BIGINT"/>
+            <column name="checked_count" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="generated_cmdlets" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_21" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="cmdlet"/>
+            </not>
+        </preConditions>
+        <createTable tableName="cmdlet">
+            <column name="cid" type="INT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="rid" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="aids" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="state" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="parameters" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="generate_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="state_changed_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_22" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="action"/>
+            </not>
+        </preConditions>
+        <createTable tableName="action">
+            <column name="aid" type="INT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="cid" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="action_name" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="args" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="result" type="MEDIUMTEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="log" type="LONGTEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="successful" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="create_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="finished" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="finish_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="exec_host" type="VARCHAR(255)"/>
+            <column name="progress" type="FLOAT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_23" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="file_diff"/>
+            </not>
+        </preConditions>
+        <createTable tableName="file_diff">
+            <column autoIncrement="true" name="did" type="INT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="rid" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="diff_type" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="src" type="VARCHAR(1000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="parameters" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="state" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="create_time" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_24" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="file_diff_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="file_diff_idx" tableName="file_diff">
+            <column name="src"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_25" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="global_config"/>
+            </not>
+        </preConditions>
+        <createTable tableName="global_config">
+            <column autoIncrement="true" name="cid" type="INT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="property_name" type="VARCHAR(512)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="property_value" type="VARCHAR(3072)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_26" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="cluster_config"/>
+            </not>
+        </preConditions>
+        <createTable tableName="cluster_config">
+            <column autoIncrement="true" name="cid" type="INT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="node_name" type="VARCHAR(512)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="config_path" type="VARCHAR(3072)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_27" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="sys_info"/>
+            </not>
+        </preConditions>
+        <createTable tableName="sys_info">
+            <column name="property" type="VARCHAR(512)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="value" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_28" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="user_info"/>
+            </not>
+        </preConditions>
+        <createTable tableName="user_info">
+            <column name="user_name" type="VARCHAR(20)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="user_password" type="VARCHAR(256)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_29" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <tableIsEmpty tableName="user_info"/>
+        </preConditions>
+        <insert tableName="user_info">
+            <column name="user_name" value="admin"/>
+            <column name="user_password" value="f2400ad74fe868714eee7e6f4f5b1bb98b140dc43cd8cb44970345c93d87fb80e7419f2a17cc6a1571776da21d321befb266b552ee09923ea2d4e82f32ad65fa"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="2023.09.28_30" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="cluster_info"/>
+            </not>
+        </preConditions>
+        <createTable tableName="cluster_info">
+            <column autoIncrement="true" name="cid" type="INT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(512)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="url" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="conf_path" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="state" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="type" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_31" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="backup_file"/>
+            </not>
+        </preConditions>
+        <createTable tableName="backup_file">
+            <column name="rid" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="src" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="dest" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="period" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_32" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="backup_file_rid_idx"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="backup_file_rid_idx" tableName="backup_file">
+            <column name="rid"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2023.09.28_33" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="file_state"/>
+            </not>
+        </preConditions>
+        <createTable tableName="file_state">
+            <column name="path" type="VARCHAR(512)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="type" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="stage" type="TINYINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_34" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="compression_file"/>
+            </not>
+        </preConditions>
+        <createTable tableName="compression_file">
+            <column name="path" type="VARCHAR(512)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="buffer_size" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="compression_impl" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="original_length" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="compressed_length" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="originalPos" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="compressedPos" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_35" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="small_file"/>
+            </not>
+        </preConditions>
+        <createTable tableName="small_file">
+            <column name="path" type="VARCHAR(1000)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="container_file_path" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="offset" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="length" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_36" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="whitelist"/>
+            </not>
+        </preConditions>
+        <createTable tableName="whitelist">
+            <column name="last_fetched_dirs" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2023.09.28_37" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <tableIsEmpty tableName="whitelist"/>
+        </preConditions>
+        <insert tableName="whitelist">
+            <column name="last_fetched_dirs" value=""/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="2023.09.28_38" author="tmanasyan" labels="old_mysql">
+        <sql dbms="mysql, mariadb">
+            SET GLOBAL innodb_file_format=barracuda;
+            SET GLOBAL innodb_file_per_table=true;
+            SET GLOBAL innodb_large_prefix = ON;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/smart-metastore/src/main/resources/db/changelog/changelog-root.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-root.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd">
+    <include file="db/changelog/changelog-1.init-db.xml"/>
+</databaseChangeLog>

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestDBUtil.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestDBUtil.java
@@ -89,7 +89,7 @@ public class TestDBUtil {
       throws MetaStoreException {
     try (TestSQLiteDBPool dbPool = new TestSQLiteDBPool()) {
       DBManager dbManager = new DBManagerFactory()
-              .createDbManager(dbPool, new Configuration());
+          .createDbManager(dbPool, new Configuration());
       dbManager.initializeDatabase();
       return dbPool.dbFilePath;
     } catch (Exception e) {
@@ -186,7 +186,7 @@ public class TestDBUtil {
         closeConnection(connection);
         new File(dbFilePath).deleteOnExit();
       } catch (SQLException e) {
-          throw new RuntimeException(e);
+        throw new RuntimeException(e);
       }
     }
   }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestDBUtil.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestDBUtil.java
@@ -17,7 +17,12 @@
  */
 package org.smartdata.metastore;
 
+import org.apache.hadoop.conf.Configuration;
+import org.smartdata.metastore.db.DBManager;
+import org.smartdata.metastore.db.DBManagerFactory;
 import org.smartdata.metastore.utils.MetaStoreUtils;
+
+import javax.sql.DataSource;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -27,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.UUID;
 
 /**
@@ -81,25 +87,13 @@ public class TestDBUtil {
    */
   public static String getUniqueEmptySqliteDBFile()
       throws MetaStoreException {
-    String dbFile = getUniqueDBFilePath();
-    Connection conn = null;
-    try {
-      conn = MetaStoreUtils.createSqliteConnection(dbFile);
-      MetaStoreUtils.initializeDataBase(conn);
-      conn.close();
-      return dbFile;
+    try (TestSQLiteDBPool dbPool = new TestSQLiteDBPool()) {
+      DBManager dbManager = new DBManagerFactory()
+              .createDbManager(dbPool, new Configuration());
+      dbManager.initializeDatabase();
+      return dbPool.dbFilePath;
     } catch (Exception e) {
       throw new MetaStoreException(e);
-    } finally {
-      if (conn != null) {
-        try {
-          conn.close();
-        } catch (Exception e) {
-          throw new MetaStoreException(e);
-        }
-      }
-      File file = new File(dbFile);
-      file.deleteOnExit();
     }
   }
 
@@ -150,6 +144,49 @@ public class TestDBUtil {
         }
       } catch (IOException e) {
         e.printStackTrace();
+      }
+    }
+  }
+
+  private static class TestSQLiteDBPool implements DBPool, AutoCloseable {
+
+    private final String dbFilePath;
+    private Connection connection;
+
+    public TestSQLiteDBPool() {
+      this.dbFilePath = getUniqueDBFilePath();
+    }
+
+    @Override
+    public Connection getConnection() {
+      if (connection == null) {
+        try {
+          connection = MetaStoreUtils.createSqliteConnection(dbFilePath);
+        } catch (MetaStoreException exception) {
+          throw new RuntimeException(exception);
+        }
+      }
+
+      return connection;
+    }
+
+    @Override
+    public DataSource getDataSource() {
+      return null;
+    }
+
+    @Override
+    public void closeConnection(Connection conn) throws SQLException {
+      conn.close();
+    }
+
+    @Override
+    public void close() {
+      try {
+        closeConnection(connection);
+        new File(dbFilePath).deleteOnExit();
+      } catch (SQLException e) {
+          throw new RuntimeException(e);
       }
     }
   }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestDaoUtil.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestDaoUtil.java
@@ -18,6 +18,8 @@
 package org.smartdata.metastore;
 
 import org.apache.hadoop.conf.Configuration;
+import org.smartdata.metastore.dao.DaoProvider;
+import org.smartdata.metastore.dao.impl.DefaultDaoProvider;
 import org.smartdata.metastore.db.DBManager;
 import org.smartdata.metastore.db.DBManagerFactory;
 import org.smartdata.metastore.utils.MetaStoreUtils;
@@ -30,6 +32,7 @@ import java.util.Properties;
 public class TestDaoUtil {
   protected DruidPool druidPool;
   protected DBManager dbManager;
+  protected DaoProvider daoProvider;
   protected String dbFile;
   protected String url;
 
@@ -45,7 +48,8 @@ public class TestDaoUtil {
 
     druidPool = new DruidPool(p);
     dbManager = new DBManagerFactory()
-            .createDbManager(druidPool, new Configuration());
+        .createDbManager(druidPool, new Configuration());
+    daoProvider = new DefaultDaoProvider(druidPool);
   }
 
   public void closeDao() throws Exception {
@@ -59,6 +63,6 @@ public class TestDaoUtil {
   }
 
   protected MetaStore createMetastore() throws MetaStoreException {
-    return new MetaStore(druidPool, dbManager);
+    return new MetaStore(druidPool, dbManager, new DefaultDaoProvider(druidPool));
   }
 }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestDaoUtil.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestDaoUtil.java
@@ -17,6 +17,9 @@
  */
 package org.smartdata.metastore;
 
+import org.apache.hadoop.conf.Configuration;
+import org.smartdata.metastore.db.DBManager;
+import org.smartdata.metastore.db.DBManagerFactory;
 import org.smartdata.metastore.utils.MetaStoreUtils;
 
 import java.io.File;
@@ -26,6 +29,7 @@ import java.util.Properties;
 
 public class TestDaoUtil {
   protected DruidPool druidPool;
+  protected DBManager dbManager;
   protected String dbFile;
   protected String url;
 
@@ -40,6 +44,8 @@ public class TestDaoUtil {
     p.setProperty("url", url);
 
     druidPool = new DruidPool(p);
+    dbManager = new DBManagerFactory()
+            .createDbManager(druidPool, new Configuration());
   }
 
   public void closeDao() throws Exception {
@@ -50,5 +56,9 @@ public class TestDaoUtil {
     if (druidPool != null) {
       druidPool.close();
     }
+  }
+
+  protected MetaStore createMetastore() throws MetaStoreException {
+    return new MetaStore(druidPool, dbManager);
   }
 }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestDruid.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestDruid.java
@@ -20,6 +20,8 @@ package org.smartdata.metastore;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
+import org.smartdata.metastore.dao.DaoProvider;
+import org.smartdata.metastore.dao.impl.DefaultDaoProvider;
 import org.smartdata.metastore.db.DBManager;
 import org.smartdata.metastore.db.DBManagerFactory;
 import org.smartdata.metastore.utils.MetaStoreUtils;
@@ -44,8 +46,9 @@ public class TestDruid {
 
     DruidPool druidPool = new DruidPool(p);
     DBManager dbManager = new DBManagerFactory()
-            .createDbManager(druidPool, new Configuration());
-    MetaStore adapter = new MetaStore(druidPool, dbManager);
+        .createDbManager(druidPool, new Configuration());
+    DaoProvider daoProvider = new DefaultDaoProvider(druidPool);
+    MetaStore adapter = new MetaStore(druidPool, dbManager, daoProvider);
 
     String rule = "file : accessCount(10m) > 20 \n\n"
         + "and length() > 3 | cache";

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestDruid.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestDruid.java
@@ -17,8 +17,11 @@
  */
 package org.smartdata.metastore;
 
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
+import org.smartdata.metastore.db.DBManager;
+import org.smartdata.metastore.db.DBManagerFactory;
 import org.smartdata.metastore.utils.MetaStoreUtils;
 import org.smartdata.model.RuleInfo;
 import org.smartdata.model.RuleState;
@@ -40,7 +43,9 @@ public class TestDruid {
     p.setProperty("url", url);
 
     DruidPool druidPool = new DruidPool(p);
-    MetaStore adapter = new MetaStore(druidPool);
+    DBManager dbManager = new DBManagerFactory()
+            .createDbManager(druidPool, new Configuration());
+    MetaStore adapter = new MetaStore(druidPool, dbManager);
 
     String rule = "file : accessCount(10m) > 20 \n\n"
         + "and length() > 3 | cache";

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
@@ -126,7 +126,8 @@ public class TestMetaStore extends TestDaoUtil {
     public void run() {
       Map<String, String> args = new HashMap();
       ActionInfo actionInfo =
-          new ActionInfo(1, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+          new ActionInfo(1, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+              100);
       for (int i = 0; i < 100; i++) {
         actionInfo.setActionId(i);
         try {
@@ -332,11 +333,13 @@ public class TestMetaStore extends TestDaoUtil {
     Assert.assertTrue(metaStore.listMoveRules().size() == 3);
     Assert.assertTrue(metaStore.listSyncRules().size() == 1);
     CmdletInfo cmdletInfo =
-        new CmdletInfo(1, ruleInfo.getId(), CmdletState.EXECUTING, "test", 123123333L, 232444444L);
+        new CmdletInfo(1, ruleInfo.getId(), CmdletState.EXECUTING, "test", 123123333L,
+            232444444L);
     cmdletInfo.setAids(Collections.singletonList(1L));
     metaStore.insertCmdlet(cmdletInfo);
     metaStore.insertAction(
-        new ActionInfo(1, 1, "allssd", args, "Test", "Test", true, 123213213L, true, 123123L, 100));
+        new ActionInfo(1, 1, "allssd", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100));
     Assert.assertTrue(metaStore.listFileActions(ruleInfo.getId(), 0).size() >= 0);
   }
 
@@ -426,20 +429,20 @@ public class TestMetaStore extends TestDaoUtil {
     byte storagePolicy = 0;
     byte erasureCodingPolicy = 0;
     FileInfo[] files = {
-      new FileInfo(
-          pathString,
-          fileId,
-          length,
-          isDir,
-          (short) blockReplication,
-          blockSize,
-          modTime,
-          accessTime,
-          (short) 1,
-          owner,
-          group,
-          storagePolicy,
-          erasureCodingPolicy)
+        new FileInfo(
+            pathString,
+            fileId,
+            length,
+            isDir,
+            (short) blockReplication,
+            blockSize,
+            modTime,
+            accessTime,
+            (short) 1,
+            owner,
+            group,
+            storagePolicy,
+            erasureCodingPolicy)
     };
     metaStore.insertFiles(files);
     FileInfo dbFileInfo = metaStore.getFile("/tmp/testFile");
@@ -471,13 +474,16 @@ public class TestMetaStore extends TestDaoUtil {
     CmdletInfo command2 = new CmdletInfo(1, 78, CmdletState.DONE, "tt", 128L, 232444994L);
     metaStore.insertCmdlet(command2);
     ActionInfo actionInfo =
-        new ActionInfo(1, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+        new ActionInfo(1, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
     metaStore.insertAction(actionInfo);
     ActionInfo actionInfo2 =
-        new ActionInfo(2, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+        new ActionInfo(2, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
     metaStore.insertAction(actionInfo2);
     ActionInfo actionInfo3 =
-        new ActionInfo(3, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+        new ActionInfo(3, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
     metaStore.insertAction(actionInfo3);
     metaStore.deleteFinishedCmdletsWithGenTimeBefore(125);
     Assert.assertTrue(metaStore.getCmdletById(0) == null);
@@ -494,13 +500,16 @@ public class TestMetaStore extends TestDaoUtil {
     CmdletInfo command2 = new CmdletInfo(1, 78, CmdletState.DONE, "tt", 128L, 232444994L);
     metaStore.insertCmdlet(command2);
     ActionInfo actionInfo =
-        new ActionInfo(1, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+        new ActionInfo(1, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
     metaStore.insertAction(actionInfo);
     ActionInfo actionInfo2 =
-        new ActionInfo(2, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+        new ActionInfo(2, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
     metaStore.insertAction(actionInfo2);
     ActionInfo actionInfo3 =
-        new ActionInfo(3, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+        new ActionInfo(3, 0, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
     metaStore.insertAction(actionInfo3);
     metaStore.deleteKeepNewCmdlets(1);
     Assert.assertTrue(metaStore.getCmdletById(0) == null);
@@ -539,12 +548,13 @@ public class TestMetaStore extends TestDaoUtil {
   public void testInsertListActions() throws Exception {
     Map<String, String> args = new HashMap();
     ActionInfo actionInfo =
-        new ActionInfo(1, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
-    metaStore.insertActions(new ActionInfo[] {actionInfo});
+        new ActionInfo(1, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
+    metaStore.insertActions(new ActionInfo[]{actionInfo});
     List<ActionInfo> actionInfos = metaStore.getActions(null, null);
     Assert.assertTrue(actionInfos.size() == 1);
     actionInfo.setResult("Finished");
-    metaStore.updateActions(new ActionInfo[] {actionInfo});
+    metaStore.updateActions(new ActionInfo[]{actionInfo});
     actionInfos = metaStore.getActions(null, null);
     Assert.assertTrue(actionInfos.get(0).equals(actionInfo));
   }
@@ -554,7 +564,8 @@ public class TestMetaStore extends TestDaoUtil {
     Map<String, String> args = new HashMap();
     List<ActionInfo> actionInfos;
     ActionInfo actionInfo =
-        new ActionInfo(1, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
+        new ActionInfo(1, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
     metaStore.insertAction(actionInfo);
     actionInfo.setActionId(2);
     metaStore.insertAction(actionInfo);
@@ -573,14 +584,16 @@ public class TestMetaStore extends TestDaoUtil {
     Assert.assertTrue(currentId == 0);
     ActionInfo actionInfo =
         new ActionInfo(
-            currentId, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
-    metaStore.insertActions(new ActionInfo[] {actionInfo});
+            currentId, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
+    metaStore.insertActions(new ActionInfo[]{actionInfo});
     currentId = metaStore.getMaxActionId();
     Assert.assertTrue(currentId == 1);
     actionInfo =
         new ActionInfo(
-            currentId, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L, 100);
-    metaStore.insertActions(new ActionInfo[] {actionInfo});
+            currentId, 1, "cache", args, "Test", "Test", true, 123213213L, true, 123123L,
+            100);
+    metaStore.insertActions(new ActionInfo[]{actionInfo});
     currentId = metaStore.getMaxActionId();
     Assert.assertTrue(currentId == 2);
   }
@@ -654,7 +667,7 @@ public class TestMetaStore extends TestDaoUtil {
 
     DataNodeInfo insertInfo2 = new DataNodeInfo("UUID2", "HOSTNAME", "www.ssm.com", 0, 0, null);
     DataNodeInfo insertInfo3 = new DataNodeInfo("UUID3", "HOSTNAME", "www.ssm.com", 0, 0, null);
-    metaStore.insertDataNodeInfos(new DataNodeInfo[] {insertInfo2, insertInfo3});
+    metaStore.insertDataNodeInfos(new DataNodeInfo[]{insertInfo2, insertInfo3});
     List<DataNodeInfo> getInfo2 = metaStore.getDataNodeInfoByUuid("UUID2");
     Assert.assertTrue(insertInfo2.equals(getInfo2.get(0)));
     List<DataNodeInfo> getInfo3 = metaStore.getDataNodeInfoByUuid("UUID3");
@@ -666,7 +679,7 @@ public class TestMetaStore extends TestDaoUtil {
     DataNodeInfo insertInfo1 = new DataNodeInfo("UUID1", "hostname", "www.ssm.com", 100, 50, "lab");
     DataNodeInfo insertInfo2 = new DataNodeInfo("UUID2", "HOSTNAME", "www.ssm.com", 0, 0, null);
     DataNodeInfo insertInfo3 = new DataNodeInfo("UUID3", "HOSTNAME", "www.ssm.com", 0, 0, null);
-    metaStore.insertDataNodeInfos(new DataNodeInfo[] {insertInfo1, insertInfo2, insertInfo3});
+    metaStore.insertDataNodeInfos(new DataNodeInfo[]{insertInfo1, insertInfo2, insertInfo3});
 
     List<DataNodeInfo> infos = metaStore.getAllDataNodeInfo();
     Assert.assertTrue(infos.size() == 3);
@@ -692,7 +705,7 @@ public class TestMetaStore extends TestDaoUtil {
         new DataNodeStorageInfo("UUID2", 10, 10, "storageid2", 0, 0, 0, 0, 0);
     DataNodeStorageInfo insertInfo3 =
         new DataNodeStorageInfo("UUID3", 10, 10, "storageid2", 0, 0, 0, 0, 0);
-    metaStore.insertDataNodeStorageInfos(new DataNodeStorageInfo[] {insertInfo2, insertInfo3});
+    metaStore.insertDataNodeStorageInfos(new DataNodeStorageInfo[]{insertInfo2, insertInfo3});
     List<DataNodeStorageInfo> getInfo2 = metaStore.getDataNodeStorageInfoByUuid("UUID2");
     Assert.assertTrue(insertInfo2.equals(getInfo2.get(0)));
     List<DataNodeStorageInfo> getInfo3 = metaStore.getDataNodeStorageInfoByUuid("UUID3");
@@ -708,7 +721,7 @@ public class TestMetaStore extends TestDaoUtil {
     DataNodeStorageInfo insertInfo3 =
         new DataNodeStorageInfo("UUID3", 10, 10, "storageid3", 0, 0, 0, 0, 0);
     metaStore.insertDataNodeStorageInfos(
-        new DataNodeStorageInfo[] {insertInfo1, insertInfo2, insertInfo3});
+        new DataNodeStorageInfo[]{insertInfo1, insertInfo2, insertInfo3});
 
     List<DataNodeStorageInfo> infos = metaStore.getAllDataNodeStorageInfo();
     Assert.assertTrue(infos.size() == 3);

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
@@ -58,7 +58,7 @@ public class TestMetaStore extends TestDaoUtil {
   @Before
   public void metaInit() throws Exception {
     initDao();
-    metaStore = new MetaStore(druidPool);
+    metaStore = createMetastore();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestRulesTable.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestRulesTable.java
@@ -36,7 +36,7 @@ public class TestRulesTable extends TestDaoUtil {
   @Test
   public void testRuleInsert() throws Exception {
     initDao();
-    MetaStore adapter = new MetaStore(druidPool);
+    MetaStore adapter = createMetastore();
     String rule = "file : accessCount(10m) > 20 \n\n"
         + "and length() > 3 | cache";
     long submitTime = System.currentTimeMillis();

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestRulesTable.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestRulesTable.java
@@ -54,7 +54,7 @@ public class TestRulesTable extends TestDaoUtil {
     Assert.assertFalse(info11.equals(info21));
 
     List<RuleInfo> infos = adapter.getRuleInfo();
-    assert(infos.size() == 2);
+    assert (infos.size() == 2);
     closeDao();
   }
 }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestSqliteDB.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestSqliteDB.java
@@ -37,7 +37,7 @@ public class TestSqliteDB extends TestDaoUtil {
   @Before
   public void initDB() throws Exception {
     initDao();
-    metaStore = new MetaStore(druidPool);
+    metaStore = createMetastore();
   }
 
   @After
@@ -48,7 +48,7 @@ public class TestSqliteDB extends TestDaoUtil {
 
   @Test
   public void testInitDB() throws Exception {
-    MetaStoreUtils.initializeDataBase(metaStore.getConnection());
+    dbManager.clearDatabase();
   }
 
   @Test

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestSqliteDB.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestSqliteDB.java
@@ -110,11 +110,11 @@ public class TestSqliteDB extends TestDaoUtil {
   @Test
   public void testDBBlankStatements() throws Exception {
     String[] presqls =
-        new String[] {
-          "INSERT INTO rule (state, rule_text, submit_time, checked_count, "
-              + "generated_cmdlets) VALUES (0, 'file: every 1s \n"
-              + " | "
-              + "accessCount(5s) > 3 | cache', 1494903787619, 0, 0);"
+        new String[]{
+            "INSERT INTO rule (state, rule_text, submit_time, checked_count, "
+                + "generated_cmdlets) VALUES (0, 'file: every 1s \n"
+                + " | "
+                + "accessCount(5s) > 3 | cache', 1494903787619, 0, 0);"
         };
 
     for (int i = 0; i < presqls.length; i++) {
@@ -123,13 +123,13 @@ public class TestSqliteDB extends TestDaoUtil {
     }
 
     String[] sqls =
-        new String[] {
-          "DROP TABLE IF EXISTS VIR_ACC_CNT_TAB_1_accessCount_5000;",
-          "CREATE TABLE VIR_ACC_CNT_TAB_1_accessCount_5000 "
-              + "AS SELECT * FROM blank_access_count_info;",
-          "SELECT fid from VIR_ACC_CNT_TAB_1_accessCount_5000;",
-          "SELECT path FROM file WHERE (fid IN (SELECT fid FROM "
-              + "VIR_ACC_CNT_TAB_1_accessCount_5000 WHERE ((count > 3))));"
+        new String[]{
+            "DROP TABLE IF EXISTS VIR_ACC_CNT_TAB_1_accessCount_5000;",
+            "CREATE TABLE VIR_ACC_CNT_TAB_1_accessCount_5000 "
+                + "AS SELECT * FROM blank_access_count_info;",
+            "SELECT fid from VIR_ACC_CNT_TAB_1_accessCount_5000;",
+            "SELECT path FROM file WHERE (fid IN (SELECT fid FROM "
+                + "VIR_ACC_CNT_TAB_1_accessCount_5000 WHERE ((count > 3))));"
         };
 
     for (int i = 0; i < sqls.length * 3; i++) {

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestAccessCountTableManager.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestAccessCountTableManager.java
@@ -133,7 +133,7 @@ public class TestAccessCountTableManager extends DBTest {
     assertTableEquals(new AccessCountTable(10000L, 15000L).getTableName(), "expect2");
     assertTableEquals(new AccessCountTable(15000L, 20000L).getTableName(), "expect2");
 
-    insertNewFile(new MetaStore(druidPool), "file4", 4L);
+    insertNewFile(createMetastore(), "file4", 4L);
     accessEvents.clear();
     accessEvents.add(new FileAccessEvent("file4", 25000));
     manager.onAccessEventsArrived(accessEvents);
@@ -141,7 +141,7 @@ public class TestAccessCountTableManager extends DBTest {
   }
 
   private AccessCountTableManager initTestEnvironment() throws Exception {
-    MetaStore metaStore = new MetaStore(druidPool);
+    MetaStore metaStore = createMetastore();
     createTables(databaseTester.getConnection().getConnection());
     IDataSet dataSet = new XmlDataSet(getClass().getClassLoader().getResourceAsStream("files.xml"));
     databaseTester.setDataSet(dataSet);

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestAccessCountTableManager.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestAccessCountTableManager.java
@@ -153,7 +153,7 @@ public class TestAccessCountTableManager extends DBTest {
   private void assertTableEquals(String actualTableName, String expectedDataSet) throws Exception {
     ITable actual = databaseTester.getConnection().createTable(actualTableName);
     ITable expect = databaseTester.getDataSet().getTable(expectedDataSet);
-    SortedTable sortedActual = new SortedTable(actual, new String[] {"fid"});
+    SortedTable sortedActual = new SortedTable(actual, new String[]{"fid"});
     sortedActual.setUseComparable(true);
     Assertion.assertEquals(expect, sortedActual);
   }
@@ -209,9 +209,11 @@ public class TestAccessCountTableManager extends DBTest {
 
     AccessCountTableDeque hourDeque = new AccessCountTableDeque(tableEvictor);
     AccessCountTable firstHour =
-        new AccessCountTable(23 * Constants.ONE_HOUR_IN_MILLIS, 24 * Constants.ONE_HOUR_IN_MILLIS);
+        new AccessCountTable(23 * Constants.ONE_HOUR_IN_MILLIS,
+            24 * Constants.ONE_HOUR_IN_MILLIS);
     AccessCountTable secondHour =
-        new AccessCountTable(24 * Constants.ONE_HOUR_IN_MILLIS, 25 * Constants.ONE_HOUR_IN_MILLIS);
+        new AccessCountTable(24 * Constants.ONE_HOUR_IN_MILLIS,
+            25 * Constants.ONE_HOUR_IN_MILLIS);
     hourDeque.addAndNotifyListener(firstHour);
     hourDeque.addAndNotifyListener(secondHour);
     map.put(TimeGranularity.HOUR, hourDeque);
@@ -264,13 +266,15 @@ public class TestAccessCountTableManager extends DBTest {
 
     List<AccessCountTable> thirdResult =
         AccessCountTableManager.getTables(
-            map, adapter, secondFiveSeconds.getEndTime() - 23 * Constants.ONE_HOUR_IN_MILLIS);
+            map, adapter,
+            secondFiveSeconds.getEndTime() - 23 * Constants.ONE_HOUR_IN_MILLIS);
     Assert.assertTrue(thirdResult.size() == 4);
     Assert.assertEquals(thirdResult.get(0), firstHour);
 
     List<AccessCountTable> fourthResult =
         AccessCountTableManager.getTables(
-            map, adapter, secondFiveSeconds.getEndTime() - 24 * Constants.ONE_HOUR_IN_MILLIS);
+            map, adapter,
+            secondFiveSeconds.getEndTime() - 24 * Constants.ONE_HOUR_IN_MILLIS);
     Assert.assertTrue(fourthResult.size() == 3);
     Assert.assertEquals(fourthResult.get(0), secondHour);
   }
@@ -285,16 +289,16 @@ public class TestAccessCountTableManager extends DBTest {
 
     AccessCountTableDeque secondDeque = new AccessCountTableDeque(tableEvictor);
     AccessCountTable firstFiveSeconds =
-      new AccessCountTable(0L, 5 * Constants.ONE_SECOND_IN_MILLIS);
+        new AccessCountTable(0L, 5 * Constants.ONE_SECOND_IN_MILLIS);
     AccessCountTable secondFiveSeconds =
-      new AccessCountTable(5 * Constants.ONE_SECOND_IN_MILLIS,
-        10 * Constants.ONE_SECOND_IN_MILLIS);
+        new AccessCountTable(5 * Constants.ONE_SECOND_IN_MILLIS,
+            10 * Constants.ONE_SECOND_IN_MILLIS);
     secondDeque.addAndNotifyListener(firstFiveSeconds);
     secondDeque.addAndNotifyListener(secondFiveSeconds);
     map.put(TimeGranularity.SECOND, secondDeque);
 
     List<AccessCountTable> result = AccessCountTableManager.getTables(map, adapter,
-    2 * Constants.ONE_MINUTE_IN_MILLIS);
+        2 * Constants.ONE_MINUTE_IN_MILLIS);
     Assert.assertTrue(result.size() == 2);
     Assert.assertTrue(result.get(0).equals(firstFiveSeconds));
     Assert.assertTrue(result.get(1).equals(secondFiveSeconds));
@@ -307,7 +311,7 @@ public class TestAccessCountTableManager extends DBTest {
     Map<TimeGranularity, AccessCountTableDeque> map = new HashMap<>();
     AccessCountTableDeque minute = new AccessCountTableDeque(tableEvictor);
     AccessCountTable firstMinute =
-      new AccessCountTable(0L, Constants.ONE_MINUTE_IN_MILLIS);
+        new AccessCountTable(0L, Constants.ONE_MINUTE_IN_MILLIS);
     minute.addAndNotifyListener(firstMinute);
     map.put(TimeGranularity.MINUTE, minute);
 
@@ -316,18 +320,18 @@ public class TestAccessCountTableManager extends DBTest {
         new AccessCountTable(
             55 * Constants.ONE_SECOND_IN_MILLIS, 60 * Constants.ONE_SECOND_IN_MILLIS);
     AccessCountTable secondFiveSeconds =
-      new AccessCountTable(60 * Constants.ONE_SECOND_IN_MILLIS,
-        65 * Constants.ONE_SECOND_IN_MILLIS);
+        new AccessCountTable(60 * Constants.ONE_SECOND_IN_MILLIS,
+            65 * Constants.ONE_SECOND_IN_MILLIS);
     AccessCountTable thirdFiveSeconds =
-      new AccessCountTable(110 * Constants.ONE_SECOND_IN_MILLIS,
-        115 * Constants.ONE_SECOND_IN_MILLIS);
+        new AccessCountTable(110 * Constants.ONE_SECOND_IN_MILLIS,
+            115 * Constants.ONE_SECOND_IN_MILLIS);
     secondDeque.addAndNotifyListener(firstFiveSeconds);
     secondDeque.addAndNotifyListener(secondFiveSeconds);
     secondDeque.addAndNotifyListener(thirdFiveSeconds);
     map.put(TimeGranularity.SECOND, secondDeque);
 
     List<AccessCountTable> result = AccessCountTableManager.getTables(map, adapter,
-      Constants.ONE_MINUTE_IN_MILLIS);
+        Constants.ONE_MINUTE_IN_MILLIS);
     Assert.assertTrue(result.size() == 3);
     Assert.assertTrue(result.get(0).equals(firstFiveSeconds));
     Assert.assertFalse(result.get(0).isEphemeral());

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestActionDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestActionDao.java
@@ -41,7 +41,7 @@ public class TestActionDao extends TestDaoUtil {
   @Before
   public void initActionDao() throws Exception {
     initDao();
-    actionDao = new ActionDao(druidPool.getDataSource());
+    actionDao = daoProvider.actionDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestAddTableOpListener.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestAddTableOpListener.java
@@ -21,7 +21,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.smartdata.metastore.MetaStore;
 
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -39,7 +38,8 @@ public class TestAddTableOpListener {
     TableEvictor tableEvictor = new CountEvictor(adapter, 10);
     AccessCountTableDeque minuteTableDeque = new AccessCountTableDeque(tableEvictor);
     TableAddOpListener minuteTableListener =
-        new TableAddOpListener.MinuteTableListener(minuteTableDeque, aggregator, executorService);
+        new TableAddOpListener.MinuteTableListener(minuteTableDeque, aggregator,
+            executorService);
     AccessCountTableDeque secondTableDeque =
         new AccessCountTableDeque(tableEvictor, minuteTableListener);
 

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestBackUpInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestBackUpInfoDao.java
@@ -34,7 +34,7 @@ public class TestBackUpInfoDao extends TestDaoUtil {
   @Before
   public void initBackUpInfoDao() throws Exception {
     initDao();
-    backUpInfoDao = new BackUpInfoDao(druidPool.getDataSource());
+    backUpInfoDao = daoProvider.backUpInfoDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestCacheFileDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestCacheFileDao.java
@@ -37,7 +37,7 @@ public class TestCacheFileDao extends TestDaoUtil {
   @Before
   public void initCacheFileDao() throws Exception {
     initDao();
-    cacheFileDao = new CacheFileDao(druidPool.getDataSource());
+    cacheFileDao = daoProvider.cacheFileDao();
   }
 
   @After
@@ -91,19 +91,19 @@ public class TestCacheFileDao extends TestDaoUtil {
         .insert(80L,
             "testPath", 123456L, 234567L, 456);
     Assert.assertTrue(cacheFileDao.getById(
-      80L).getFromTime() == 123456L);
+        80L).getFromTime() == 123456L);
     // Update record with 80l id
     cacheFileDao.update(80L,
-      123455L, 460);
+        123455L, 460);
     Assert.assertTrue(cacheFileDao
-                          .getAll().get(0)
-                          .getLastAccessTime() == 123455L);
-    CachedFileStatus[] cachedFileStatuses = new CachedFileStatus[] {
+        .getAll().get(0)
+        .getLastAccessTime() == 123455L);
+    CachedFileStatus[] cachedFileStatuses = new CachedFileStatus[]{
         new CachedFileStatus(321L, "testPath",
-          113334L, 222222L, 222)};
+            113334L, 222222L, 222)};
     cacheFileDao.insert(cachedFileStatuses);
     Assert.assertTrue(cacheFileDao.getById(321L)
-                          .equals(cachedFileStatuses[0]));
+        .equals(cachedFileStatuses[0]));
     Assert.assertTrue(cacheFileDao.getAll().size() == 2);
     // Delete one record
     cacheFileDao.deleteById(321L);
@@ -116,13 +116,13 @@ public class TestCacheFileDao extends TestDaoUtil {
   @Test
   public void testGetCachedFileStatus() throws Exception {
     cacheFileDao.insert(6L, "testPath", 1490918400000L,
-      234567L, 456);
+        234567L, 456);
     CachedFileStatus cachedFileStatus = new CachedFileStatus(6L, "testPath", 1490918400000L,
-      234567L, 456);
+        234567L, 456);
     cacheFileDao.insert(19L, "testPath", 1490918400000L,
-      234567L, 456);
+        234567L, 456);
     cacheFileDao.insert(23L, "testPath", 1490918400000L,
-      234567L, 456);
+        234567L, 456);
     CachedFileStatus dbcachedFileStatus = cacheFileDao.getById(6);
     Assert.assertTrue(dbcachedFileStatus.equals(cachedFileStatus));
     List<CachedFileStatus> cachedFileList = cacheFileDao.getAll();

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestClusterConfigDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestClusterConfigDao.java
@@ -30,7 +30,7 @@ public class TestClusterConfigDao extends TestDaoUtil {
   @Before
   public void initClusterConfigDao() throws Exception {
     initDao();
-    clusterConfigDao = new ClusterConfigDao(druidPool.getDataSource());
+    clusterConfigDao = daoProvider.clusterConfigDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestClusterInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestClusterInfoDao.java
@@ -32,7 +32,7 @@ public class TestClusterInfoDao extends TestDaoUtil {
   @Before
   public void initClusterDao() throws Exception {
     initDao();
-    clusterInfoDao = new ClusterInfoDao(druidPool.getDataSource());
+    clusterInfoDao = daoProvider.clusterInfoDao();
   }
 
   @After
@@ -56,7 +56,7 @@ public class TestClusterInfoDao extends TestDaoUtil {
   }
 
   @Test
-  public void testBatchInssertAndQuery(){
+  public void testBatchInssertAndQuery() {
     ClusterInfo[] clusterInfos = new ClusterInfo[2];
     clusterInfos[0] = new ClusterInfo();
     clusterInfos[0].setCid(1);
@@ -77,7 +77,7 @@ public class TestClusterInfoDao extends TestDaoUtil {
     clusterInfoDao.insert(clusterInfos);
     clusterInfos[1].setCid(2);
     List<ClusterInfo> clusterInfoList = clusterInfoDao.getAll();
-    for (int i = 0; i < 2; i++){
+    for (int i = 0; i < 2; i++) {
       Assert.assertTrue(clusterInfoList.get(i).equals(clusterInfos[i]));
     }
   }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestCmdletDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestCmdletDao.java
@@ -36,7 +36,7 @@ public class TestCmdletDao extends TestDaoUtil {
   @Before
   public void initCmdletDao() throws Exception {
     initDao();
-    cmdletDao = new CmdletDao(druidPool.getDataSource());
+    cmdletDao = daoProvider.cmdletDao();
   }
 
   @After
@@ -130,19 +130,19 @@ public class TestCmdletDao extends TestDaoUtil {
   }
 
   @Test
-  public void testgetByRid() throws Exception{
+  public void testgetByRid() throws Exception {
     CmdletInfo cmdlet1 = new CmdletInfo(0, 1,
-            CmdletState.EXECUTING, "test", 123123333L, 232444444L);
+        CmdletState.EXECUTING, "test", 123123333L, 232444444L);
     CmdletInfo cmdlet2 = new CmdletInfo(1, 1,
-            CmdletState.PAUSED, "tt", 123178333L, 232444994L);
+        CmdletState.PAUSED, "tt", 123178333L, 232444994L);
     CmdletInfo cmdlet3 = new CmdletInfo(2, 1,
-            CmdletState.EXECUTING, "test", 123123333L, 232444444L);
+        CmdletState.EXECUTING, "test", 123123333L, 232444444L);
     CmdletInfo cmdlet4 = new CmdletInfo(3, 1,
-            CmdletState.PAUSED, "tt", 123178333L, 232444994L);
+        CmdletState.PAUSED, "tt", 123178333L, 232444994L);
     CmdletInfo cmdlet5 = new CmdletInfo(4, 1,
-            CmdletState.EXECUTING, "test", 123123333L, 232444444L);
+        CmdletState.EXECUTING, "test", 123123333L, 232444444L);
     CmdletInfo cmdlet6 = new CmdletInfo(5, 1,
-            CmdletState.PAUSED, "tt", 123178333L, 232444994L);
+        CmdletState.PAUSED, "tt", 123178333L, 232444994L);
     cmdletDao.insert(new CmdletInfo[]{cmdlet1, cmdlet2, cmdlet3, cmdlet4, cmdlet5, cmdlet6});
     List<CmdletInfo> cmdlets = cmdletDao.getByRid(1, 1, 2);
     List<String> order = new ArrayList<>();

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestCompressionFileDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestCompressionFileDao.java
@@ -37,7 +37,7 @@ public class TestCompressionFileDao extends TestDaoUtil {
   @Before
   public void initCompressionFileDao() throws Exception {
     initDao();
-    compressionFileDao = new CompressionFileDao(druidPool.getDataSource());
+    compressionFileDao = daoProvider.compressionFileDao();
     originalPos.add(9000L);
     originalPos.add(8000L);
     compressedPos.add(3000L);
@@ -53,13 +53,13 @@ public class TestCompressionFileDao extends TestDaoUtil {
   @Test
   public void testInsertDeleteCompressionFiles() throws Exception {
     CompressionFileState compressionInfo = new CompressionFileState(
-      "/test", 131072, compressionImpl, originalPos.toArray(new Long[0]),
+        "/test", 131072, compressionImpl, originalPos.toArray(new Long[0]),
         compressedPos.toArray(new Long[0]));
 
     //insert test
     compressionFileDao.insert(compressionInfo);
     Assert.assertTrue(compressionFileDao.getInfoByPath("/test").
-      getOriginalPos()[0].equals(9000L));
+        getOriginalPos()[0].equals(9000L));
 
     //delete test
     compressionFileDao.deleteByPath("/test");
@@ -93,10 +93,10 @@ public class TestCompressionFileDao extends TestDaoUtil {
     long originalLen = 100;
     long compressedLen = 50;
     CompressionFileState compressionInfo = new CompressionFileState(
-      "/test1", 131072, compressionImpl, originalLen, compressedLen,
+        "/test1", 131072, compressionImpl, originalLen, compressedLen,
         originalPos.toArray(new Long[0]), compressedPos.toArray(new Long[0]));
     CompressionFileState compressionInfo2 = new CompressionFileState(
-      "/test2", 131072, compressionImpl, originalPos.toArray(new Long[0]),
+        "/test2", 131072, compressionImpl, originalPos.toArray(new Long[0]),
         compressedPos.toArray(new Long[0]));
 
     compressionFileDao.insert(compressionInfo);

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestDataNodeInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestDataNodeInfoDao.java
@@ -33,7 +33,7 @@ public class TestDataNodeInfoDao extends TestDaoUtil {
   @Before
   public void initDataNodeInfoDao() throws Exception {
     initDao();
-    dataNodeInfoDao = new DataNodeInfoDao(druidPool.getDataSource());
+    dataNodeInfoDao = daoProvider.dataNodeInfoDao();
   }
 
   @After
@@ -45,14 +45,14 @@ public class TestDataNodeInfoDao extends TestDaoUtil {
   @Test
   public void testInsertGetDataInfo() throws Exception {
     DataNodeInfo insertInfo1 = new DataNodeInfo(
-        "UUID1", "hostname", "www.ssm.com",  10000, 50, "lab");
+        "UUID1", "hostname", "www.ssm.com", 10000, 50, "lab");
     dataNodeInfoDao.insert(insertInfo1);
     List<DataNodeInfo> getInfo1 = dataNodeInfoDao.getByUuid("UUID1");
     Assert.assertEquals(1, getInfo1.size());
     Assert.assertTrue(insertInfo1.equals(getInfo1.get(0)));
 
     DataNodeInfo insertInfo2 = new DataNodeInfo(
-        "UUID2", "HOSTNAME", "www.ssm.com",  0, 0, null);
+        "UUID2", "HOSTNAME", "www.ssm.com", 0, 0, null);
     dataNodeInfoDao.insert(insertInfo2);
     List<DataNodeInfo> getInfo2 = dataNodeInfoDao.getByUuid("UUID2");
     Assert.assertEquals(1, getInfo2.size());

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestDataNodeStorageInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestDataNodeStorageInfoDao.java
@@ -33,7 +33,7 @@ public class TestDataNodeStorageInfoDao extends TestDaoUtil {
   @Before
   public void initDataNodeInfoDao() throws Exception {
     initDao();
-    dataNodeStorageInfoDao = new DataNodeStorageInfoDao(druidPool.getDataSource());
+    dataNodeStorageInfoDao = daoProvider.dataNodeStorageInfoDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestErasureCodingPolicyDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestErasureCodingPolicyDao.java
@@ -53,7 +53,7 @@ public class TestErasureCodingPolicyDao extends TestDaoUtil {
   @Before
   public void initErasureCodingPolicyDao() throws Exception {
     initDao();
-    ecPolicyDao = new ErasureCodingPolicyDao(druidPool.getDataSource());
+    ecPolicyDao = daoProvider.ecDao();
   }
 
   @Test

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileDiffDao.java
@@ -37,7 +37,7 @@ public class TestFileDiffDao extends TestDaoUtil {
   @Before
   public void initFileDiffDAO() throws Exception {
     initDao();
-    fileDiffDao = new FileDiffDao(druidPool.getDataSource());
+    fileDiffDao = daoProvider.fileDiffDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileInfoDao.java
@@ -34,7 +34,7 @@ public class TestFileInfoDao extends TestDaoUtil {
   @Before
   public void initFileDao() throws Exception {
     initDao();
-    fileInfoDao = new FileInfoDao(druidPool.getDataSource());
+    fileInfoDao = daoProvider.fileInfoDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileStateDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileStateDao.java
@@ -32,7 +32,7 @@ public class TestFileStateDao extends TestDaoUtil {
   @Before
   public void initFileDao() throws Exception {
     initDao();
-    fileStateDao = new FileStateDao(druidPool.getDataSource());
+    fileStateDao = daoProvider.fileStateDao();
   }
 
   @Test

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestGlobalConfigDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestGlobalConfigDao.java
@@ -25,13 +25,13 @@ import org.junit.Test;
 import org.smartdata.metastore.TestDaoUtil;
 import org.smartdata.model.GlobalConfig;
 
-public class TestGlobalConfigDao extends TestDaoUtil{
+public class TestGlobalConfigDao extends TestDaoUtil {
   private GlobalConfigDao globalConfigDao;
 
   @Before
   public void initGlobalConfigDao() throws Exception {
     initDao();
-    globalConfigDao = new GlobalConfigDao(druidPool.getDataSource());
+    globalConfigDao = daoProvider.globalConfigDao();
   }
 
   @After
@@ -41,7 +41,7 @@ public class TestGlobalConfigDao extends TestDaoUtil{
   }
 
   @Test
-  public void testInsertAndGetSingleRecord(){
+  public void testInsertAndGetSingleRecord() {
     GlobalConfig globalConfig = new GlobalConfig();
     globalConfig.setCid(1);
     globalConfig.setPropertyName("test");

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestRuleDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestRuleDao.java
@@ -34,7 +34,7 @@ public class TestRuleDao extends TestDaoUtil {
   @Before
   public void initRuleDao() throws Exception {
     initDao();
-    ruleDao = new RuleDao(druidPool.getDataSource());
+    ruleDao = daoProvider.ruleDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestStorageDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestStorageDao.java
@@ -38,7 +38,7 @@ public class TestStorageDao extends TestDaoUtil {
   @Before
   public void initStorageDao() throws Exception {
     initDao();
-    storageDao = new StorageDao(druidPool.getDataSource());
+    storageDao = daoProvider.storageDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestStorageHistoryDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestStorageHistoryDao.java
@@ -37,7 +37,7 @@ public class TestStorageHistoryDao extends TestDaoUtil {
   @Before
   public void initStorageDao() throws Exception {
     initDao();
-    storageHistDao = new StorageHistoryDao(druidPool.getDataSource());
+    storageHistDao = daoProvider.storageHistoryDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestStoragePolicyDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestStoragePolicyDao.java
@@ -30,7 +30,7 @@ public class TestStoragePolicyDao extends TestDaoUtil {
   @Before
   public void initStoragePolicyDao() throws Exception {
     initDao();
-    storagePolicyDao = new StoragePolicyDao(druidPool.getDataSource());
+    storagePolicyDao = daoProvider.storagePolicyDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestSystemInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestSystemInfoDao.java
@@ -32,7 +32,7 @@ public class TestSystemInfoDao extends TestDaoUtil {
   @Before
   public void initSystemInfoDao() throws Exception {
     initDao();
-    systemInfoDao = new SystemInfoDao(druidPool.getDataSource());
+    systemInfoDao = daoProvider.systemInfoDao();
   }
 
   @After

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestTableAggregator.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestTableAggregator.java
@@ -51,7 +51,7 @@ public class TestTableAggregator extends DBTest {
         new XmlDataSet(getClass().getClassLoader().getResourceAsStream("accessCountTable.xml"));
     databaseTester.setDataSet(dataSet);
     databaseTester.onSetup();
-    MetaStore metaStore = new MetaStore(druidPool);
+    MetaStore metaStore = createMetastore();
     prepareFiles(metaStore);
 
     AccessCountTable result = new AccessCountTable("actual", 0L, 0L, false);
@@ -72,7 +72,7 @@ public class TestTableAggregator extends DBTest {
         new XmlDataSet(getClass().getClassLoader().getResourceAsStream("accessCountTable.xml"));
     databaseTester.setDataSet(dataSet);
     databaseTester.onSetup();
-    MetaStore metaStore = new MetaStore(druidPool);
+    MetaStore metaStore = createMetastore();
     prepareFiles(metaStore);
 
     AccessCountTable table1 = new AccessCountTable("table1", 0L, 0L, false);

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestXattrDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestXattrDao.java
@@ -28,7 +28,7 @@ public class TestXattrDao extends TestDaoUtil {
   @Before
   public void initOtherDao() throws Exception {
     initDao();
-    xattrDao = new XattrDao(druidPool.getDataSource());
+    xattrDao = daoProvider.xattrDao();
   }
 
   @After

--- a/smart-server/src/test/java/org/smartdata/server/engine/rule/TestRuleManager.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/rule/TestRuleManager.java
@@ -47,7 +47,7 @@ public class TestRuleManager extends TestDaoUtil {
   public void init() throws Exception {
     initDao();
     smartConf = new SmartConf();
-    metaStore = new MetaStore(druidPool);
+    metaStore = createMetastore();
     ServerContext serverContext = new ServerContext(smartConf, metaStore);
     serverContext.setServiceMode(ServiceMode.HDFS);
     ruleManager = new RuleManager(serverContext, null, null);

--- a/smart-server/src/test/java/org/smartdata/server/engine/rule/TestRuleManager.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/rule/TestRuleManager.java
@@ -197,7 +197,7 @@ public class TestRuleManager extends TestDaoUtil {
     String rule = "file: every 1s \n | length > 300 | cache";
 
     // id increasing
-    int nRules =  3;
+    int nRules = 3;
     long[] ids = new long[nRules];
     for (int i = 0; i < nRules; i++) {
       ids[i] = ruleManager.submitRule(rule, RuleState.DISABLED);
@@ -243,7 +243,7 @@ public class TestRuleManager extends TestDaoUtil {
 
     long start = System.currentTimeMillis();
 
-    Thread[] threads = new Thread[] {
+    Thread[] threads = new Thread[]{
         new Thread(new RuleInfoUpdater(rid, 3)),
 //        new Thread(new RuleInfoUpdater(rid, 7)),
 //        new Thread(new RuleInfoUpdater(rid, 11)),
@@ -304,8 +304,8 @@ public class TestRuleManager extends TestDaoUtil {
 
     long length = 100;
     long fid = 10000;
-    FileInfo[] files = { new FileInfo("/tmp/testfile", fid,  length, false, (short) 3,
-        1024, now, now, (short) 1, null, null, (byte) 3, (byte) 0) };
+    FileInfo[] files = {new FileInfo("/tmp/testfile", fid, length, false, (short) 3,
+        1024, now, now, (short) 1, null, null, (byte) 3, (byte) 0)};
 
     metaStore.insertFiles(files);
     long rid = ruleManager.submitRule(rule, RuleState.ACTIVE);

--- a/smart-zeppelin/zeppelin-web/pom.xml
+++ b/smart-zeppelin/zeppelin-web/pom.xml
@@ -16,7 +16,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -102,59 +103,59 @@
         </configuration>
       </plugin>
 
-            <plugin>
-              <groupId>com.github.eirslett</groupId>
-              <artifactId>frontend-maven-plugin</artifactId>
-              <version>${plugin.frontned.version}</version>
-              <executions>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>${plugin.frontned.version}</version>
+        <executions>
 
-                <execution>
-                  <id>install node and yarn</id>
-                  <goals>
-                    <goal>install-node-and-yarn</goal>
-                    <goal>install-node-and-npm</goal>
-                  </goals>
-                  <configuration>
-                    <nodeVersion>${node.version}</nodeVersion>
-                    <yarnVersion>${yarn.version}</yarnVersion>
-                    <npmVersion>${npm.version}</npmVersion>
-                  </configuration>
-                </execution>
+          <execution>
+            <id>install node and yarn</id>
+            <goals>
+              <goal>install-node-and-yarn</goal>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <nodeVersion>${node.version}</nodeVersion>
+              <yarnVersion>${yarn.version}</yarnVersion>
+              <npmVersion>${npm.version}</npmVersion>
+            </configuration>
+          </execution>
 
 
-                <execution>
-                  <id>yarn install</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>install --no-lockfile</arguments>
-                  </configuration>
-                </execution>
+          <execution>
+            <id>yarn install</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>install --no-lockfile</arguments>
+            </configuration>
+          </execution>
 
-                <execution>
-                  <id>yarn build</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>run build --force</arguments>
-                  </configuration>
-                </execution>
+          <execution>
+            <id>yarn build</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>run build --force</arguments>
+            </configuration>
+          </execution>
 
-                <execution>
-                  <id>yarn test</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <phase>test</phase>
-                  <configuration>
-                    <arguments>run test</arguments>
-                  </configuration>
-                </execution>
+          <execution>
+            <id>yarn test</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <arguments>run test</arguments>
+            </configuration>
+          </execution>
 
-              </executions>
-            </plugin>
+        </executions>
+      </plugin>
 
       <!--
           Disabling test report generation as it forks the lifecycle

--- a/smart-zeppelin/zeppelin-web/pom.xml
+++ b/smart-zeppelin/zeppelin-web/pom.xml
@@ -38,7 +38,7 @@
   </prerequisites>
 
   <properties>
-    <node.version>v12.0.0</node.version>
+    <node.version>v16.0.0</node.version>
     <yarn.version>v0.27.5</yarn.version>
     <npm.version>4.2.0</npm.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
1. Refactored the `*Dao` package classes. Extracted interfaces and inherited existing implementation.
2. Moved migrations from `MetaStoreUtils.initializeDataBase` to Liquibase migrations. To enable the old MySQL logic (version < 5.7) user should set the option `smart.metastore.migration.liquibase.labels` to value `old_mysql` in `${SSM_dist}/conf/smart-site.xml` 