### PR TITLE
[ADH-4068] Fix sync action source path pattern matching

### DIFF
--- a/smart-common/src/main/java/org/smartdata/model/BackUpInfo.java
+++ b/smart-common/src/main/java/org/smartdata/model/BackUpInfo.java
@@ -23,14 +23,19 @@ public class BackUpInfo {
   private long rid;
   private String src;
   private String dest;
-  private long period; // in milli-seconds
-
+  private long period; // in milliseconds
+  private String srcPattern;
 
   public BackUpInfo(long rid, String src, String dest, long period) {
+    this(rid, src, dest, period, src);
+  }
+
+  public BackUpInfo(long rid, String src, String dest, long period, String srcPattern) {
     this.rid = rid;
     this.src = src;
     this.dest = dest;
     this.period = period;
+    this.srcPattern = srcPattern;
   }
 
   public BackUpInfo() {
@@ -68,6 +73,14 @@ public class BackUpInfo {
     this.period = period;
   }
 
+  public String getSrcPattern() {
+    return srcPattern;
+  }
+
+  public void setSrcPattern(String srcPattern) {
+    this.srcPattern = srcPattern;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -80,17 +93,23 @@ public class BackUpInfo {
     return rid == that.rid
         && period == that.period
         && Objects.equals(src, that.src)
-        && Objects.equals(dest, that.dest);
+        && Objects.equals(dest, that.dest)
+        && Objects.equals(srcPattern, that.srcPattern);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(rid, src, dest, period);
+    return Objects.hash(rid, src, dest, period, srcPattern);
   }
 
   @Override
   public String toString() {
-    return String.format(
-        "BackUpInfo{rid=%s, src\'%s\', dest=\'%s\', period=%s}", rid, src, dest, period);
+    return "BackUpInfo{"
+        + "rid=" + rid
+        + ", src='" + src + '\''
+        + ", dest='" + dest + '\''
+        + ", period=" + period
+        + ", srcPattern='" + srcPattern + '\''
+        + '}';
   }
 }

--- a/smart-common/src/main/java/org/smartdata/model/BackUpInfo.java
+++ b/smart-common/src/main/java/org/smartdata/model/BackUpInfo.java
@@ -19,6 +19,8 @@ package org.smartdata.model;
 
 import java.util.Objects;
 
+import static org.smartdata.utils.StringUtil.ssmPatternToRegex;
+
 public class BackUpInfo {
   private long rid;
   private String src;
@@ -27,7 +29,7 @@ public class BackUpInfo {
   private String srcPattern;
 
   public BackUpInfo(long rid, String src, String dest, long period) {
-    this(rid, src, dest, period, src);
+    this(rid, src, dest, period, ssmPatternToRegex(src + "*"));
   }
 
   public BackUpInfo(long rid, String src, String dest, long period, String srcPattern) {

--- a/smart-common/src/main/java/org/smartdata/utils/StringUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/StringUtil.java
@@ -83,7 +83,7 @@ public class StringUtil {
     return path.substring(0, last + 1);
   }
 
-  public static String globString2SqlLike(String str) {
+  public static String ssmPatternToSqlLike(String str) {
     return str.replace("*", "%")
         .replace("?", "_");
   }
@@ -273,7 +273,9 @@ public class StringUtil {
   }
 
   public static String ssmPatternToRegex(String ssmPattern) {
-    return ssmPattern.replace("*", ".*")
+    return ssmPattern
+        .replace(".", "\\.")
+        .replace("*", ".*")
         .replace("?", ".");
   }
 }

--- a/smart-common/src/main/java/org/smartdata/utils/StringUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/StringUtil.java
@@ -17,6 +17,7 @@
  *  under the License.
  *
  */
+
 package org.smartdata.utils;
 
 import com.google.common.hash.Hashing;
@@ -26,12 +27,13 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class StringUtil {
   private static final String DIR_SEP = "/";
-  private static final String[] GLOBS = new String[]{
+  private static final String[] GLOBS = new String[] {
       "*", "?"
   };
 
@@ -82,9 +84,8 @@ public class StringUtil {
   }
 
   public static String globString2SqlLike(String str) {
-    str = str.replace("*", "%");
-    str = str.replace("?", "_");
-    return str;
+    return str.replace("*", "%")
+        .replace("?", "_");
   }
 
   /**
@@ -260,5 +261,19 @@ public class StringUtil {
 
   public static String toSHA512String(String password) {
     return Hashing.sha512().hashString(password, StandardCharsets.UTF_8).toString();
+  }
+
+  public static String ssmPatternsToRegex(List<String> rawPatterns) {
+    StringJoiner regexBuilder = new StringJoiner("|", "(", ")");
+    rawPatterns.stream()
+        .map(StringUtil::ssmPatternToRegex)
+        .forEach(regexBuilder::add);
+
+    return regexBuilder.toString();
+  }
+
+  public static String ssmPatternToRegex(String ssmPattern) {
+    return ssmPattern.replace("*", ".*")
+        .replace("?", ".");
   }
 }

--- a/smart-common/src/test/java/org/smartdata/utils/TestStringUtil.java
+++ b/smart-common/src/test/java/org/smartdata/utils/TestStringUtil.java
@@ -20,9 +20,14 @@ package org.smartdata.utils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.smartdata.utils.StringUtil.ssmPatternToRegex;
+import static org.smartdata.utils.StringUtil.ssmPatternToSqlLike;
+import static org.smartdata.utils.StringUtil.ssmPatternsToRegex;
 
 /**
  * Tests for StringUtil.
@@ -41,5 +46,27 @@ public class TestStringUtil {
       Assert.assertTrue(strs.get(str) == items.size());
       System.out.println(items.size() + " -> " + str);
     }
+  }
+
+  @Test
+  public void testSsmPatternToSqlLike() {
+    Assert.assertEquals("/src/%", ssmPatternToSqlLike("/src/*"));
+    Assert.assertEquals("/another_dir/test/%.bin", ssmPatternToSqlLike("/another_dir/test/*.bin"));
+    Assert.assertEquals("/some/dir-_/file.%", ssmPatternToSqlLike("/some/dir-?/file.*"));
+    Assert.assertEquals("/plain/path", ssmPatternToSqlLike("/plain/path"));
+  }
+
+  @Test
+  public void testSsmPatternToRegex() {
+    Assert.assertEquals("/src/.*", ssmPatternToRegex("/src/*"));
+    Assert.assertEquals("/another_dir/test/.*\\.bin", ssmPatternToRegex("/another_dir/test/*.bin"));
+    Assert.assertEquals("/some/dir_./file\\..*", ssmPatternToRegex("/some/dir_?/file.*"));
+    Assert.assertEquals("/plain/path", ssmPatternToRegex("/plain/path"));
+  }
+
+  @Test
+  public void testSsmPatternsToRegex() {
+    List<String> ssmPatterns = Arrays.asList("/src/*", "/file_?.*", "/test_dir");
+    Assert.assertEquals("(/src/.*|/file_.\\..*|/test_dir)", ssmPatternsToRegex(ssmPatterns));
   }
 }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
@@ -17,6 +17,7 @@
  */
 package org.smartdata.server.engine.rule;
 
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.action.SyncAction;
@@ -32,11 +33,14 @@ import org.smartdata.model.rule.TranslateResult;
 import org.smartdata.utils.StringUtil;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
+
+import static org.smartdata.utils.StringUtil.ssmPatternsToRegex;
 
 public class FileCopyDrPlugin implements RuleExecutorPlugin {
   private MetaStore metaStore;
@@ -51,8 +55,8 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
   public void onNewRuleExecutor(final RuleInfo ruleInfo, TranslateResult tResult) {
     long ruleId = ruleInfo.getId();
     List<String> pathsCheckGlob = tResult.getGlobPathCheck();
-    if (pathsCheckGlob.size() == 0) {
-      pathsCheckGlob = Arrays.asList("/*");
+    if (pathsCheckGlob.isEmpty()) {
+      pathsCheckGlob = Collections.singletonList("/*");
     }
     List<String> pathsCheck = getPathMatchesList(pathsCheckGlob);
     String dirs = StringUtil.join(",", pathsCheck);
@@ -62,12 +66,13 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
 
         List<String> statements = tResult.getSqlStatements();
         String before = statements.get(statements.size() - 1);
-        String after = before.replace(";", " UNION " + referenceNonExists(tResult, pathsCheck));
+        String after = before.replace(";", " UNION " + referenceNonExists(pathsCheckGlob));
         statements.set(statements.size() - 1, after);
 
         BackUpInfo backUpInfo = new BackUpInfo();
         backUpInfo.setRid(ruleId);
         backUpInfo.setSrc(dirs);
+        backUpInfo.setSrcPattern(ssmPatternsToRegex(pathsCheckGlob));
         String dest = des.getActionArgs(i).get(SyncAction.DEST);
         if (!dest.endsWith("/")) {
           dest += "/";
@@ -118,14 +123,16 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
     return ret;
   }
 
-  private String referenceNonExists(TranslateResult tr, List<String> dirs) {
+  private String referenceNonExists(List<String> globTemplates) {
     String temp = "SELECT src FROM file_diff WHERE "
         + "state = 0 AND diff_type IN (1,2) AND (%s);";
-    String srcs = "src LIKE '" + dirs.get(0) + "%'";
-    for (int i = 1; i < dirs.size(); i++) {
-      srcs +=  " OR src LIKE '" + dirs.get(i) + "%'";
-    }
-    return String.format(temp, srcs);
+
+    StringJoiner queryFilterBuilder = new StringJoiner(" OR ");
+    globTemplates.stream()
+        .map(StringUtil::globString2SqlLike)
+        .forEach(template -> queryFilterBuilder.add("src LIKE '" + template + "'"));
+
+    return String.format(temp, queryFilterBuilder);
   }
 
   public boolean preExecution(final RuleInfo ruleInfo, TranslateResult tResult) {

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
@@ -129,7 +129,7 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
 
     StringJoiner queryFilterBuilder = new StringJoiner(" OR ");
     globTemplates.stream()
-        .map(StringUtil::globString2SqlLike)
+        .map(StringUtil::ssmPatternToSqlLike)
         .forEach(template -> queryFilterBuilder.add("src LIKE '" + template + "'"));
 
     return String.format(temp, queryFilterBuilder);

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
@@ -193,7 +193,7 @@ public class InotifyEventApplier {
   }
 
   private boolean inBackup(String src) throws MetaStoreException {
-    return metaStore.srcInbackup(src);
+    return metaStore.srcInBackup(src);
   }
 
   //Todo: should update mtime? atime?

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
@@ -451,7 +451,7 @@ public class InotifyEventApplier {
   private void insertDeleteDiff(String path) throws MetaStoreException {
     // TODO: remove "/" appended in src or dest in backup_file table
     String pathWithSlash = path.endsWith("/") ? path : path + "/";
-    if (inBackup(pathWithSlash)) {
+    if (inBackup(path)) {
       List<BackUpInfo> backUpInfos = metaStore.getBackUpInfoBySrc(pathWithSlash);
       for (BackUpInfo backUpInfo : backUpInfos) {
         String destPath = pathWithSlash.replaceFirst(backUpInfo.getSrc(), backUpInfo.getDest());

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -372,7 +372,7 @@ public class CopyScheduler extends ActionSchedulerService {
 
   private void batchDirectSync() throws MetaStoreException {
     // Use 90% of check interval to batchSync
-    if (baseSyncQueue.size() == 0) {
+    if (baseSyncQueue.isEmpty()) {
       return;
     }
     LOG.debug("Base Sync size = {}", baseSyncQueue.size());
@@ -714,7 +714,7 @@ public class CopyScheduler extends ActionSchedulerService {
       }
       // Merge all existing fileDiffs into fileChains
       LOG.debug("Size of Pending diffs {}", fileDiffs.size());
-      if (fileDiffs.size() == 0 && baseSyncQueue.size() == 0) {
+      if (fileDiffs.isEmpty() && baseSyncQueue.isEmpty()) {
         LOG.debug("All Backup directories are synced");
         return;
       }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -89,12 +89,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
 
 /**
  * Operations supported for upper functions.
@@ -110,7 +109,7 @@ public class MetaStore implements CopyMetaService,
   private Map<Integer, String> mapStoragePolicyIdName = null;
   private Map<String, Integer> mapStoragePolicyNameId = null;
   private Map<String, StorageCapacity> mapStorageCapacity = null;
-  private Set<String> setBackSrc = null;
+  private Map<String, Pattern> backupSourcePatterns = null;
   private final RuleDao ruleDao;
   private final CmdletDao cmdletDao;
   private final ActionDao actionDao;
@@ -861,10 +860,11 @@ public class MetaStore implements CopyMetaService,
         BackUpInfo backUpInfo = getBackUpInfo(ruleInfo.getId());
         // Get total matched files
         if (backUpInfo != null) {
+          String src = backUpInfo.getSrc();
           detailedRuleInfo
-              .setBaseProgress(getFilesByPrefix(backUpInfo.getSrc()).size());
-          long count = fileDiffDao.getPendingDiff(backUpInfo.getSrc()).size();
-          count += fileDiffDao.getByState(backUpInfo.getSrc(), FileDiffState.RUNNING).size();
+              .setBaseProgress(getFilesByPrefix(src).size());
+          long count = fileDiffDao.getPendingDiff(src).size();
+          count += fileDiffDao.getByState(src, FileDiffState.RUNNING).size();
           if (count > detailedRuleInfo.baseProgress) {
             count = detailedRuleInfo.baseProgress;
           }
@@ -2014,17 +2014,15 @@ public class MetaStore implements CopyMetaService,
     }
   }
 
-  public boolean srcInbackup(String src) throws MetaStoreException {
-    if (setBackSrc == null) {
-      setBackSrc = new HashSet<>();
-      List<BackUpInfo> backUpInfos = listAllBackUpInfo();
-      for (BackUpInfo backUpInfo : backUpInfos) {
-        setBackSrc.add(backUpInfo.getSrc());
-      }
+  public boolean srcInBackup(String src) throws MetaStoreException {
+    if (backupSourcePatterns == null) {
+      listAllBackUpInfo().stream()
+          .map(BackUpInfo::getSrcPattern)
+          .forEach(this::addBackUpSourcePattern);
     }
     // LOG.info("Backup src = {}, setBackSrc {}", src, setBackSrc);
-    for (String srcDir : setBackSrc) {
-      if (src.startsWith(srcDir)) {
+    for (Pattern srcPattern : backupSourcePatterns.values()) {
+      if (srcPattern.matcher(src).matches()) {
         return true;
       }
     }
@@ -2061,7 +2059,7 @@ public class MetaStore implements CopyMetaService,
   public void deleteAllBackUpInfo() throws MetaStoreException {
     try {
       backUpInfoDao.deleteAll();
-      setBackSrc.clear();
+      backupSourcePatterns.clear();
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }
@@ -2073,8 +2071,8 @@ public class MetaStore implements CopyMetaService,
       BackUpInfo backUpInfo = getBackUpInfo(rid);
       if (backUpInfo != null) {
         if (backUpInfoDao.getBySrc(backUpInfo.getSrc()).size() == 1) {
-          if (setBackSrc != null) {
-            setBackSrc.remove(backUpInfo.getSrc());
+          if (backupSourcePatterns != null) {
+            backupSourcePatterns.remove(backUpInfo.getSrcPattern());
           }
         }
         backUpInfoDao.delete(rid);
@@ -2089,10 +2087,7 @@ public class MetaStore implements CopyMetaService,
       BackUpInfo backUpInfo) throws MetaStoreException {
     try {
       backUpInfoDao.insert(backUpInfo);
-      if (setBackSrc == null) {
-        setBackSrc = new HashSet<>();
-      }
-      setBackSrc.add(backUpInfo.getSrc());
+      addBackUpSourcePattern(backUpInfo.getSrcPattern());
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }
@@ -2486,5 +2481,12 @@ public class MetaStore implements CopyMetaService,
   @Override
   public void close() {
     dbPool.close();
+  }
+
+  private void addBackUpSourcePattern(String sourcePattern) {
+    if (backupSourcePatterns == null) {
+      backupSourcePatterns = new HashMap<>();
+    }
+    backupSourcePatterns.put(sourcePattern, Pattern.compile(sourcePattern));
   }
 }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -2016,6 +2016,7 @@ public class MetaStore implements CopyMetaService,
 
   public boolean srcInBackup(String src) throws MetaStoreException {
     if (backupSourcePatterns == null) {
+      backupSourcePatterns = new HashMap<>();
       listAllBackUpInfo().stream()
           .map(BackUpInfo::getSrcPattern)
           .forEach(this::addBackUpSourcePattern);

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -1696,12 +1696,14 @@ public class MetaStore implements CopyMetaService,
       if (num == 0) {
         LOG.info("The table set required by SSM does not exist. "
             + "The configured database will be formatted.");
-        formatDataBase();
+        dropAllTables();
       } else if (num < MetaStoreUtils.SSM_TABLES.size()) {
         LOG.error("One or more tables required by SSM are missing! "
             + "You can restart SSM with -format option or configure another database.");
         System.exit(1);
       }
+      // we should run migration tool on every launch to check if there are new changelogs
+      initializeDataBase();
     } catch (Exception e) {
       throw new MetaStoreException(e);
     }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultBackUpInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultBackUpInfoDao.java
@@ -110,6 +110,7 @@ public class DefaultBackUpInfoDao extends AbstractDao implements BackUpInfoDao {
     parameters.put("src", backUpInfo.getSrc());
     parameters.put("dest", backUpInfo.getDest());
     parameters.put("period", backUpInfo.getPeriod());
+    parameters.put("src_pattern", backUpInfo.getSrcPattern());
     return parameters;
   }
 
@@ -122,6 +123,7 @@ public class DefaultBackUpInfoDao extends AbstractDao implements BackUpInfoDao {
       backUpInfo.setSrc(resultSet.getString("src"));
       backUpInfo.setDest(resultSet.getString("dest"));
       backUpInfo.setPeriod(resultSet.getLong("period"));
+      backUpInfo.setSrcPattern(resultSet.getString("src_pattern"));
 
       return backUpInfo;
     }

--- a/smart-metastore/src/main/resources/db/changelog/changelog-2.add-backup-info-pattern-field.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-2.add-backup-info-pattern-field.xml
@@ -8,6 +8,16 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
         http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd">
-    <include file="db/changelog/changelog-1.init-db.xml"/>
-    <include file="db/changelog/changelog-2.add-backup-info-pattern-field.xml"/>
+    <changeSet id="2024.01.31_001" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="backup_file" columnName="src_pattern"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="backup_file">
+            <column name="src_pattern" type="VARCHAR(4096)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import static org.smartdata.utils.StringUtil.ssmPatternToRegex;
+
 public class TestMetaStore extends TestDaoBase {
   @Test
   public void testHighConcurrency() throws Exception {
@@ -739,6 +741,24 @@ public class TestMetaStore extends TestDaoBase {
     BackUpInfo backUpInfo1 = new BackUpInfo(1, "test1", "test1", 1);
     metaStore.insertBackUpInfo(backUpInfo1);
     Assert.assertTrue(metaStore.getBackUpInfo(1).equals(backUpInfo1));
+  }
+
+  @Test
+  public void testSrcInBackup() throws MetaStoreException {
+    BackUpInfo backUpInfo1 = new BackUpInfo(1, "src/", "dest/", 1,
+        ssmPatternToRegex("src/test_?/*.bin"));
+    metaStore.insertBackUpInfo(backUpInfo1);
+
+    Assert.assertFalse(metaStore.srcInBackup("src/file.bin"));
+    Assert.assertFalse(metaStore.srcInBackup("/tmp/dest/logs"));
+    Assert.assertFalse(metaStore.srcInBackup("src/another_file"));
+    Assert.assertFalse(metaStore.srcInBackup("src/test_1/another_file"));
+    Assert.assertFalse(metaStore.srcInBackup("src/test_2/another_dir/file.jpg"));
+    Assert.assertFalse(metaStore.srcInBackup("src/test_/file.bin"));
+    Assert.assertFalse(metaStore.srcInBackup("src/test_12/file.bin"));
+
+    Assert.assertTrue(metaStore.srcInBackup("src/test_3/file.bin"));
+    Assert.assertTrue(metaStore.srcInBackup("src/test_4/inner/another.bin"));
   }
 
   @Test

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
@@ -745,8 +745,8 @@ public class TestMetaStore extends TestDaoBase {
   public void testDeleteBackUpInfo() throws MetaStoreException {
     BackUpInfo backUpInfo1 = new BackUpInfo(1, "test1", "test1", 1);
     metaStore.insertBackUpInfo(backUpInfo1);
-    Assert.assertTrue(metaStore.srcInbackup("test1/dfafdsaf"));
-    Assert.assertFalse(metaStore.srcInbackup("test2"));
+    Assert.assertTrue(metaStore.srcInBackup("test1/dfafdsaf"));
+    Assert.assertFalse(metaStore.srcInBackup("test2"));
     metaStore.deleteBackUpInfo(1);
 
     Assert.assertTrue(metaStore.listAllBackUpInfo().size() == 0);

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestBackUpInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestBackUpInfoDao.java
@@ -42,6 +42,7 @@ public class TestBackUpInfoDao extends TestDaoBase {
     backUpInfo.setPeriod(1);
     backUpInfo.setDest("");
     backUpInfo.setSrc("");
+    backUpInfo.setSrcPattern("");
     backUpInfoDao.insert(backUpInfo);
 
     Assert.assertTrue(backUpInfoDao.getByRid(1).equals(backUpInfo));
@@ -83,6 +84,7 @@ public class TestBackUpInfoDao extends TestDaoBase {
     backUpInfo.setSrc("test");
     backUpInfo.setDest("test");
     backUpInfo.setPeriod(1);
+    backUpInfo.setSrcPattern("");
 
     backUpInfoDao.insert(backUpInfo);
     backUpInfoDao.update(1, 2);

--- a/smart-rule/src/main/java/org/smartdata/rule/parser/SmartRuleVisitTranslator.java
+++ b/smart-rule/src/main/java/org/smartdata/rule/parser/SmartRuleVisitTranslator.java
@@ -43,6 +43,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.smartdata.utils.StringUtil.globString2SqlLike;
+
 /** Convert SSM parse tree into internal representation. */
 public class SmartRuleVisitTranslator extends SmartRuleBaseVisitor<TreeNode> {
   private Map<String, SmartObject> objects = new HashMap<>();
@@ -801,8 +803,7 @@ public class SmartRuleVisitTranslator extends SmartRuleBaseVisitor<TreeNode> {
       if (op.length() > 0) {
         String ropStr = rop.getRet();
         if (optype == OperatorType.MATCHES) {
-          ropStr = ropStr.replace("*", "%");
-          ropStr = ropStr.replace("?", "_");
+          ropStr = globString2SqlLike(ropStr);
         }
 
         if (bEflag && !procAcc) {

--- a/smart-rule/src/main/java/org/smartdata/rule/parser/SmartRuleVisitTranslator.java
+++ b/smart-rule/src/main/java/org/smartdata/rule/parser/SmartRuleVisitTranslator.java
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.smartdata.utils.StringUtil.globString2SqlLike;
+import static org.smartdata.utils.StringUtil.ssmPatternToSqlLike;
 
 /** Convert SSM parse tree into internal representation. */
 public class SmartRuleVisitTranslator extends SmartRuleBaseVisitor<TreeNode> {
@@ -803,7 +803,7 @@ public class SmartRuleVisitTranslator extends SmartRuleBaseVisitor<TreeNode> {
       if (op.length() > 0) {
         String ropStr = rop.getRet();
         if (optype == OperatorType.MATCHES) {
-          ropStr = globString2SqlLike(ropStr);
+          ropStr = ssmPatternToSqlLike(ropStr);
         }
 
         if (bEflag && !procAcc) {


### PR DESCRIPTION
- Fixed bug, when the `sync` action src path pattern's base directory was used for matching files to backup instead of using the pattern itself.
- Enhanced the `InotifyEventApplier` to properly support regex during check whether we need to backup incoming file. Before these changes simple path prefix check was used - SSM tested if the incoming file is located in one of the backup directories.
- Enabled db schema manager (Liquibase) invocation on each SSM server start to iteratively apply new changelogs, if any.