### PR TITLE
[ADH-4176] Fix unnecessary copying of files in backup directory after sync rule restart

### DIFF
--- a/smart-action/src/main/java/org/smartdata/action/SmartAction.java
+++ b/smart-action/src/main/java/org/smartdata/action/SmartAction.java
@@ -35,16 +35,16 @@ import java.util.Map;
  * are also meant to extend this.
  */
 public abstract class SmartAction {
-  static final Logger LOG = LoggerFactory.getLogger(SmartAction.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SmartAction.class);
   private long cmdletId;
   private boolean lastAction;
   private long actionId;
   private Map<String, String> actionArgs;
   private SmartContext context;
-  private ByteArrayOutputStream resultOs;
-  private PrintStream psResultOs;
-  private ByteArrayOutputStream logOs;
-  private PrintStream psLogOs;
+  private final ByteArrayOutputStream resultOutputStream;
+  private final PrintStream resultPrintStream;
+  private final ByteArrayOutputStream logOutputStream;
+  private final PrintStream logPrintStream;
   private volatile boolean successful;
   protected String name;
   private long startTime;
@@ -55,10 +55,10 @@ public abstract class SmartAction {
   public SmartAction() {
     this.successful = false;
     //Todo: extract the print stream out of this class
-    this.resultOs = new ByteArrayOutputStream(64 * 1024);
-    this.psResultOs = new PrintStream(resultOs, false);
-    this.logOs = new ByteArrayOutputStream(64 * 1024);
-    this.psLogOs = new PrintStream(logOs, false);
+    this.resultOutputStream = new ByteArrayOutputStream(64 * 1024);
+    this.resultPrintStream = new PrintStream(resultOutputStream, false);
+    this.logOutputStream = new ByteArrayOutputStream(64 * 1024);
+    this.logPrintStream = new PrintStream(logOutputStream, false);
   }
 
   public String getName() {
@@ -155,20 +155,20 @@ public abstract class SmartAction {
 
   // The result will be shown in each action's summary page.
   protected void appendResult(String result) {
-    psResultOs.println(result);
+    resultPrintStream.println(result);
   }
 
   // The log will be shown in action's submission section and summary page.
   protected void appendLog(String log) {
-    psLogOs.println(log);
+    logPrintStream.println(log);
   }
 
-  public PrintStream getResultOs() {
-    return psResultOs;
+  public PrintStream getResultOutputStream() {
+    return resultPrintStream;
   }
 
-  public PrintStream getLogOs() {
-    return psLogOs;
+  public PrintStream getLogPrintStream() {
+    return logPrintStream;
   }
 
   public float getProgress() {
@@ -184,8 +184,8 @@ public abstract class SmartAction {
         lastAction,
         actionId,
         getProgress(),
-        resultOs.toString("UTF-8"),
-        logOs.toString("UTF-8"),
+        resultOutputStream.toString("UTF-8"),
+        logOutputStream.toString("UTF-8"),
         startTime,
         finishTime,
         throwable,
@@ -193,8 +193,8 @@ public abstract class SmartAction {
   }
 
   private void stop() {
-    psLogOs.close();
-    psResultOs.close();
+    logPrintStream.close();
+    resultPrintStream.close();
   }
 
   public boolean isSuccessful() {

--- a/smart-common/src/main/java/org/smartdata/model/FileDiff.java
+++ b/smart-common/src/main/java/org/smartdata/model/FileDiff.java
@@ -91,6 +91,10 @@ public class FileDiff {
     this.parameters = parameters;
   }
 
+  public void setParameter(String key, String value) {
+    parameters.put(key, value);
+  }
+
   public String getParametersJsonString() {
     Gson gson = new Gson();
     return gson.toJson(parameters);

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MetaDataAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MetaDataAction.java
@@ -18,23 +18,11 @@
 
 package org.smartdata.hdfs.action;
 
-import java.io.IOException;
-import java.net.URI;
 import java.util.Map;
-import java.util.Optional;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.smartdata.action.annotation.ActionSignature;
-import org.smartdata.hdfs.HadoopUtil;
 import org.smartdata.model.FileInfoDiff;
-
-import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
 
 /**
  * action to set MetaData of file
@@ -48,7 +36,6 @@ import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
         MetaDataAction.ATIME + " $atime"
 )
 public class MetaDataAction extends HdfsAction {
-  private static final Logger LOG = LoggerFactory.getLogger(MetaDataAction.class);
   public static final String OWNER_NAME = "-owner";
   public static final String GROUP_NAME = "-group";
   public static final String BLOCK_REPLICATION = "-replication";
@@ -57,16 +44,16 @@ public class MetaDataAction extends HdfsAction {
   public static final String MTIME = "-mtime";
   public static final String ATIME = "-atime";
 
-  private String srcPath;
-
   private FileInfoDiff fileInfoDiff;
+
+  private UpdateFileMetadataSupport delegate;
 
   @Override
   public void init(Map<String, String> args) {
     super.init(args);
-    srcPath = args.get(FILE_PATH);
 
     fileInfoDiff = new FileInfoDiff()
+        .setPath(args.get(FILE_PATH))
         .setOwner(args.get(OWNER_NAME))
         .setGroup(args.get(GROUP_NAME))
         .setModificationTime(NumberUtils.createLong(args.get(MTIME)))
@@ -79,76 +66,17 @@ public class MetaDataAction extends HdfsAction {
     if (args.containsKey(PERMISSION)) {
       fileInfoDiff.setPermission(Short.parseShort(args.get(PERMISSION)));
     }
+
+    delegate = new UpdateFileMetadataSupport(
+        getContext().getConf(), getLogPrintStream());
   }
 
   @Override
   protected void execute() throws Exception {
-    if (srcPath == null) {
+    if (StringUtils.isBlank(fileInfoDiff.getPath())) {
       throw new IllegalArgumentException("File src is missing.");
     }
 
-    changeFileMetadata(srcPath, fileInfoDiff, getContext().getConf());
-  }
-
-  static void changeFileMetadata(String srcFile, FileInfoDiff fileInfoDiff, Configuration configuration) throws IOException {
-    try {
-      if (srcFile.startsWith("hdfs")) {
-        changeRemoteFileMetadata(srcFile, fileInfoDiff, configuration);
-        return;
-      }
-      changeLocalFileMetadata(srcFile, fileInfoDiff, configuration);
-    } catch (
-        Exception exception) {
-      LOG.error("Metadata cannot be applied", exception);
-      throw exception;
-    }
-  }
-
-  private static void changeRemoteFileMetadata(String srcFile,
-      FileInfoDiff fileInfoDiff, Configuration configuration) throws IOException {
-    FileSystem remoteFileSystem = FileSystem.get(URI.create(srcFile),
-        toRemoteClusterConfig(configuration));
-    changeFileMetadata(srcFile, fileInfoDiff, remoteFileSystem);
-  }
-
-  private static void changeLocalFileMetadata(String srcFile,
-      FileInfoDiff fileInfoDiff, Configuration configuration) throws IOException {
-    FileSystem localFileSystem = FileSystem.get(
-        HadoopUtil.getNameNodeUri(configuration), configuration);
-    changeFileMetadata(srcFile, fileInfoDiff, localFileSystem);
-  }
-
-  private static void changeFileMetadata(String srcFile,
-      FileInfoDiff fileInfoDiff, FileSystem fileSystem) throws IOException {
-    Path srcPath = new Path(srcFile);
-    FileStatus srcFileStatus = fileSystem.getFileStatus(srcPath);
-
-    String owner = Optional.ofNullable(fileInfoDiff.getOwner())
-        .orElseGet(srcFileStatus::getOwner);
-    String group = Optional.ofNullable(fileInfoDiff.getGroup())
-        .orElseGet(srcFileStatus::getGroup);
-
-    if (fileInfoDiff.getOwner() != null
-        || fileInfoDiff.getGroup() != null) {
-      fileSystem.setOwner(srcPath, owner, group);
-    }
-
-    if (fileInfoDiff.getBlockReplication() != null) {
-      fileSystem.setReplication(srcPath, fileInfoDiff.getBlockReplication());
-    }
-
-    if (fileInfoDiff.getPermission() != null) {
-      fileSystem.setPermission(srcPath, new FsPermission(fileInfoDiff.getPermission()));
-    }
-
-    long modificationTime = Optional.ofNullable(fileInfoDiff.getModificationTime())
-        .orElseGet(srcFileStatus::getModificationTime);
-    long accessTime = Optional.ofNullable(fileInfoDiff.getAccessTime())
-        .orElseGet(srcFileStatus::getAccessTime);
-
-    if (fileInfoDiff.getAccessTime() != null
-        || fileInfoDiff.getModificationTime() != null) {
-      fileSystem.setTimes(srcPath, modificationTime, accessTime);
-    }
+    delegate.changeFileMetadata(fileInfoDiff);
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MoveFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/MoveFileAction.java
@@ -18,6 +18,7 @@
 package org.smartdata.hdfs.action;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +76,7 @@ public class MoveFileAction extends AbstractMoveFileAction {
   protected void execute() throws Exception {
     this.setDfsClient(HadoopUtil.getDFSClient(
             HadoopUtil.getNameNodeUri(conf), conf));
-    if (fileName == null) {
+    if (StringUtils.isBlank(fileName)) {
       throw new IllegalArgumentException("File parameter is missing!");
     }
 
@@ -114,7 +115,7 @@ public class MoveFileAction extends AbstractMoveFileAction {
     int maxMoves = movePlan.getPropertyValueInt(FileMovePlan.MAX_CONCURRENT_MOVES, 10);
     int maxRetries = movePlan.getPropertyValueInt(FileMovePlan.MAX_NUM_RETRIES, 10);
     MoverExecutor executor = new MoverExecutor(status, getContext().getConf(), maxRetries, maxMoves);
-    return executor.executeMove(movePlan, getResultOs(), getLogOs());
+    return executor.executeMove(movePlan, getResultOutputStream(), getLogPrintStream());
   }
 
   private boolean recheckModification() {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/UpdateFileMetadataSupport.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/UpdateFileMetadataSupport.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.hdfs.action;
+
+import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.smartdata.hdfs.HadoopUtil;
+import org.smartdata.model.FileInfoDiff;
+
+public class UpdateFileMetadataSupport {
+  private final Configuration configuration;
+  private final PrintStream logOutput;
+
+  public UpdateFileMetadataSupport(Configuration configuration, PrintStream logOutput) {
+    this.configuration = configuration;
+    this.logOutput = logOutput;
+  }
+
+  public void changeFileMetadata(FileInfoDiff fileInfoDiff) throws IOException {
+    if (fileInfoDiff.getPath().startsWith("hdfs")) {
+      changeRemoteFileMetadata(fileInfoDiff);
+    } else {
+      changeLocalFileMetadata(fileInfoDiff);
+    }
+  }
+
+  private void changeRemoteFileMetadata(FileInfoDiff fileInfoDiff) throws IOException {
+    FileSystem remoteFileSystem = FileSystem.get(URI.create(fileInfoDiff.getPath()),
+        toRemoteClusterConfig(configuration));
+    changeFileMetadata(fileInfoDiff, remoteFileSystem);
+  }
+
+  private void changeLocalFileMetadata(FileInfoDiff fileInfoDiff) throws IOException {
+    FileSystem localFileSystem = FileSystem.get(
+        HadoopUtil.getNameNodeUri(configuration), configuration);
+    changeFileMetadata(fileInfoDiff, localFileSystem);
+  }
+
+  private void maybeChangeOwnerAndGroup(FileSystem fileSystem,
+      FileInfoDiff fileInfoDiff, FileStatus srcFileStatus) throws IOException {
+
+    String owner = Optional.ofNullable(fileInfoDiff.getOwner())
+        .orElseGet(srcFileStatus::getOwner);
+    String group = Optional.ofNullable(fileInfoDiff.getGroup())
+        .orElseGet(srcFileStatus::getGroup);
+
+    if (!owner.equals(srcFileStatus.getOwner())
+        || !group.equals(srcFileStatus.getGroup())) {
+      logOutput.printf("Updating file's owner from '%s' to '%s' " +
+              "and file's group from '%s' to '%s'%n",
+          srcFileStatus.getOwner(), owner,
+          srcFileStatus.getGroup(), group);
+      fileSystem.setOwner(srcFileStatus.getPath(), owner, group);
+    }
+  }
+
+  private void maybeChangeBlockReplication(FileSystem fileSystem,
+      FileInfoDiff fileInfoDiff, FileStatus srcFileStatus) throws IOException {
+
+    Short newBlockReplication = fileInfoDiff.getBlockReplication();
+    if (newBlockReplication != null
+        && !newBlockReplication.equals(srcFileStatus.getReplication())) {
+      logOutput.printf("Updating file's replication factor from '%s' to '%s'%n",
+          srcFileStatus.getReplication(), newBlockReplication);
+      fileSystem.setReplication(srcFileStatus.getPath(), newBlockReplication);
+    }
+  }
+
+  private void maybeChangePermissions(FileSystem fileSystem,
+      FileInfoDiff fileInfoDiff, FileStatus srcFileStatus) throws IOException {
+
+    Short newPermission = fileInfoDiff.getPermission();
+    if (newPermission != null
+        && !newPermission.equals(srcFileStatus.getPermission().toShort())) {
+      logOutput.printf("Updating file's permissions from '%s' to '%s'%n",
+          srcFileStatus.getPermission().toShort(), newPermission);
+      fileSystem.setPermission(srcFileStatus.getPath(), new FsPermission(newPermission));
+    }
+  }
+
+  private void maybeChangeTimes(FileSystem fileSystem,
+      FileInfoDiff fileInfoDiff, FileStatus srcFileStatus) throws IOException {
+
+    long modificationTime = Optional.ofNullable(fileInfoDiff.getModificationTime())
+        .orElseGet(srcFileStatus::getModificationTime);
+    long accessTime = Optional.ofNullable(fileInfoDiff.getAccessTime())
+        .orElseGet(srcFileStatus::getAccessTime);
+
+    if (accessTime != srcFileStatus.getAccessTime()
+        || modificationTime != srcFileStatus.getModificationTime()) {
+      logOutput.printf("Updating file's access time from '%s' to '%s' " +
+              "and file's modification time from '%s' to '%s'%n",
+          srcFileStatus.getAccessTime(), accessTime,
+          srcFileStatus.getModificationTime(), modificationTime);
+      fileSystem.setTimes(srcFileStatus.getPath(), modificationTime, accessTime);
+    }
+  }
+
+  private void changeFileMetadata(
+      FileInfoDiff fileInfoDiff, FileSystem fileSystem) throws IOException {
+    Path srcPath = new Path(fileInfoDiff.getPath());
+    FileStatus srcFileStatus = fileSystem.getFileStatus(srcPath);
+
+    maybeChangeOwnerAndGroup(fileSystem, fileInfoDiff, srcFileStatus);
+    maybeChangeBlockReplication(fileSystem, fileInfoDiff, srcFileStatus);
+    maybeChangePermissions(fileSystem, fileInfoDiff, srcFileStatus);
+    maybeChangeTimes(fileSystem, fileInfoDiff, srcFileStatus);
+  }
+}


### PR DESCRIPTION
- Added `-copyContent` to the `copy` action to manage whether we need to copy file content. 
- Fixed the bug of files located in directories, except for the root backup directory, are copied again after restarting the `sync` rule, regardless of the state of the target file
- Fixed the bug of ignoring file attributes changes during a pause of `sync` rule in the case when the contents of the file have not been changed