### PR TITLE
[ADH-4031] Fix all file table fields rewrite during update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.20</version>
           <configuration>
-            <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+            <argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/smart-common/src/main/java/org/smartdata/model/FileInfoUpdate.java
+++ b/smart-common/src/main/java/org/smartdata/model/FileInfoUpdate.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.model;
+
+import java.util.Objects;
+
+public class FileInfoUpdate {
+  private String path;
+  private Long length;
+  private Boolean isdir;
+  private Short blockReplication;
+  private Long blocksize;
+  private Long modificationTime;
+  private Long accessTime;
+  private Short permission;
+  private String owner;
+  private String group;
+  private Byte erasureCodingPolicy;
+
+  public String getPath() {
+    return path;
+  }
+
+  public FileInfoUpdate setPath(String path) {
+    this.path = path;
+    return this;
+  }
+
+  public Long getLength() {
+    return length;
+  }
+
+  public FileInfoUpdate setLength(long length) {
+    this.length = length;
+    return this;
+  }
+
+  public Boolean getIsdir() {
+    return isdir;
+  }
+
+  public FileInfoUpdate setIsdir(boolean isdir) {
+    this.isdir = isdir;
+    return this;
+  }
+
+  public Short getBlockReplication() {
+    return blockReplication;
+  }
+
+  public FileInfoUpdate setBlockReplication(short blockReplication) {
+    this.blockReplication = blockReplication;
+    return this;
+  }
+
+  public Long getBlocksize() {
+    return blocksize;
+  }
+
+  public FileInfoUpdate setBlocksize(long blocksize) {
+    this.blocksize = blocksize;
+    return this;
+  }
+
+  public Long getModificationTime() {
+    return modificationTime;
+  }
+
+  public FileInfoUpdate setModificationTime(long modificationTime) {
+    this.modificationTime = modificationTime;
+    return this;
+  }
+
+  public Long getAccessTime() {
+    return accessTime;
+  }
+
+  public FileInfoUpdate setAccessTime(long accessTime) {
+    this.accessTime = accessTime;
+    return this;
+  }
+
+  public Short getPermission() {
+    return permission;
+  }
+
+  public FileInfoUpdate setPermission(short permission) {
+    this.permission = permission;
+    return this;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public FileInfoUpdate setOwner(String owner) {
+    this.owner = owner;
+    return this;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public FileInfoUpdate setGroup(String group) {
+    this.group = group;
+    return this;
+  }
+
+  public Byte getErasureCodingPolicy() {
+    return erasureCodingPolicy;
+  }
+
+  public FileInfoUpdate setErasureCodingPolicy(byte erasureCodingPolicy) {
+    this.erasureCodingPolicy = erasureCodingPolicy;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FileInfoUpdate that = (FileInfoUpdate) o;
+    return Objects.equals(path, that.path)
+        && Objects.equals(length, that.length)
+        && Objects.equals(isdir, that.isdir)
+        && Objects.equals(blockReplication, that.blockReplication)
+        && Objects.equals(blocksize, that.blocksize)
+        && Objects.equals(modificationTime, that.modificationTime)
+        && Objects.equals(accessTime, that.accessTime)
+        && Objects.equals(permission, that.permission)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(group, that.group)
+        && Objects.equals(erasureCodingPolicy, that.erasureCodingPolicy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path, length, isdir, blockReplication,
+        blocksize, modificationTime, accessTime, permission, owner, group, erasureCodingPolicy);
+  }
+
+  @Override
+  public String toString() {
+    return "FileInfoUpdate{"
+        + "path='" + path + '\''
+        + ", length=" + length
+        + ", isdir=" + isdir
+        + ", blockReplication=" + blockReplication
+        + ", blocksize=" + blocksize
+        + ", modificationTime=" + modificationTime
+        + ", accessTime=" + accessTime
+        + ", permission=" + permission
+        + ", owner='" + owner + '\''
+        + ", group='" + group + '\''
+        + ", erasureCodingPolicy=" + erasureCodingPolicy
+        + '}';
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyEventApplier.java
@@ -128,6 +128,9 @@ public class TestInotifyEventApplier extends TestDaoBase {
     result4 = metaStore.getFile().get(1);
     Assert.assertEquals(result4.getOwner(), "user1");
     Assert.assertEquals(result4.getGroup(), "cg1");
+    // check metadata event didn't flush other FileInfo fields
+    Assert.assertEquals(result4.getFileId(), 1010L);
+    Assert.assertEquals(result4.getPermission(), new FsPermission("777").toShort());
 
     Event.CreateEvent createEvent2 =
         new Event.CreateEvent.Builder()

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -71,6 +71,7 @@ import org.smartdata.model.FileAccessInfo;
 import org.smartdata.model.FileDiff;
 import org.smartdata.model.FileDiffState;
 import org.smartdata.model.FileInfo;
+import org.smartdata.model.FileInfoUpdate;
 import org.smartdata.model.FileState;
 import org.smartdata.model.GlobalConfig;
 import org.smartdata.model.NormalFileState;
@@ -202,8 +203,8 @@ public class MetaStore implements CopyMetaService, CmdletMetaService, BackupMeta
     fileInfoDao.insert(files);
   }
 
-  public void updateFileByPath(String path, FileInfo file) {
-    fileInfoDao.updateByPath(path, file);
+  public void updateFileByPath(String path, FileInfoUpdate fileUpdate) {
+    fileInfoDao.updateByPath(path, fileUpdate);
   }
 
   public void unlinkRootDirectory() {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
@@ -18,6 +18,7 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.FileInfo;
+import org.smartdata.model.FileInfoUpdate;
 
 import java.sql.SQLException;
 import java.util.Collection;
@@ -50,7 +51,7 @@ public interface FileInfoDao {
 
   int update(String path, int storagePolicy);
 
-  int updateByPath(String path, FileInfo fileInfo);
+  int updateByPath(String path, FileInfoUpdate fileUpdate);
 
   void deleteById(long fid);
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
@@ -20,6 +20,7 @@ package org.smartdata.metastore.dao.impl;
 import org.smartdata.metastore.dao.AbstractDao;
 import org.smartdata.metastore.dao.FileInfoDao;
 import org.smartdata.model.FileInfo;
+import org.smartdata.model.FileInfoUpdate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -133,8 +134,8 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
   }
 
   @Override
-  public int updateByPath(String path, FileInfo fileInfo) {
-    return update(toMap(fileInfo), "path = ?", path);
+  public int updateByPath(String path, FileInfoUpdate fileUpdate) {
+    return update(updateToMap(fileUpdate), "path = ?", path);
   }
 
   @Override
@@ -172,6 +173,23 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
     String sql = "UPDATE " + TABLE_NAME
         + " SET path = CONCAT(?, SUBSTR(path, ?)) WHERE path LIKE ?";
     jdbcTemplate.update(sql, newPath, oldPath.length() + 1, oldPath + "/%");
+  }
+
+  private Map<String, Object> updateToMap(FileInfoUpdate fileInfo) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("path", fileInfo.getPath());
+    parameters.put("length", fileInfo.getLength());
+    parameters.put("block_replication", fileInfo.getBlockReplication());
+    parameters.put("block_size", fileInfo.getBlocksize());
+    parameters.put("modification_time", fileInfo.getModificationTime());
+    parameters.put("access_time", fileInfo.getAccessTime());
+    parameters
+        .put("owner", fileInfo.getOwner());
+    parameters
+        .put("owner_group", fileInfo.getGroup());
+    parameters.put("permission", fileInfo.getPermission());
+    parameters.put("ec_policy_id", fileInfo.getErasureCodingPolicy());
+    return parameters;
   }
 
   private Map<String, Object> toMap(FileInfo fileInfo) {


### PR DESCRIPTION
Fixed bug, when the columns of `file` table are rewritten with unfilled fields of INotify metadata update event. This issue led to an incorrect calculation of the file access counts.