### PR TITLE
[ADH-4027] Parametrize hardcoded attributes

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -391,4 +391,84 @@
       Comma-separated list of regex templates of internal files to be completely ignored by SSM.
     </description>
   </property>
+
+  <property>
+    <name>smart.access.count.day.tables.num</name>
+    <value>30</value>
+    <description>
+      The max number of access count per day tables in the Metastore.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.access.count.hour.tables.num</name>
+    <value>48</value>
+    <description>
+      The max number of access count per hour tables in the Metastore.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.access.count.minute.tables.num</name>
+    <value>120</value>
+    <description>
+      The max number of access count per minute tables in the Metastore.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.access.count.second.tables.num</name>
+    <value>30</value>
+    <description>
+      The max number of access count per second tables in the Metastore.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.access.event.fetch.interval.ms</name>
+    <value>1000</value>
+    <description>
+      The interval in milliseconds between access event fetches.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.cached.file.fetch.interval.ms</name>
+    <value>5000</value>
+    <description>
+      The interval in milliseconds between cached files fetches from HDFS.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.namespace.fetch.interval.ms</name>
+    <value>1</value>
+    <description>
+      The interval in milliseconds between namespace fetches from HDFS.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.mover.scheduler.storage.report.fetch.interval.ms</name>
+    <value>120000</value>
+    <description>
+      The interval in milliseconds between storage report fetches from HDFS DataNode in mover scheduler.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.metastore.small-file.insert.batch.size</name>
+    <value>200</value>
+    <description>
+      The max size of small file insert batch to the Metastore.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.agent.master.ask.timeout.ms</name>
+    <value>5000</value>
+    <description>
+      The max time in milliseconds to wait an answer from the SmartAgent master actor during action submission.
+    </description>
+  </property>
 </configuration>

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -90,6 +90,34 @@ public class SmartConfKeys {
       "smart.metastore.mysql.legacy.enabled";
   public static final boolean SMART_METASTORE_LEGACY_MYSQL_SUPPORT_DEFAULT = false;
 
+  public static final String SMART_NUM_DAY_TABLES_TO_KEEP_KEY =
+      "smart.access.count.day.tables.num";
+  public static final int SMART_NUM_DAY_TABLES_TO_KEEP_DEFAULT = 30;
+
+  public static final String SMART_NUM_HOUR_TABLES_TO_KEEP_KEY =
+      "smart.access.count.hour.tables.num";
+  public static final int SMART_NUM_HOUR_TABLES_TO_KEEP_DEFAULT = 48;
+
+  public static final String SMART_NUM_MINUTE_TABLES_TO_KEEP_KEY =
+      "smart.access.count.minute.tables.num";
+  public static final int SMART_NUM_MINUTE_TABLES_TO_KEEP_DEFAULT = 120;
+
+  public static final String SMART_NUM_SECOND_TABLES_TO_KEEP_KEY =
+      "smart.access.count.second.tables.num";
+  public static final int SMART_NUM_SECOND_TABLES_TO_KEEP_DEFAULT = 30;
+
+  public static final String SMART_ACCESS_EVENT_FETCH_INTERVAL_MS_KEY =
+      "smart.access.event.fetch.interval.ms";
+  public static final long SMART_ACCESS_EVENT_FETCH_INTERVAL_MS_DEFAULT = 1000L;
+
+  public static final String SMART_CACHED_FILE_FETCH_INTERVAL_MS_KEY =
+      "smart.cached.file.fetch.interval.ms";
+  public static final long SMART_CACHED_FILE_FETCH_INTERVAL_MS_DEFAULT = 5 * 1000L;
+
+  public static final String SMART_NAMESPACE_FETCH_INTERVAL_MS_KEY =
+      "smart.namespace.fetch.interval.ms";
+  public static final long SMART_NAMESPACE_FETCH_INTERVAL_MS_DEFAULT = 1L;
+
   // StatesManager
 
   // RuleManager
@@ -140,6 +168,14 @@ public class SmartConfKeys {
   public static final int SMART_FILE_DIFF_MAX_NUM_RECORDS_DEFAULT =
       10000;
 
+  public static final String SMART_MOVER_SCHEDULER_REPORT_FETCH_INTERVAL_MS_KEY =
+      "smart.mover.scheduler.storage.report.fetch.interval.ms";
+  public static final long SMART_MOVER_SCHEDULER_REPORT_FETCH_INTERVAL_MS_DEFAULT = 2 * 60 * 1000;
+
+  public static final String SMART_SMALL_FILE_METASTORE_INSERT_BATCH_SIZE_KEY =
+      "smart.metastore.small-file.insert.batch.size";
+  public static final int SMART_SMALL_FILE_METASTORE_INSERT_BATCH_SIZE_DEFAULT = 200;
+
   // Dispatcher
   public static final String SMART_CMDLET_DISPATCHER_LOG_DISP_RESULT_KEY =
       "smart.cmdlet.dispatcher.log.disp.result";
@@ -166,6 +202,10 @@ public class SmartConfKeys {
   public static final int SMART_AGENT_MASTER_PORT_DEFAULT = 7051;
   public static final String SMART_AGENT_PORT_KEY = "smart.agent.port";
   public static final int SMART_AGENT_PORT_DEFAULT = 7048;
+
+  public static final String SMART_AGENT_MASTER_ASK_TIMEOUT_MS_KEY =
+      "smart.agent.master.ask.timeout.ms";
+  public static final long SMART_AGENT_MASTER_ASK_TIMEOUT_MS_DEFAULT = 5000L;
 
   /** Do NOT configure the following two options manually. They are set by the boot scripts. **/
   public static final String SMART_AGENT_MASTER_ADDRESS_KEY = "smart.agent.master.address";

--- a/smart-engine/src/main/java/org/smartdata/server/engine/StatesManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/StatesManager.java
@@ -75,7 +75,7 @@ public class StatesManager extends AbstractService implements Reconfigurable {
     LOG.info("Initializing ...");
     this.executorService = Executors.newScheduledThreadPool(4);
     this.accessCountTableManager = new AccessCountTableManager(
-        serverContext.getMetaStore(), executorService);
+        serverContext.getMetaStore(), executorService, serverContext.getConf());
     this.fileAccessEventSource = MetricsFactory.createAccessEventSource(serverContext.getConf());
     this.accessEventFetcher =
         new AccessEventFetcher(

--- a/smart-engine/src/main/java/org/smartdata/server/engine/data/AccessEventFetcher.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/data/AccessEventFetcher.java
@@ -26,15 +26,16 @@ import org.smartdata.metrics.FileAccessEventCollector;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.smartdata.conf.SmartConfKeys.SMART_ACCESS_EVENT_FETCH_INTERVAL_MS_DEFAULT;
+import static org.smartdata.conf.SmartConfKeys.SMART_ACCESS_EVENT_FETCH_INTERVAL_MS_KEY;
+
 public class AccessEventFetcher {
   static final Logger LOG = LoggerFactory.getLogger(AccessEventFetcher.class);
 
-  private static final Long DEFAULT_INTERVAL = 1 * 1000L;
   private final ScheduledExecutorService scheduledExecutorService;
   private final Long fetchInterval;
   private ScheduledFuture scheduledFuture;
@@ -45,24 +46,10 @@ public class AccessEventFetcher {
       AccessCountTableManager manager,
       ScheduledExecutorService service,
       FileAccessEventCollector collector) {
-    this(DEFAULT_INTERVAL, conf, manager, service, collector);
-  }
-
-  public AccessEventFetcher(
-      Long fetchInterval,
-      Configuration conf,
-      AccessCountTableManager manager,
-      FileAccessEventCollector collector) {
-    this(fetchInterval, conf, manager, Executors.newSingleThreadScheduledExecutor(), collector);
-  }
-
-  public AccessEventFetcher(
-      Long fetchInterval,
-      Configuration conf,
-      AccessCountTableManager manager,
-      ScheduledExecutorService service,
-      FileAccessEventCollector collector) {
-    this.fetchInterval = fetchInterval;
+    this.fetchInterval = conf.getLong(
+        SMART_ACCESS_EVENT_FETCH_INTERVAL_MS_KEY,
+        SMART_ACCESS_EVENT_FETCH_INTERVAL_MS_DEFAULT
+    );
     this.fetchTask = new FetchTask(conf, manager, collector);
     this.scheduledExecutorService = service;
   }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/HdfsStatesUpdateService.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/HdfsStatesUpdateService.java
@@ -91,7 +91,7 @@ public class HdfsStatesUpdateService extends StatesUpdateService {
     client = HadoopUtil.getDFSClient(nnUri, conf);
     checkAndCreateIdFiles(nnUri, context.getConf());
     this.executorService = Executors.newScheduledThreadPool(4);
-    this.cachedListFetcher = new CachedListFetcher(client, metaStore);
+    this.cachedListFetcher = new CachedListFetcher(conf, client, metaStore);
     this.inotifyEventFetcher = new InotifyEventFetcher(client,
         metaStore, executorService, new FetchFinishedCallBack(), context.getConf());
     this.dataNodeInfoFetcher = new DataNodeInfoFetcher(

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/CachedListFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/CachedListFetcher.java
@@ -17,6 +17,7 @@
  */
 package org.smartdata.hdfs.metric.fetcher;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.protocol.CacheDirectiveEntry;
@@ -42,9 +43,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.smartdata.conf.SmartConfKeys.SMART_CACHED_FILE_FETCH_INTERVAL_MS_DEFAULT;
+import static org.smartdata.conf.SmartConfKeys.SMART_CACHED_FILE_FETCH_INTERVAL_MS_KEY;
+
 public class CachedListFetcher {
 
-  private static final Long DEFAULT_INTERVAL = 5 * 1000L;
   private final ScheduledExecutorService scheduledExecutorService;
   private final Long fetchInterval;
   private FetchTask fetchTask;
@@ -55,32 +58,22 @@ public class CachedListFetcher {
       LoggerFactory.getLogger(CachedListFetcher.class);
 
   public CachedListFetcher(
-      Long fetchInterval,
+      Configuration configuration,
       DFSClient dfsClient, MetaStore metaStore,
       ScheduledExecutorService service) {
-    this.fetchInterval = fetchInterval;
+    this.fetchInterval = configuration.getLong(
+        SMART_CACHED_FILE_FETCH_INTERVAL_MS_KEY,
+        SMART_CACHED_FILE_FETCH_INTERVAL_MS_DEFAULT
+    );
     this.metaStore = metaStore;
     this.fetchTask = new FetchTask(dfsClient, metaStore);
     this.scheduledExecutorService = service;
   }
 
   public CachedListFetcher(
-      Long fetchInterval,
+      Configuration configuration,
       DFSClient dfsClient, MetaStore metaStore) {
-    this(fetchInterval, dfsClient, metaStore,
-        Executors.newSingleThreadScheduledExecutor());
-  }
-
-  public CachedListFetcher(
-      DFSClient dfsClient, MetaStore metaStore) {
-    this(DEFAULT_INTERVAL, dfsClient, metaStore,
-        Executors.newSingleThreadScheduledExecutor());
-  }
-
-  public CachedListFetcher(
-      DFSClient dfsClient, MetaStore metaStore,
-      ScheduledExecutorService service) {
-    this(DEFAULT_INTERVAL, dfsClient, metaStore, service);
+    this(configuration, dfsClient, metaStore, Executors.newSingleThreadScheduledExecutor());
   }
 
   public void start() {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/MoverScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/MoverScheduler.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdfs.DFSClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.SmartContext;
+import org.smartdata.conf.SmartConf;
 import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.hdfs.HadoopUtil;
 import org.smartdata.hdfs.action.HdfsAction;
@@ -53,7 +54,7 @@ public class MoverScheduler extends ActionSchedulerService {
   private MovePlanStatistics statistics;
   private MovePlanMaker planMaker;
   private final URI nnUri;
-  private long dnInfoUpdateInterval = 2 * 60 * 1000;
+  private final long dnInfoUpdateInterval;
   private ScheduledExecutorService updateService;
   private ScheduledFuture updateServiceFuture;
   private long throttleInMb;
@@ -67,10 +68,16 @@ public class MoverScheduler extends ActionSchedulerService {
   public MoverScheduler(SmartContext context, MetaStore metaStore)
       throws IOException {
     super(context, metaStore);
-    nnUri = HadoopUtil.getNameNodeUri(getContext().getConf());
-    throttleInMb = getContext().getConf()
-        .getLong(SmartConfKeys.SMART_ACTION_MOVE_THROTTLE_MB_KEY,
-            SmartConfKeys.SMART_ACTION_MOVE_THROTTLE_MB_DEFAULT);
+    SmartConf conf = getContext().getConf();
+    nnUri = HadoopUtil.getNameNodeUri(conf);
+    throttleInMb = conf.getLong(
+        SmartConfKeys.SMART_ACTION_MOVE_THROTTLE_MB_KEY,
+        SmartConfKeys.SMART_ACTION_MOVE_THROTTLE_MB_DEFAULT
+    );
+    dnInfoUpdateInterval = conf.getLong(
+        SmartConfKeys.SMART_MOVER_SCHEDULER_REPORT_FETCH_INTERVAL_MS_KEY,
+        SmartConfKeys.SMART_MOVER_SCHEDULER_REPORT_FETCH_INTERVAL_MS_DEFAULT
+    );
     if (throttleInMb > 0) {
       rateLimiter = RateLimiter.create(throttleInMb);
     }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.smartdata.SmartContext;
 import org.smartdata.conf.SmartConf;
+import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.hdfs.MiniClusterFactory;
 import org.smartdata.hdfs.action.CacheFileAction;
 import org.smartdata.hdfs.action.UncacheFileAction;
@@ -71,7 +72,7 @@ public class TestCachedListFetcher extends SqliteTestDaoBase {
     dfs = cluster.getFileSystem();
     dfsClient = dfs.getClient();
     smartContext = new SmartContext(conf);
-    cachedListFetcher = new CachedListFetcher(600l, dfsClient, metaStore);
+    cachedListFetcher = new CachedListFetcher(conf, dfsClient, metaStore);
   }
 
   static void initConf(Configuration conf) {
@@ -79,6 +80,7 @@ public class TestCachedListFetcher extends SqliteTestDaoBase {
     conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, DEFAULT_BLOCK_SIZE);
     conf.setLong(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1L);
     conf.setLong(DFSConfigKeys.DFS_BALANCER_MOVEDWINWIDTH_KEY, 2000L);
+    conf.setLong(SmartConfKeys.SMART_CACHED_FILE_FETCH_INTERVAL_MS_KEY, 600);
   }
 
   @After

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestNamespaceFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestNamespaceFetcher.java
@@ -20,6 +20,7 @@ package org.smartdata.hdfs.metric.fetcher;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -39,6 +40,7 @@ import org.smartdata.metastore.MetaStoreException;
 import static org.mockito.Mockito.*;
 import static org.smartdata.conf.SmartConfKeys.SMART_IGNORED_PATH_TEMPLATES_KEY;
 import static org.smartdata.conf.SmartConfKeys.SMART_IGNORE_DIRS_KEY;
+import static org.smartdata.conf.SmartConfKeys.SMART_NAMESPACE_FETCH_INTERVAL_MS_KEY;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,13 +75,12 @@ public class TestNamespaceFetcher {
           return null;
         }
       }).when(adapter).insertFiles(any(FileInfo[].class));
-      NamespaceFetcher fetcher;
-      if(conf != null) {
-        fetcher = new NamespaceFetcher(client, adapter, 100, conf);
-      } else {
-        fetcher = new NamespaceFetcher(client, adapter, 100);
-      }
-      return fetcher;
+
+      SmartConf nonNullConfig = Optional.ofNullable(conf)
+          .orElseGet(SmartConf::new);
+      nonNullConfig.setLong(SMART_NAMESPACE_FETCH_INTERVAL_MS_KEY, 100L);
+
+      return new NamespaceFetcher(client, adapter, nonNullConfig);
   }
 
   @Test


### PR DESCRIPTION
The following options were added:
- `smart.access.count.day.tables.num`
- `smart.access.count.hour.tables.num`
- `smart.access.count.minute.tables.num`
- `smart.access.count.second.tables.num`
- `smart.access.event.fetch.interval.ms`
- `smart.cached.file.fetch.interval.ms`
- `smart.namespace.fetch.interval.ms`
- `smart.mover.scheduler.storage.report.fetch.interval.ms`
- `smart.metastore.small-file.insert.batch.size`
- `smart.agent.master.ask.timeout.ms`

This PR shouldn't be merged until GitHub Actions will be enabled by the merge of #4 