### PR TITLE
[ADH-4064] Preserve file attributes in sync and distcp actions

### DIFF
--- a/smart-action/src/main/java/org/smartdata/action/SyncAction.java
+++ b/smart-action/src/main/java/org/smartdata/action/SyncAction.java
@@ -27,13 +27,16 @@ import org.smartdata.action.annotation.ActionSignature;
 @ActionSignature(
     actionId = "sync",
     displayName = "sync",
-    usage = SyncAction.SRC + " $src" + SyncAction.DEST + " $dest"
+    usage = SyncAction.SRC + " $src "
+        + SyncAction.DEST + " $dest "
+        + SyncAction.PRESERVE + " $attributes"
 )
 public class SyncAction extends SmartAction {
   // related to fileDiff.src
   public static final String SRC = "-src";
   // related to remote cluster and fileDiff.src
   public static final String DEST = "-dest";
+  public static final String PRESERVE = "-preserve";
 
   @Override
   protected void execute() throws Exception {

--- a/smart-common/src/main/java/org/smartdata/model/FileInfoDiff.java
+++ b/smart-common/src/main/java/org/smartdata/model/FileInfoDiff.java
@@ -23,9 +23,7 @@ import java.util.Objects;
 public class FileInfoDiff {
   private String path;
   private Long length;
-  private Boolean isdir;
   private Short blockReplication;
-  private Long blocksize;
   private Long modificationTime;
   private Long accessTime;
   private Short permission;
@@ -51,30 +49,12 @@ public class FileInfoDiff {
     return this;
   }
 
-  public Boolean getIsdir() {
-    return isdir;
-  }
-
-  public FileInfoDiff setIsdir(boolean isdir) {
-    this.isdir = isdir;
-    return this;
-  }
-
   public Short getBlockReplication() {
     return blockReplication;
   }
 
   public FileInfoDiff setBlockReplication(Short blockReplication) {
     this.blockReplication = blockReplication;
-    return this;
-  }
-
-  public Long getBlocksize() {
-    return blocksize;
-  }
-
-  public FileInfoDiff setBlocksize(Long blocksize) {
-    this.blocksize = blocksize;
     return this;
   }
 
@@ -143,9 +123,7 @@ public class FileInfoDiff {
     FileInfoDiff that = (FileInfoDiff) o;
     return Objects.equals(path, that.path)
         && Objects.equals(length, that.length)
-        && Objects.equals(isdir, that.isdir)
         && Objects.equals(blockReplication, that.blockReplication)
-        && Objects.equals(blocksize, that.blocksize)
         && Objects.equals(modificationTime, that.modificationTime)
         && Objects.equals(accessTime, that.accessTime)
         && Objects.equals(permission, that.permission)
@@ -156,8 +134,8 @@ public class FileInfoDiff {
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, length, isdir, blockReplication,
-        blocksize, modificationTime, accessTime, permission, owner, group, erasureCodingPolicy);
+    return Objects.hash(path, length, blockReplication,
+        modificationTime, accessTime, permission, owner, group, erasureCodingPolicy);
   }
 
   @Override
@@ -165,9 +143,7 @@ public class FileInfoDiff {
     return "FileInfoDiff{"
         + "path='" + path + '\''
         + ", length=" + length
-        + ", isdir=" + isdir
         + ", blockReplication=" + blockReplication
-        + ", blocksize=" + blocksize
         + ", modificationTime=" + modificationTime
         + ", accessTime=" + accessTime
         + ", permission=" + permission

--- a/smart-common/src/main/java/org/smartdata/model/FileInfoDiff.java
+++ b/smart-common/src/main/java/org/smartdata/model/FileInfoDiff.java
@@ -20,7 +20,7 @@ package org.smartdata.model;
 
 import java.util.Objects;
 
-public class FileInfoUpdate {
+public class FileInfoDiff {
   private String path;
   private Long length;
   private Boolean isdir;
@@ -37,7 +37,7 @@ public class FileInfoUpdate {
     return path;
   }
 
-  public FileInfoUpdate setPath(String path) {
+  public FileInfoDiff setPath(String path) {
     this.path = path;
     return this;
   }
@@ -46,7 +46,7 @@ public class FileInfoUpdate {
     return length;
   }
 
-  public FileInfoUpdate setLength(long length) {
+  public FileInfoDiff setLength(Long length) {
     this.length = length;
     return this;
   }
@@ -55,7 +55,7 @@ public class FileInfoUpdate {
     return isdir;
   }
 
-  public FileInfoUpdate setIsdir(boolean isdir) {
+  public FileInfoDiff setIsdir(boolean isdir) {
     this.isdir = isdir;
     return this;
   }
@@ -64,7 +64,7 @@ public class FileInfoUpdate {
     return blockReplication;
   }
 
-  public FileInfoUpdate setBlockReplication(short blockReplication) {
+  public FileInfoDiff setBlockReplication(Short blockReplication) {
     this.blockReplication = blockReplication;
     return this;
   }
@@ -73,7 +73,7 @@ public class FileInfoUpdate {
     return blocksize;
   }
 
-  public FileInfoUpdate setBlocksize(long blocksize) {
+  public FileInfoDiff setBlocksize(Long blocksize) {
     this.blocksize = blocksize;
     return this;
   }
@@ -82,7 +82,7 @@ public class FileInfoUpdate {
     return modificationTime;
   }
 
-  public FileInfoUpdate setModificationTime(long modificationTime) {
+  public FileInfoDiff setModificationTime(Long modificationTime) {
     this.modificationTime = modificationTime;
     return this;
   }
@@ -91,7 +91,7 @@ public class FileInfoUpdate {
     return accessTime;
   }
 
-  public FileInfoUpdate setAccessTime(long accessTime) {
+  public FileInfoDiff setAccessTime(Long accessTime) {
     this.accessTime = accessTime;
     return this;
   }
@@ -100,7 +100,7 @@ public class FileInfoUpdate {
     return permission;
   }
 
-  public FileInfoUpdate setPermission(short permission) {
+  public FileInfoDiff setPermission(Short permission) {
     this.permission = permission;
     return this;
   }
@@ -109,7 +109,7 @@ public class FileInfoUpdate {
     return owner;
   }
 
-  public FileInfoUpdate setOwner(String owner) {
+  public FileInfoDiff setOwner(String owner) {
     this.owner = owner;
     return this;
   }
@@ -118,7 +118,7 @@ public class FileInfoUpdate {
     return group;
   }
 
-  public FileInfoUpdate setGroup(String group) {
+  public FileInfoDiff setGroup(String group) {
     this.group = group;
     return this;
   }
@@ -127,7 +127,7 @@ public class FileInfoUpdate {
     return erasureCodingPolicy;
   }
 
-  public FileInfoUpdate setErasureCodingPolicy(byte erasureCodingPolicy) {
+  public FileInfoDiff setErasureCodingPolicy(Byte erasureCodingPolicy) {
     this.erasureCodingPolicy = erasureCodingPolicy;
     return this;
   }
@@ -140,7 +140,7 @@ public class FileInfoUpdate {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    FileInfoUpdate that = (FileInfoUpdate) o;
+    FileInfoDiff that = (FileInfoDiff) o;
     return Objects.equals(path, that.path)
         && Objects.equals(length, that.length)
         && Objects.equals(isdir, that.isdir)
@@ -162,7 +162,7 @@ public class FileInfoUpdate {
 
   @Override
   public String toString() {
-    return "FileInfoUpdate{"
+    return "FileInfoDiff{"
         + "path='" + path + '\''
         + ", length=" + length
         + ", isdir=" + isdir

--- a/smart-common/src/main/java/org/smartdata/utils/ConfigUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/ConfigUtil.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.utils;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.smartdata.SmartConstants.DISTRIBUTED_FILE_SYSTEM;
+import static org.smartdata.SmartConstants.FS_HDFS_IMPL;
+import static org.smartdata.SmartConstants.SMART_FILE_SYSTEM;
+
+public class ConfigUtil {
+  public static Configuration toRemoteClusterConfig(Configuration configuration) {
+    Configuration remoteConfig = new Configuration(configuration);
+    if (SMART_FILE_SYSTEM.equals(remoteConfig.get(FS_HDFS_IMPL))) {
+      remoteConfig.set(FS_HDFS_IMPL, DISTRIBUTED_FILE_SYSTEM);
+    }
+
+    return remoteConfig;
+  }
+}

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
@@ -44,8 +44,8 @@ import java.util.StringJoiner;
 import static org.smartdata.utils.StringUtil.ssmPatternsToRegex;
 
 public class FileCopyDrPlugin implements RuleExecutorPlugin {
-  private MetaStore metaStore;
-  private Map<Long, List<BackUpInfo>> backups = new HashMap<>();
+  private final MetaStore metaStore;
+  private final Map<Long, List<BackUpInfo>> backups = new HashMap<>();
   private static final Logger LOG =
       LoggerFactory.getLogger(FileCopyDrPlugin.class.getName());
 
@@ -180,7 +180,7 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
     }
 
     for (String attribute: rawPreserveArg.split(",")) {
-      CopyFileAction.PreserveAttribute.fromOption(attribute);
+      CopyFileAction.PreserveAttribute.validate(attribute);
     }
   }
 }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopyDrPlugin.java
@@ -17,10 +17,11 @@
  */
 package org.smartdata.server.engine.rule;
 
-
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.action.SyncAction;
+import org.smartdata.hdfs.action.CopyFileAction;
 import org.smartdata.metastore.MetaStore;
 import org.smartdata.metastore.MetaStoreException;
 import org.smartdata.model.BackUpInfo;
@@ -63,6 +64,9 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
     CmdletDescriptor des = tResult.getCmdDescriptor();
     for (int i = 0; i < des.getActionSize(); i++) {
       if (des.getActionName(i).equals("sync")) {
+        String rawPreserveArg = des.getActionArgs(i).get(SyncAction.PRESERVE);
+        // fail fast if preserve arg is not valid
+        validatePreserveArg(rawPreserveArg);
 
         List<String> statements = tResult.getSqlStatements();
         String before = statements.get(statements.size() - 1);
@@ -167,6 +171,16 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
       } catch (MetaStoreException e) {
         LOG.error("Remove backup info error:" + ruleInfo, e);
       }
+    }
+  }
+
+  private void validatePreserveArg(String rawPreserveArg) {
+    if (StringUtils.isBlank(rawPreserveArg)) {
+      return;
+    }
+
+    for (String attribute: rawPreserveArg.split(",")) {
+      CopyFileAction.PreserveAttribute.fromOption(attribute);
     }
   }
 }

--- a/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MultiClusterHarness.java
+++ b/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MultiClusterHarness.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSClient;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.smartdata.hdfs.MultiClusterHarness.TestType.INTER_CLUSTER;
+import static org.smartdata.hdfs.MultiClusterHarness.TestType.INTRA_CLUSTER;
+
+/**
+ * A MiniCluster for action test.
+ */
+@RunWith(Parameterized.class)
+public abstract class MultiClusterHarness extends MiniClusterHarness {
+
+  public enum TestType {
+    INTRA_CLUSTER,
+    INTER_CLUSTER
+  }
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Parameterized.Parameter()
+  public TestType testType;
+
+  protected MiniDFSCluster anotherCluster;
+  protected DistributedFileSystem anotherDfs;
+  protected DFSClient anotherDfsClient;
+
+  @Parameterized.Parameters(name = "Test type - {0}")
+  public static Object[] parameters() {
+    return new Object[] {INTRA_CLUSTER, INTER_CLUSTER};
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    if (testType == INTRA_CLUSTER) {
+      anotherDfs = dfs;
+      anotherDfsClient = dfsClient;
+      return;
+    }
+    Configuration clusterConfig = new Configuration(smartContext.getConf());
+    clusterConfig.set("hdfs.minidfs.basedir", tmpFolder.newFolder().getAbsolutePath());
+    anotherCluster = createCluster(clusterConfig);
+    anotherDfs = anotherCluster.getFileSystem();
+    anotherDfsClient = anotherDfs.getClient();
+  }
+
+  @After
+  public void shutdown() throws IOException {
+    if (anotherCluster != null) {
+      anotherCluster.shutdown(true);
+    }
+  }
+
+  protected Path anotherClusterPath(String parent, String child) {
+    return anotherDfs.makeQualified(new Path(parent, child));
+  }
+
+  protected String pathToActionArg(Path path) {
+    return testType == TestType.INTER_CLUSTER ? path.toString() : path.toUri().getPath();
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
@@ -273,7 +273,7 @@ public class CopyFileAction extends HdfsAction {
       fileInfoDiff.setModificationTime(srcFileStatus.getModificationTime());
     }
 
-    MetaDataAction.changeFileMetadata(destPath, fileInfoDiff, dfsClient, conf);
+    MetaDataAction.changeFileMetadata(destPath, fileInfoDiff, conf);
     appendLog("Successfully transferred file attributes: " + preserveAttributes);
   }
 
@@ -296,6 +296,10 @@ public class CopyFileAction extends HdfsAction {
           .findFirst()
           .orElseThrow(() ->
               new IllegalArgumentException("Wrong preserve attribute: " + option));
+    }
+
+    public static void validate(String option) {
+      fromOption(option);
     }
 
     @Override

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DistCpAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DistCpAction.java
@@ -46,7 +46,10 @@ public class DistCpAction extends HdfsAction {
   public static final String TARGET_ARG = "-target";
   public static final String SOURCE_PATH_LIST_FILE = "-f";
 
+  // preserve file owner, group and permissions by default
+  private static final String PRESERVE_DISTCP_OPTION_DEFAULT = "-pugp";
   private static final String SOURCE_PATHS_DELIMITER = ",";
+  private static final String PRESERVE_DISTCP_OPTION_PREFIX = "-p";
 
   private String sourcePaths;
 
@@ -64,6 +67,10 @@ public class DistCpAction extends HdfsAction {
     distCpArgs = new HashMap<>(args);
     distCpArgs.remove(FILE_PATH);
     distCpArgs.remove(TARGET_ARG);
+
+    if (!containsPreserveOption(args)) {
+      distCpArgs.put(PRESERVE_DISTCP_OPTION_DEFAULT, "");
+    }
   }
 
   @Override
@@ -124,6 +131,12 @@ public class DistCpAction extends HdfsAction {
       return Stream.of(key);
     }
     return Stream.of(key, value);
+  }
+
+  private boolean containsPreserveOption(Map<String, String> args) {
+    return args.keySet()
+        .stream()
+        .anyMatch(option -> option.startsWith(PRESERVE_DISTCP_OPTION_PREFIX));
   }
 
   /** Used to gracefully close MapReduce job (MR Job is not AutoCloseable inheritor in Hadoop 2.7) */

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MetaDataAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MetaDataAction.java
@@ -75,7 +75,7 @@ public class MetaDataAction extends HdfsAction {
     }
 
     if (args.containsKey(PERMISSION)) {
-      fileInfoDiff.setPermission(new FsPermission(args.get(PERMISSION)).toShort());
+      fileInfoDiff.setPermission(Short.parseShort(args.get(PERMISSION)));
     }
   }
 

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
@@ -33,7 +33,7 @@ import org.smartdata.model.BackUpInfo;
 import org.smartdata.model.FileDiff;
 import org.smartdata.model.FileDiffType;
 import org.smartdata.model.FileInfo;
-import org.smartdata.model.FileInfoUpdate;
+import org.smartdata.model.FileInfoDiff;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -218,10 +218,10 @@ public class InotifyEventApplier {
         metaStore.insertFileDiff(fileDiff);
       }
     }
-    FileInfoUpdate fileInfoUpdate = new FileInfoUpdate()
+    FileInfoDiff fileInfoDiff = new FileInfoDiff()
         .setLength(closeEvent.getFileSize())
         .setModificationTime(closeEvent.getTimestamp());
-    metaStore.updateFileByPath(closeEvent.getPath(), fileInfoUpdate);
+    metaStore.updateFileByPath(closeEvent.getPath(), fileInfoDiff);
   }
 
   //Todo: should update mtime? atime?
@@ -333,7 +333,7 @@ public class InotifyEventApplier {
       fileDiff = new FileDiff(FileDiffType.METADATA);
       fileDiff.setSrc(metadataUpdateEvent.getPath());
     }
-    FileInfoUpdate fileInfoUpdate = new FileInfoUpdate();
+    FileInfoDiff fileInfoUpdate = new FileInfoDiff();
     switch (metadataUpdateEvent.getMetadataType()) {
       case TIMES:
         if (metadataUpdateEvent.getMtime() > 0) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.smartdata.SmartContext;
 import org.smartdata.action.SyncAction;
 import org.smartdata.conf.SmartConfKeys;
+import org.smartdata.hdfs.action.CopyFileAction;
 import org.smartdata.hdfs.action.HdfsAction;
 import org.smartdata.metastore.MetaStore;
 import org.smartdata.metastore.MetaStoreException;
@@ -149,6 +150,7 @@ public class CopyScheduler extends ActionSchedulerService {
     String srcDir = action.getArgs().get(SyncAction.SRC);
     String path = action.getArgs().get(HdfsAction.FILE_PATH);
     String destDir = action.getArgs().get(SyncAction.DEST);
+    String preserveAttributes = action.getArgs().get(SyncAction.PRESERVE);
     String destPath = path.replaceFirst(srcDir, destDir);
     // Check again to avoid corner cases
     long did = fileDiffChainMap.get(path).getHead();
@@ -192,6 +194,9 @@ public class CopyScheduler extends ActionSchedulerService {
       case APPEND:
         action.setActionType("copy");
         action.getArgs().put("-dest", destPath);
+        if (preserveAttributes != null) {
+          action.getArgs().put(CopyFileAction.PRESERVE, preserveAttributes);
+        }
         if (rateLimiter != null) {
           String strLen = fileDiff.getParameters().get("-length");
           if (strLen != null) {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -54,9 +54,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.smartdata.SmartConstants.DISTRIBUTED_FILE_SYSTEM;
-import static org.smartdata.SmartConstants.FS_HDFS_IMPL;
-import static org.smartdata.SmartConstants.SMART_FILE_SYSTEM;
+import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
 
 public class CopyScheduler extends ActionSchedulerService {
   static final Logger LOG =
@@ -418,11 +416,7 @@ public class CopyScheduler extends ActionSchedulerService {
       // We simply use local HDFS conf for getting remote file system.
       // The smart file system configured for local HDFS should not be
       // introduced to remote file system.
-      Configuration remoteConf = new Configuration(conf);
-      if (remoteConf.get(FS_HDFS_IMPL, "").equals(
-          SMART_FILE_SYSTEM)) {
-        remoteConf.set(FS_HDFS_IMPL, DISTRIBUTED_FILE_SYSTEM);
-      }
+      Configuration remoteConf = toRemoteClusterConfig(conf);
       fs = FileSystem.get(URI.create(dirName), remoteConf);
       tmpFileStatus = fs.listStatus(new Path(dirName));
       for (FileStatus fileStatus : tmpFileStatus) {

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyFileAction.java
@@ -19,25 +19,20 @@ package org.smartdata.hdfs.action;
 
 import com.google.common.collect.Sets;
 import java.io.IOException;
-import java.net.URI;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.smartdata.hdfs.MiniClusterHarness;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.smartdata.hdfs.MultiClusterHarness;
 
 import static org.smartdata.hdfs.action.CopyFileAction.PreserveAttribute.MODIFICATION_TIME;
 import static org.smartdata.hdfs.action.CopyFileAction.PreserveAttribute.OWNER;
@@ -46,39 +41,23 @@ import static org.smartdata.hdfs.action.CopyFileAction.PreserveAttribute.REPLICA
 /**
  * Test for CopyFileAction.
  */
-@RunWith(Parameterized.class)
-public class TestCopyFileAction extends MiniClusterHarness {
+public class TestCopyFileAction extends MultiClusterHarness {
 
   private static final String FILE_TO_COPY_CONTENT = "testContent 112";
 
-  @Parameterized.Parameter()
-  public boolean isRemoteCopy;
-
-  private String pathPrefix;
-
-  @Parameterized.Parameters(name = "Remote copy - {0}")
-  public static Object[] parameters() {
-    return new Object[] {true, false};
-  }
-
-  @Before
-  public void setUp() {
-    pathPrefix = isRemoteCopy ? dfs.getUri().toString() : "";
-  }
-
-  private void copyFile(String src, String dest, long length,
+  private void copyFile(Path src, Path dest, long length,
       long offset) throws Exception {
     copyFile(src, dest, length, offset, Collections.emptySet());
   }
 
-  private void copyFile(String src, String dest, long length,
+  private void copyFile(Path src, Path dest, long length,
       long offset, Set<CopyFileAction.PreserveAttribute> preserveAttributes) throws Exception {
     CopyFileAction copyFileAction = new CopyFileAction();
     copyFileAction.setDfsClient(dfsClient);
     copyFileAction.setContext(smartContext);
     Map<String, String> args = new HashMap<>();
-    args.put(CopyFileAction.FILE_PATH, src);
-    args.put(CopyFileAction.DEST_PATH, dest);
+    args.put(CopyFileAction.FILE_PATH, src.toUri().getPath());
+    args.put(CopyFileAction.DEST_PATH, pathToActionArg(dest));
     args.put(CopyFileAction.LENGTH, "" + length);
     args.put(CopyFileAction.OFFSET_INDEX, "" + offset);
 
@@ -96,80 +75,56 @@ public class TestCopyFileAction extends MiniClusterHarness {
 
   @Test
   public void testFileCopy() throws Exception {
-    final String srcPath = "/testCopy";
-    final String file1 = "file1";
-    final String destPath = pathPrefix + "/backup";
-    Path srcDir = new Path(srcPath);
-    dfs.mkdirs(srcDir);
-    dfs.mkdirs(new Path(destPath));
-    // write to DISK
-    final FSDataOutputStream out1 = dfs.create(new Path(srcPath + "/" + file1));
-    out1.writeChars("testCopy1");
-    out1.close();
-    copyFile(srcPath + "/" + file1, destPath + "/" + file1, 0, 0);
-    // Check if file exists
-    Assert.assertTrue(dfsClient.exists("/backup/" + file1));
-    final FSDataInputStream in1 = dfs.open(new Path(destPath + "/" + file1));
-    StringBuilder readString = new StringBuilder();
-    for (int i = 0; i < 9; i++) {
-      readString.append(in1.readChar());
-    }
-    Assert.assertTrue(readString.toString().equals("testCopy1"));
+    Path srcPath = new Path("/testCopy/file1");
+    Path destPath = anotherClusterPath("/backup", srcPath.getName());
+
+    DFSTestUtil.writeFile(dfs, srcPath, "testCopy1");
+
+    copyFile(srcPath, destPath, 0, 0);
+
+    assertFileContent(destPath, "testCopy1");
   }
 
   @Test
   public void testCopyWithOffset() throws Exception {
-    final String srcPath = "/testCopy";
-    final String file1 = "file1";
-    final String destPath = pathPrefix + "/backup";
-    dfs.mkdirs(new Path(srcPath));
-    dfs.mkdirs(new Path(destPath));
-    // write to DISK
-    final FSDataOutputStream out1 = dfs.create(new Path(srcPath + "/" + file1));
-    for (int i = 0; i < 50; i++) {
-      out1.writeByte(1);
-    }
-    for (int i = 0; i < 50; i++) {
-      out1.writeByte(2);
-    }
-    out1.close();
-    copyFile(srcPath + "/" + file1, destPath + "/" + file1, 50, 50);
-    // Check if file exists
-    Assert.assertTrue(dfsClient.exists("/backup/" + file1));
-    final FSDataInputStream in1 = dfs.open(new Path(destPath + "/" + file1));
-    for (int i = 0; i < 50; i++) {
-      Assert.assertTrue(in1.readByte() == 2);
-    }
+    Path srcPath = new Path("/testCopy/testCopyWithOffset");
+    Path destPath = anotherClusterPath("/backup", srcPath.getName());
+
+    byte[] srcFileContent = {0, 1, 2, 3, 4, 5, 6, 7};
+    DFSTestUtil.writeFile(dfs, srcPath, srcFileContent);
+
+    copyFile(srcPath, destPath, 4, 4);
+
+    Assert.assertTrue(anotherDfs.exists(destPath));
+
+    byte[] actualDestContent = DFSTestUtil.readFileAsBytes(anotherDfs, destPath);
+    byte[] expectedDestContent = Arrays.copyOfRange(srcFileContent, 4, srcFileContent.length);
+    Assert.assertArrayEquals(expectedDestContent, actualDestContent);
   }
 
   @Test
   public void testAppend() throws Exception {
-    final String srcPath = "/testCopy";
-    final String file1 = "file1";
-    final String destPath = pathPrefix + "/backup";
-    dfs.mkdirs(new Path(srcPath));
-    dfs.mkdirs(new Path(destPath));
-    // write to DISK
-    DFSTestUtil.createFile(dfs, new Path(srcPath + "/" + file1), 100, (short) 3,
-        0xFEED);
-    DFSTestUtil.createFile(dfs, new Path(destPath + "/" + file1), 50, (short) 3,
-        0xFEED);
-    copyFile(srcPath + "/" + file1, destPath + "/" + file1, 50, 50);
-    // Check if file exists
-    Assert.assertTrue(dfsClient.exists("/backup/" + file1));
-    FileStatus fileStatus = dfs.getFileStatus(new Path(destPath + "/" + file1));
-    Assert.assertEquals(100, fileStatus.getLen());
+    Path srcPath = new Path("/testCopy/testAppend");
+    Path destPath = anotherClusterPath("/backup", srcPath.getName());
+
+    DFSTestUtil.createFile(dfs, srcPath, 100, (short) 3, 0xFEED);
+    DFSTestUtil.createFile(anotherDfs, destPath, 50, (short) 3, 0xFEED);
+
+    copyFile(srcPath, destPath, 50, 50);
+
+    Assert.assertTrue(anotherDfs.exists(destPath));
+    Assert.assertEquals(100, anotherDfs.getFileStatus(destPath).getLen());
   }
 
   @Test
   public void testPreserveAllAttributes() throws Exception {
-    Path srcFilePath = createFileWithAttributes("/test/src/fileToCopy");
-    String destPath = pathPrefix + "/dest/fileToCopy";
+    Path srcPath = createFileWithAttributes("/test/src/fileToCopy");
+    Path destPath = anotherClusterPath("/dest", srcPath.getName());
 
-    Path copiedFilePath = copyFileWithAttributes(srcFilePath, destPath,
+    copyFileWithAttributes(srcPath, destPath,
         Sets.newHashSet(CopyFileAction.PreserveAttribute.values()));
 
-    FileStatus destFileStatus = dfs.getFileStatus(copiedFilePath);
+    FileStatus destFileStatus = anotherDfs.getFileStatus(destPath);
     Assert.assertEquals(new FsPermission("777"), destFileStatus.getPermission());
     Assert.assertEquals("newUser", destFileStatus.getOwner());
     Assert.assertEquals("newGroup", destFileStatus.getGroup());
@@ -179,13 +134,13 @@ public class TestCopyFileAction extends MiniClusterHarness {
 
   @Test
   public void testPreserveSomeAttributes() throws Exception {
-    Path srcFilePath = createFileWithAttributes("/test/src/fileToCopy");
-    String destPath = pathPrefix + "/dest/fileToCopy";
+    Path srcPath = createFileWithAttributes("/test/src/anotherFileToCopy");
+    Path destPath = anotherClusterPath("/dest", srcPath.getName());
 
-    Path copiedFilePath = copyFileWithAttributes(srcFilePath, destPath,
+    copyFileWithAttributes(srcPath, destPath,
         Sets.newHashSet(OWNER, MODIFICATION_TIME, REPLICATION_NUMBER));
 
-    FileStatus destFileStatus = dfs.getFileStatus(copiedFilePath);
+    FileStatus destFileStatus = anotherDfs.getFileStatus(destPath);
     Assert.assertEquals("newUser", destFileStatus.getOwner());
     Assert.assertEquals(0L, destFileStatus.getModificationTime());
     Assert.assertEquals(2, destFileStatus.getReplication());
@@ -195,11 +150,8 @@ public class TestCopyFileAction extends MiniClusterHarness {
 
   private Path createFileWithAttributes(String path) throws IOException {
     Path srcFilePath = new Path(path);
-    dfs.mkdirs(srcFilePath.getParent());
 
-    try (FSDataOutputStream srcOutStream = dfs.create(srcFilePath)) {
-      srcOutStream.writeUTF(FILE_TO_COPY_CONTENT);
-    }
+    DFSTestUtil.writeFile(dfs, srcFilePath, FILE_TO_COPY_CONTENT);
 
     FsPermission newPermission = new FsPermission("777");
     dfs.setOwner(srcFilePath, "newUser", "newGroup");
@@ -210,19 +162,15 @@ public class TestCopyFileAction extends MiniClusterHarness {
     return srcFilePath;
   }
 
-  private Path copyFileWithAttributes(Path srcFilePath, String destPath,
+  private void copyFileWithAttributes(Path srcFilePath, Path destPath,
       Set<CopyFileAction.PreserveAttribute> preserveAttributes) throws Exception {
+    copyFile(srcFilePath, destPath, 0, 0, preserveAttributes);
+    assertFileContent(destPath, FILE_TO_COPY_CONTENT);
+  }
 
-    copyFile(srcFilePath.toUri().getPath(), destPath,
-        0, 0, preserveAttributes);
-    Assert.assertTrue(dfsClient.exists(URI.create(destPath).getPath()));
-
-    Path destFilePath = new Path(destPath);
-    try (FSDataInputStream destInputStream = dfs.open(destFilePath)) {
-      String actualContent = destInputStream.readUTF();
-      Assert.assertEquals(FILE_TO_COPY_CONTENT, actualContent);
-    }
-
-    return destFilePath;
+  private void assertFileContent(Path filePath, String expectedContent) throws Exception {
+    Assert.assertTrue(anotherDfs.exists(filePath));
+    String actualContent = DFSTestUtil.readFile(anotherDfs, filePath);
+    Assert.assertEquals(expectedContent, actualContent);
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyFileAction.java
@@ -17,25 +17,62 @@
 */
 package org.smartdata.hdfs.action;
 
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.smartdata.hdfs.MiniClusterHarness;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.smartdata.hdfs.action.CopyFileAction.PreserveAttribute.GROUP;
+import static org.smartdata.hdfs.action.CopyFileAction.PreserveAttribute.OWNER;
+import static org.smartdata.hdfs.action.CopyFileAction.PreserveAttribute.PERMISSIONS;
+
 /**
  * Test for CopyFileAction.
  */
+@RunWith(Parameterized.class)
 public class TestCopyFileAction extends MiniClusterHarness {
+
+  private static final String FILE_TO_COPY_CONTENT = "testContent 112";
+
+  @Parameterized.Parameter()
+  public boolean isRemoteCopy;
+
+  private String pathPrefix;
+
+  @Before
+  public void setUp() {
+    pathPrefix = isRemoteCopy ? dfs.getUri().toString() : "";
+  }
+
+  @Parameterized.Parameters(name = "Remote copy - {0}")
+  public static Object[] parameters() {
+    return new Object[] {true, false};
+  }
 
   private void copyFile(String src, String dest, long length,
       long offset) throws Exception {
+    copyFile(src, dest, length, offset, Collections.emptySet());
+  }
+
+  private void copyFile(String src, String dest, long length,
+      long offset, Set<CopyFileAction.PreserveAttribute> preserveAttributes) throws Exception {
     CopyFileAction copyFileAction = new CopyFileAction();
     copyFileAction.setDfsClient(dfsClient);
     copyFileAction.setContext(smartContext);
@@ -44,16 +81,24 @@ public class TestCopyFileAction extends MiniClusterHarness {
     args.put(CopyFileAction.DEST_PATH, dest);
     args.put(CopyFileAction.LENGTH, "" + length);
     args.put(CopyFileAction.OFFSET_INDEX, "" + offset);
+
+    if (!preserveAttributes.isEmpty()) {
+      String attributesOption = preserveAttributes.stream()
+          .map(Object::toString)
+          .collect(Collectors.joining(","));
+      args.put(CopyFileAction.PRESERVE, attributesOption);
+    }
+
     copyFileAction.init(args);
     copyFileAction.run();
     Assert.assertTrue(copyFileAction.getExpectedAfterRun());
   }
 
-  /*@Test
-  public void testLocalFileCopy() throws Exception {
+  @Test
+  public void testFileCopy() throws Exception {
     final String srcPath = "/testCopy";
     final String file1 = "file1";
-    final String destPath = "/backup";
+    final String destPath = pathPrefix + "/backup";
     Path srcDir = new Path(srcPath);
     dfs.mkdirs(srcDir);
     dfs.mkdirs(new Path(destPath));
@@ -63,30 +108,6 @@ public class TestCopyFileAction extends MiniClusterHarness {
     out1.close();
     copyFile(srcPath + "/" + file1, destPath + "/" + file1, 0, 0);
     // Check if file exists
-    Assert.assertTrue(dfsClient.exists(destPath + "/" + file1));
-    final FSDataInputStream in1 = dfs.open(new Path(destPath + "/" + file1));
-    StringBuilder readString = new StringBuilder();
-    for (int i = 0; i < 9; i++) {
-      readString.append(in1.readChar());
-    }
-    Assert.assertTrue(readString.toString().equals("testCopy1"));
-  }*/
-
-  @Test
-  public void testRemoteFileCopy() throws Exception {
-    final String srcPath = "/testCopy";
-    final String file1 = "file1";
-    // Destination with "hdfs" prefix
-    final String destPath = dfs.getUri() + "/backup";
-    dfs.mkdirs(new Path(srcPath));
-    dfs.mkdirs(new Path(destPath));
-    // write to DISK
-    final FSDataOutputStream out1 = dfs.create(new Path(srcPath + "/" + file1));
-    out1.writeChars("testCopy1");
-    out1.close();
-
-    copyFile(srcPath + "/" + file1, destPath + "/" + file1, 0, 0);
-    // Check if file exists
     Assert.assertTrue(dfsClient.exists("/backup/" + file1));
     final FSDataInputStream in1 = dfs.open(new Path(destPath + "/" + file1));
     StringBuilder readString = new StringBuilder();
@@ -97,11 +118,10 @@ public class TestCopyFileAction extends MiniClusterHarness {
   }
 
   @Test
-  public void testRmoteCopyWithOffset() throws Exception {
+  public void testCopyWithOffset() throws Exception {
     final String srcPath = "/testCopy";
     final String file1 = "file1";
-    // Destination with "hdfs" prefix
-    final String destPath = dfs.getUri() + "/backup";
+    final String destPath = pathPrefix + "/backup";
     dfs.mkdirs(new Path(srcPath));
     dfs.mkdirs(new Path(destPath));
     // write to DISK
@@ -122,38 +142,11 @@ public class TestCopyFileAction extends MiniClusterHarness {
     }
   }
 
-  /*@Test
-  public void testLocalCopyWithOffset() throws Exception {
-    final String srcPath = "/testCopy";
-    final String file1 = "file1";
-    // Destination with "hdfs" prefix
-    final String destPath = "/backup";
-    dfs.mkdirs(new Path(srcPath));
-    dfs.mkdirs(new Path(destPath));
-    // write to DISK
-    final FSDataOutputStream out1 = dfs.create(new Path(srcPath + "/" + file1));
-    for (int i = 0; i < 50; i++) {
-      out1.writeByte(1);
-    }
-    for (int i = 0; i < 50; i++) {
-      out1.writeByte(2);
-    }
-    out1.close();
-    copyFile(srcPath + "/" + file1, destPath + "/" + file1, 50, 50);
-    // Check if file exists
-    Assert.assertTrue(dfsClient.exists("/backup/" + file1));
-    final FSDataInputStream in1 = dfs.open(new Path(destPath + "/" + file1));
-    for (int i = 0; i < 50; i++) {
-      Assert.assertTrue(in1.readByte() == 2);
-    }
-  }*/
-
   @Test
-  public void testAppendRemote() throws Exception {
+  public void testAppend() throws Exception {
     final String srcPath = "/testCopy";
     final String file1 = "file1";
-    // Destination with "hdfs" prefix
-    final String destPath = dfs.getUri() + "/backup";
+    final String destPath = pathPrefix + "/backup";
     dfs.mkdirs(new Path(srcPath));
     dfs.mkdirs(new Path(destPath));
     // write to DISK
@@ -166,5 +159,63 @@ public class TestCopyFileAction extends MiniClusterHarness {
     Assert.assertTrue(dfsClient.exists("/backup/" + file1));
     FileStatus fileStatus = dfs.getFileStatus(new Path(destPath + "/" + file1));
     Assert.assertEquals(100, fileStatus.getLen());
+  }
+
+  @Test
+  public void testPreserveAllAttributes() throws Exception {
+    Path srcFilePath = createFileWithAttributes("/test/src/fileToCopy");
+    String destPath = pathPrefix + "/dest/fileToCopy";
+
+    Path copiedFilePath = copyFileWithAttributes(srcFilePath, destPath,
+        Sets.newHashSet(OWNER, GROUP, PERMISSIONS));
+
+    FileStatus destFileStatus = dfs.getFileStatus(copiedFilePath);
+    Assert.assertEquals(new FsPermission("777"), destFileStatus.getPermission());
+    Assert.assertEquals("newUser", destFileStatus.getOwner());
+    Assert.assertEquals("newGroup", destFileStatus.getGroup());
+  }
+
+  @Test
+  public void testPreserveSomeAttributes() throws Exception {
+    Path srcFilePath = createFileWithAttributes("/test/src/fileToCopy");
+    String destPath = pathPrefix + "/dest/fileToCopy";
+
+    Path copiedFilePath = copyFileWithAttributes(srcFilePath, destPath, Sets.newHashSet(OWNER));
+
+    FileStatus destFileStatus = dfs.getFileStatus(copiedFilePath);
+    Assert.assertEquals("newUser", destFileStatus.getOwner());
+    Assert.assertNotEquals(new FsPermission("777"), destFileStatus.getPermission());
+    Assert.assertNotEquals("newGroup", destFileStatus.getGroup());
+  }
+
+  private Path createFileWithAttributes(String path) throws IOException {
+    Path srcFilePath = new Path(path);
+    dfs.mkdirs(srcFilePath.getParent());
+
+    try (FSDataOutputStream srcOutStream = dfs.create(srcFilePath)) {
+      srcOutStream.writeUTF(FILE_TO_COPY_CONTENT);
+    }
+
+    FsPermission newPermission = new FsPermission("777");
+    dfs.setOwner(srcFilePath, "newUser", "newGroup");
+    dfs.setPermission(srcFilePath, newPermission);
+
+    return srcFilePath;
+  }
+
+  private Path copyFileWithAttributes(Path srcFilePath, String destPath,
+      Set<CopyFileAction.PreserveAttribute> preserveAttributes) throws Exception {
+
+    copyFile(srcFilePath.toUri().getPath(), destPath,
+        0, 0, preserveAttributes);
+    Assert.assertTrue(dfsClient.exists(URI.create(destPath).getPath()));
+
+    Path destFilePath = new Path(destPath);
+    try (FSDataInputStream destInputStream = dfs.open(destFilePath)) {
+      String actualContent = destInputStream.readUTF();
+      Assert.assertEquals(FILE_TO_COPY_CONTENT, actualContent);
+    }
+
+    return destFilePath;
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpAction.java
@@ -231,6 +231,7 @@ public class TestDistCpAction extends MiniClusterHarness {
     }
   }
 
+  // todo inherit from MultiClusterHarness
   private void testCopyToCluster(FileSystem sourceFs, FileSystem targetFs) throws Exception {
     Map<String, String> args = new HashMap<>();
     String sourcePath = sourceFs.getUri() + "/test/source/dir1";

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpAction.java
@@ -20,6 +20,7 @@ package org.smartdata.hdfs.action;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.smartdata.hdfs.MiniClusterHarness;
+
+import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.ACL;
+import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.CHECKSUMTYPE;
+import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.GROUP;
+import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.PERMISSION;
+import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.TIMES;
+import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.USER;
 
 /**
  * Test for DistCpAction.
@@ -67,6 +75,8 @@ public class TestDistCpAction extends MiniClusterHarness {
         distCpOptions.getSourcePaths());
     Assert.assertEquals(new Path("hdfs://nn2/test/target/dir1"),
         distCpOptions.getTargetPath());
+    Assert.assertEquals(EnumSet.of(USER, GROUP, PERMISSION),
+        distCpOptions.getPreserveAttributes());
   }
 
   @Test
@@ -181,6 +191,8 @@ public class TestDistCpAction extends MiniClusterHarness {
     Assert.assertEquals(16, distCpOptions.getMaxMaps());
     Assert.assertEquals("dynamic", distCpOptions.getCopyStrategy());
     Assert.assertTrue(distCpOptions.shouldSyncFolder());
+    Assert.assertEquals(EnumSet.of(CHECKSUMTYPE, ACL, TIMES),
+        distCpOptions.getPreserveAttributes());
   }
 
   @Test

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestMetaDataAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestMetaDataAction.java
@@ -17,10 +17,14 @@
  */
 package org.smartdata.hdfs.action;
 
-import org.apache.hadoop.fs.FSDataOutputStream;
+import java.io.UnsupportedEncodingException;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.smartdata.hdfs.MiniClusterHarness;
 
 import java.io.IOException;
@@ -30,58 +34,69 @@ import java.util.Map;
 /**
  * Test for MetaDataAction
  */
+@RunWith(Parameterized.class)
 public class TestMetaDataAction extends MiniClusterHarness {
 
-  @Test
-  public void testLocalMetadataChange() throws IOException {
-    final String srcPath = "/test";
-    final String file = "file";
+  @Parameterized.Parameter()
+  public boolean isRemoteCopy;
 
-    dfs.mkdirs(new Path(srcPath));
-    FSDataOutputStream out = dfs.create(new Path(srcPath + "/" + file));
-    out.close();
-
-    MetaDataAction metaFileAction = new MetaDataAction();
-    metaFileAction.setDfsClient(dfsClient);
-    metaFileAction.setContext(smartContext);
-
-    Map<String, String> args = new HashMap<>();
-    args.put(MetaDataAction.FILE_PATH, srcPath + "/" + file);
-    args.put(MetaDataAction.OWNER_NAME, "test");
-    args.put(MetaDataAction.PERMISSION, "511");
-
-    metaFileAction.init(args);
-    metaFileAction.run();
-
-    Assert.assertTrue(metaFileAction.getExpectedAfterRun());
-    Assert.assertTrue(dfs.getFileStatus(new Path(srcPath + "/" + file)).getOwner().equals("test"));
-    Assert.assertTrue(dfs.getFileStatus(new Path(srcPath + "/" + file)).getPermission().toString().equals("rwxrwxrwx"));
+  @Parameterized.Parameters(name = "Remote copy - {0}")
+  public static Object[] parameters() {
+    return new Object[] {true, false};
   }
 
   @Test
-  public void testRemoteMetadataChange() throws IOException {
-    final String srcPath = "/test";
-    final String file = "file";
+  public void testMetadataChange() throws IOException {
+    Map<String, String> args = new HashMap<>();
+    args.put(MetaDataAction.OWNER_NAME, "user");
+    args.put(MetaDataAction.GROUP_NAME, "group");
+    args.put(MetaDataAction.BLOCK_REPLICATION, "7");
+    args.put(MetaDataAction.PERMISSION, "511");
+    args.put(MetaDataAction.MTIME, "10");
 
-    dfs.mkdirs(new Path(srcPath));
-    FSDataOutputStream out = dfs.create(new Path(srcPath + "/" + file));
-    out.close();
+    FileStatus fileStatus = updateMetadata(args);
+    Assert.assertEquals("user", fileStatus.getOwner());
+    Assert.assertEquals("group", fileStatus.getGroup());
+    Assert.assertEquals(7, fileStatus.getReplication());
+    Assert.assertEquals("rwxrwxrwx", fileStatus.getPermission().toString());
+    Assert.assertEquals(10L, fileStatus.getModificationTime());
+  }
 
+  @Test
+  public void testPartialMetadataChange() throws IOException {
+    Map<String, String> args = new HashMap<>();
+    args.put(MetaDataAction.GROUP_NAME, "group");
+    args.put(MetaDataAction.BLOCK_REPLICATION, "7");
+    args.put(MetaDataAction.MTIME, "10");
+
+    FileStatus fileStatus = updateMetadata(args);
+    Assert.assertEquals("group", fileStatus.getGroup());
+    Assert.assertEquals(7, fileStatus.getReplication());
+    Assert.assertEquals(10L, fileStatus.getModificationTime());
+  }
+
+  private FileStatus updateMetadata(Map<String, String> args) throws IOException {
+    Path srcPath = new Path("/test/file");
+    DFSTestUtil.writeFile(dfs, srcPath, "data");
+
+    args.put(MetaDataAction.FILE_PATH, pathToActionArg(srcPath));
+    runAction(args);
+
+    return dfs.getFileStatus(srcPath);
+  }
+
+  private void runAction(Map<String, String> args) throws UnsupportedEncodingException {
     MetaDataAction metaFileAction = new MetaDataAction();
     metaFileAction.setDfsClient(dfsClient);
     metaFileAction.setContext(smartContext);
-
-    Map<String, String> args = new HashMap<>();
-    args.put(MetaDataAction.FILE_PATH, dfs.getUri() + srcPath + "/" + file);
-    args.put(MetaDataAction.OWNER_NAME, "test");
-    args.put(MetaDataAction.PERMISSION, "511");
 
     metaFileAction.init(args);
     metaFileAction.run();
 
     Assert.assertTrue(metaFileAction.getExpectedAfterRun());
-    Assert.assertTrue(dfs.getFileStatus(new Path(srcPath + "/" + file)).getOwner().equals("test"));
-    Assert.assertTrue(dfs.getFileStatus(new Path(srcPath + "/" + file)).getPermission().toString().equals("rwxrwxrwx"));
+  }
 
+  protected String pathToActionArg(Path path) {
+    return isRemoteCopy ? path.toString() : path.toUri().getPath();
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestMetaDataAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestMetaDataAction.java
@@ -48,7 +48,7 @@ public class TestMetaDataAction extends MiniClusterHarness {
     Map<String, String> args = new HashMap<>();
     args.put(MetaDataAction.FILE_PATH, srcPath + "/" + file);
     args.put(MetaDataAction.OWNER_NAME, "test");
-    args.put(MetaDataAction.PERMISSION, "777");
+    args.put(MetaDataAction.PERMISSION, "511");
 
     metaFileAction.init(args);
     metaFileAction.run();
@@ -74,7 +74,7 @@ public class TestMetaDataAction extends MiniClusterHarness {
     Map<String, String> args = new HashMap<>();
     args.put(MetaDataAction.FILE_PATH, dfs.getUri() + srcPath + "/" + file);
     args.put(MetaDataAction.OWNER_NAME, "test");
-    args.put(MetaDataAction.PERMISSION, "777");
+    args.put(MetaDataAction.PERMISSION, "511");
 
     metaFileAction.init(args);
     metaFileAction.run();

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -71,7 +71,7 @@ import org.smartdata.model.FileAccessInfo;
 import org.smartdata.model.FileDiff;
 import org.smartdata.model.FileDiffState;
 import org.smartdata.model.FileInfo;
-import org.smartdata.model.FileInfoUpdate;
+import org.smartdata.model.FileInfoDiff;
 import org.smartdata.model.FileState;
 import org.smartdata.model.GlobalConfig;
 import org.smartdata.model.NormalFileState;
@@ -205,7 +205,7 @@ public class MetaStore implements CopyMetaService,
     fileInfoDao.insert(files);
   }
 
-  public void updateFileByPath(String path, FileInfoUpdate fileUpdate) {
+  public void updateFileByPath(String path, FileInfoDiff fileUpdate) {
     fileInfoDao.updateByPath(path, fileUpdate);
   }
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
@@ -18,7 +18,7 @@
 package org.smartdata.metastore.dao;
 
 import org.smartdata.model.FileInfo;
-import org.smartdata.model.FileInfoUpdate;
+import org.smartdata.model.FileInfoDiff;
 
 import java.sql.SQLException;
 import java.util.Collection;
@@ -51,7 +51,7 @@ public interface FileInfoDao {
 
   int update(String path, int storagePolicy);
 
-  int updateByPath(String path, FileInfoUpdate fileUpdate);
+  int updateByPath(String path, FileInfoDiff fileUpdate);
 
   void deleteById(long fid);
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
@@ -180,7 +180,6 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
     parameters.put("path", fileInfo.getPath());
     parameters.put("length", fileInfo.getLength());
     parameters.put("block_replication", fileInfo.getBlockReplication());
-    parameters.put("block_size", fileInfo.getBlocksize());
     parameters.put("modification_time", fileInfo.getModificationTime());
     parameters.put("access_time", fileInfo.getAccessTime());
     parameters

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
@@ -20,7 +20,7 @@ package org.smartdata.metastore.dao.impl;
 import org.smartdata.metastore.dao.AbstractDao;
 import org.smartdata.metastore.dao.FileInfoDao;
 import org.smartdata.model.FileInfo;
-import org.smartdata.model.FileInfoUpdate;
+import org.smartdata.model.FileInfoDiff;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -134,7 +134,7 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
   }
 
   @Override
-  public int updateByPath(String path, FileInfoUpdate fileUpdate) {
+  public int updateByPath(String path, FileInfoDiff fileUpdate) {
     return update(updateToMap(fileUpdate), "path = ?", path);
   }
 
@@ -175,7 +175,7 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
     jdbcTemplate.update(sql, newPath, oldPath.length() + 1, oldPath + "/%");
   }
 
-  private Map<String, Object> updateToMap(FileInfoUpdate fileInfo) {
+  private Map<String, Object> updateToMap(FileInfoDiff fileInfo) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("path", fileInfo.getPath());
     parameters.put("length", fileInfo.getLength());

--- a/smart-zeppelin/zeppelin-web/src/app/dashboard/views/actions/submit/help.html
+++ b/smart-zeppelin/zeppelin-web/src/app/dashboard/views/actions/submit/help.html
@@ -235,7 +235,7 @@ limitations under the License.
     <tr>
       <td>sync</td>
       <td>-dest $dest -preserve $attributes</td>
-      <td>Sync file to $dest with is comma-separated list of the file $attributes to preserve: owner,group,permissions</td>
+      <td>Sync file to $dest with is comma-separated list of the file $attributes to preserve: owner, group, permissions, replication, modification-time.</td>
     </tr>
     <tr>
       <td>distcp</td>

--- a/smart-zeppelin/zeppelin-web/src/app/dashboard/views/actions/submit/help.html
+++ b/smart-zeppelin/zeppelin-web/src/app/dashboard/views/actions/submit/help.html
@@ -234,8 +234,8 @@ limitations under the License.
     </tr>
     <tr>
       <td>sync</td>
-      <td>-dest $dest</td>
-      <td>Sync file to $dest.</td>
+      <td>-dest $dest -preserve $attributes</td>
+      <td>Sync file to $dest with is comma-separated list of the file $attributes to preserve: owner,group,permissions</td>
     </tr>
     <tr>
       <td>distcp</td>


### PR DESCRIPTION
- Added `-preserve` option to `sync` and `copy` actions to transfer selected file attributes from the following list during copy:
  - `owner`
  - `group`
  - `permissions`
  - `replication`
  - `modification-time`
- Updated `copy` and `distcp` actions to preserve the file owner, group and permissions by default
- Refactored `metadata` action to decrease the number of network calls 