### PR TITLE
[ADH-4175] Add strategies for checking the equality of backup files in the src and dest clusters

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -496,4 +496,19 @@
         UNORDERED - no guarantees of the file scheduling order
     </description>
   </property>
+
+  <property>
+    <name>smart.sync.file.equality.strategy</name>
+    <value>CHECKSUM</value>
+    <description>
+      The strategy for checking whether the files with same relative path in the source and target clusters
+      are equal during scheduling of the sync action.
+      Possible values:
+        FILE_LENGTH - equality check based on the file length. This strategy is fast alternative to
+          comparing file contents/checksums, but have some corner cases when two different files with the same
+          length but with different content are considered equal.
+        CHECKSUM - equality check based on the file checksum. This strategy is more resource-intensive,
+          but it doesn't return false positive results, like previous one.
+    </description>
+  </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.20</version>
           <configuration>
-            <argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
+            <argLine>-XX:+UseG1GC -Xmx2048m -XX:MaxPermSize=256m</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -143,6 +143,10 @@ public class SmartConfKeys {
   public static final String SMART_ENABLE_ZEPPELIN_WEB = "smart.zeppelin.web.enable";
   public static final boolean SMART_ENABLE_ZEPPELIN_WEB_DEFAULT = true;
 
+  public static final String SMART_SYNC_FILE_EQUALITY_STRATEGY =
+      "smart.sync.file.equality.strategy";
+  public static final String SMART_SYNC_FILE_EQUALITY_STRATEGY_DEFAULT = "CHECKSUM";
+
   // Cmdlets
   public static final String SMART_CMDLET_MAX_NUM_PENDING_KEY =
       "smart.cmdlet.max.num.pending";

--- a/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
@@ -58,7 +58,10 @@ public class PathUtil {
   }
 
   public static String addPathSeparator(String path) {
-    return path.endsWith(DIR_SEP) ? path : path + DIR_SEP;
+    return Optional.ofNullable(path)
+        .filter(p -> !p.endsWith(DIR_SEP))
+        .map(p -> p + DIR_SEP)
+        .orElse(path);
   }
 
   public static boolean pathStartsWith(String path, String prefixToCheck) {

--- a/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
@@ -1,0 +1,83 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.smartdata.utils;
+
+import org.apache.hadoop.fs.Path;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class PathUtil {
+  private static final String DIR_SEP = "/";
+  private static final String HDFS_SCHEME = "hdfs";
+  private static final String[] GLOBS = new String[] {
+      "*", "?"
+  };
+
+  public static String getBaseDir(String path) {
+    if (path == null) {
+      return null;
+    }
+
+    int last = path.lastIndexOf(DIR_SEP);
+    if (last == -1) {
+      return null;
+    }
+
+    int first = path.length();
+    for (String g : GLOBS) {
+      int gIdx = path.indexOf(g);
+      if (gIdx >= 0) {
+        first = Math.min(gIdx, first);
+      }
+    }
+
+    last = path.substring(0, first).lastIndexOf(DIR_SEP);
+    if (last == -1) {
+      return null;
+    }
+    return path.substring(0, last + 1);
+  }
+
+  public static String addPathSeparator(String path) {
+    return path.endsWith(DIR_SEP) ? path : path + DIR_SEP;
+  }
+
+  public static boolean pathStartsWith(String path, String prefixToCheck) {
+    return addPathSeparator(path)
+        .startsWith(addPathSeparator(prefixToCheck));
+  }
+
+  // todo replace 'stringPath.startsWith("hdfs")' calls with this method
+  public static boolean isAbsoluteRemotePath(Path path) {
+    return Optional.ofNullable(path)
+            .map(Path::toUri)
+            .filter(PathUtil::isAbsoluteRemotePath)
+            .isPresent();
+  }
+
+  public static boolean isAbsoluteRemotePath(URI uri) {
+    return Optional.ofNullable(uri)
+        .map(URI::getScheme)
+        .filter(HDFS_SCHEME::equals)
+        .isPresent();
+  }
+}

--- a/smart-common/src/main/java/org/smartdata/utils/StringUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/StringUtil.java
@@ -32,11 +32,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class StringUtil {
-  private static final String DIR_SEP = "/";
-  private static final String[] GLOBS = new String[] {
-      "*", "?"
-  };
-
   public static String join(CharSequence delimiter,
                             Iterable<? extends CharSequence> elements) {
     if (elements == null) {
@@ -56,31 +51,6 @@ public class StringUtil {
       sb.append(it.next());
     }
     return sb.toString();
-  }
-
-  public static String getBaseDir(String path) {
-    if (path == null) {
-      return null;
-    }
-
-    int lastSeparatorIdx = path.lastIndexOf(DIR_SEP);
-    if (lastSeparatorIdx == -1) {
-      return null;
-    }
-
-    int firstGlobIdx = path.length();
-    for (String glob : GLOBS) {
-      int globIdx = path.indexOf(glob);
-      if (globIdx >= 0) {
-        firstGlobIdx = Math.min(globIdx, firstGlobIdx);
-      }
-    }
-
-    lastSeparatorIdx = path.substring(0, firstGlobIdx).lastIndexOf(DIR_SEP);
-    if (lastSeparatorIdx == -1) {
-      return null;
-    }
-    return path.substring(0, lastSeparatorIdx + 1);
   }
 
   public static String ssmPatternToSqlLike(String str) {
@@ -277,14 +247,5 @@ public class StringUtil {
         .replace(".", "\\.")
         .replace("*", ".*")
         .replace("?", ".");
-  }
-
-  public static String addPathSeparator(String path) {
-    return path.endsWith(DIR_SEP) ? path : path + DIR_SEP;
-  }
-
-  public static boolean pathStartsWith(String path, String prefixToCheck) {
-    return addPathSeparator(path)
-        .startsWith(addPathSeparator(prefixToCheck));
   }
 }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopy2S3Plugin.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/FileCopy2S3Plugin.java
@@ -24,11 +24,12 @@ import org.smartdata.model.CmdletDescriptor;
 import org.smartdata.model.RuleInfo;
 import org.smartdata.model.rule.RuleExecutorPlugin;
 import org.smartdata.model.rule.RuleTranslationResult;
-import org.smartdata.utils.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static org.smartdata.utils.PathUtil.getBaseDir;
 
 public class FileCopy2S3Plugin implements RuleExecutorPlugin {
 
@@ -57,7 +58,7 @@ public class FileCopy2S3Plugin implements RuleExecutorPlugin {
   private List<String> getPathMatchesList(List<String> paths) {
     List<String> ret = new ArrayList<>();
     for (String p : paths) {
-      String dir = StringUtil.getBaseDir(p);
+      String dir = getBaseDir(p);
       if (dir == null) {
         continue;
       }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/copy/FileCopyDrPlugin.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/copy/FileCopyDrPlugin.java
@@ -31,6 +31,7 @@ import org.smartdata.model.FileDiffType;
 import org.smartdata.model.RuleInfo;
 import org.smartdata.model.rule.RuleExecutorPlugin;
 import org.smartdata.model.rule.RuleTranslationResult;
+import org.smartdata.utils.PathUtil;
 import org.smartdata.utils.StringUtil;
 
 import java.util.Collections;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.smartdata.utils.PathUtil.addPathSeparator;
 import static org.smartdata.utils.StringUtil.ssmPatternsToRegex;
 
 public class FileCopyDrPlugin implements RuleExecutorPlugin {
@@ -71,7 +73,7 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
 
         String dest = cmdletDescriptor.getActionArgs(i)
             .computeIfPresent(SyncAction.DEST,
-                (arg, path) -> StringUtil.addPathSeparator(path));
+                (arg, path) -> addPathSeparator(path));
         BackUpInfo backUpInfo = buildBackupInfo(ruleId, dest, translationResult, pathPatterns);
 
         cmdletDescriptor.addActionArg(i, SyncAction.SRC, backUpInfo.getSrc());
@@ -138,7 +140,7 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
 
   private List<String> getPathPatternBaseDirs(List<String> paths) {
     return paths.stream()
-        .map(StringUtil::getBaseDir)
+        .map(PathUtil::getBaseDir)
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/copy/FileCopyDrPlugin.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/copy/FileCopyDrPlugin.java
@@ -71,9 +71,10 @@ public class FileCopyDrPlugin implements RuleExecutorPlugin {
 
         wrapGetFilesToCopyQuery(translationResult, pathPatterns);
 
-        String dest = cmdletDescriptor.getActionArgs(i)
-            .computeIfPresent(SyncAction.DEST,
-                (arg, path) -> addPathSeparator(path));
+        String destActionArg = cmdletDescriptor.getActionArgs(i).get(SyncAction.DEST);
+        String dest = addPathSeparator(destActionArg);
+        cmdletDescriptor.addActionArg(i, SyncAction.DEST, dest);
+
         BackUpInfo backUpInfo = buildBackupInfo(ruleId, dest, translationResult, pathPatterns);
 
         cmdletDescriptor.addActionArg(i, SyncAction.SRC, backUpInfo.getSrc());

--- a/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MiniClusterHarness.java
+++ b/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MiniClusterHarness.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.balancer.TestBalancer;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.junit.After;
 import org.junit.Before;
 import org.smartdata.SmartContext;
@@ -76,5 +77,7 @@ public abstract class MiniClusterHarness {
     if (cluster != null) {
       cluster.shutdown(true);
     }
+    // clear registered metric systems of name- and datanodes
+    DefaultMetricsSystem.instance().shutdown();
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
@@ -121,10 +121,10 @@ public class CopyFileAction extends CopyPreservedAttributesAction {
 
     if (!copyContent) {
       appendLog("Src and dest files are equal, no need to copy content");
-    } else if (offset == 0 && length == 0) {
-      copySingleFile(srcPath, destPath);
     } else if (length != 0) {
       copyWithOffset(srcPath, destPath, bufferSize, offset, length);
+    } else if (offset == 0) {
+      copySingleFile(srcPath, destPath);
     }
 
     copyFileAttributes(srcPath, destPath, preserveAttributes);

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/ChecksumFileEqualityStrategy.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/ChecksumFileEqualityStrategy.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.file.equality;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.smartdata.hdfs.HadoopUtil;
+import org.smartdata.model.FileInfo;
+
+import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
+import static org.smartdata.utils.PathUtil.isAbsoluteRemotePath;
+
+public class ChecksumFileEqualityStrategy implements FileEqualityStrategy {
+  static final Logger LOG = LoggerFactory.getLogger(ChecksumFileEqualityStrategy.class);
+
+  private final LengthFileEqualityStrategy filesLengthComparator
+      = new LengthFileEqualityStrategy();
+
+  private final Configuration config;
+
+  public ChecksumFileEqualityStrategy(Configuration config) {
+    this.config = config;
+  }
+
+  private FileSystem getFileSystem(Path path, Configuration conf) throws IOException {
+    return isAbsoluteRemotePath(path)
+        ? path.getFileSystem(toRemoteClusterConfig(conf))
+        : FileSystem.get(HadoopUtil.getNameNodeUri(conf), conf);
+  }
+
+  @Override
+  public boolean areEqual(FileInfo srcFileInfo, FileStatus destFileStatus) {
+    if (!filesLengthComparator.areEqual(srcFileInfo, destFileStatus)) {
+      // we don't need to fetch and compare checksums
+      // if the files are obviously not equal.
+      return false;
+    }
+    Path srcPath = new Path(srcFileInfo.getPath());
+    Path destPath = destFileStatus.getPath();
+
+    try {
+      FileChecksum srcChecksum = getFileSystem(srcPath, config)
+          .getFileChecksum(srcPath);
+      FileChecksum destChecksum = getFileSystem(destPath, config)
+          .getFileChecksum(destPath);
+
+      return Optional.ofNullable(srcChecksum)
+          .filter(checksum -> checksum.equals(destChecksum))
+          .isPresent();
+    } catch (IOException exception) {
+      LOG.error("Error comparing checksums of files '{}' and '{}'",
+          srcPath, destPath, exception);
+      return false;
+    }
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/FileEqualityStrategy.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/FileEqualityStrategy.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.file.equality;
+
+import java.util.Objects;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.smartdata.conf.SmartConfKeys;
+import org.smartdata.model.FileInfo;
+
+public interface FileEqualityStrategy {
+  enum Strategy {
+    FILE_LENGTH,
+    CHECKSUM
+  }
+
+  boolean areEqual(FileInfo srcFileInfo, FileStatus destFileStatus);
+
+  static FileEqualityStrategy from(Configuration conf) {
+    String rawStrategy = conf.get(
+        SmartConfKeys.SMART_SYNC_FILE_EQUALITY_STRATEGY,
+        SmartConfKeys.SMART_SYNC_FILE_EQUALITY_STRATEGY_DEFAULT);
+    try {
+      return of(Strategy.valueOf(rawStrategy.toUpperCase()), conf);
+    } catch (IllegalArgumentException illegalArgumentException) {
+      throw new IllegalArgumentException("Wrong file compare strategy: " + rawStrategy);
+    }
+  }
+
+  static FileEqualityStrategy of(Strategy strategy, Configuration conf) {
+    if (Objects.requireNonNull(strategy) == Strategy.CHECKSUM) {
+      return new ChecksumFileEqualityStrategy(conf);
+    }
+    return new LengthFileEqualityStrategy();
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/LengthFileEqualityStrategy.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/LengthFileEqualityStrategy.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.file.equality;
+
+import java.util.Optional;
+import org.apache.hadoop.fs.FileStatus;
+import org.smartdata.model.FileInfo;
+
+public class LengthFileEqualityStrategy implements FileEqualityStrategy {
+
+  @Override
+  public boolean areEqual(FileInfo srcFileInfo, FileStatus destFileStatus) {
+    return Optional.ofNullable(destFileStatus)
+        .map(FileStatus::getLen)
+        .filter(length -> length == srcFileInfo.getLength())
+        .isPresent();
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCheckStorageAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCheckStorageAction.java
@@ -17,12 +17,13 @@
  */
 package org.smartdata.hdfs.action;
 
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.smartdata.hdfs.MiniClusterHarness;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,17 +37,14 @@ public class TestCheckStorageAction extends MiniClusterHarness {
     checkStorageAction.setDfsClient(dfsClient);
     checkStorageAction.setContext(smartContext);
     final String file = "/testPath/file1";
-    dfsClient.mkdirs("/testPath");
+    dfsClient.mkdirs("/testPath", null, true);
     dfsClient.setStoragePolicy("/testPath", "ONE_SSD");
 
     // write to HDFS
-    final OutputStream out = dfsClient.create(file, true);
-    byte[] content = ("This is a file containing two blocks" +
-        "......................").getBytes();
-    out.write(content);
-    out.close();
+    String content = "This is a file containing two blocks......................";
+    DFSTestUtil.writeFile(dfs, new Path(file), content);
 
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     args.put(CheckStorageAction.FILE_PATH, file);
     // do CheckStorageAction
     checkStorageAction.init(args);
@@ -61,9 +59,9 @@ public class TestCheckStorageAction extends MiniClusterHarness {
     checkStorageAction.setContext(smartContext);
 
     final String file = "/testPath/wrongfile";
-    dfsClient.mkdirs("/testPath");
+    dfsClient.mkdirs("/testPath", null, true);
 
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     args.put(CheckStorageAction.FILE_PATH, file);
     // do CheckStorageAction
     checkStorageAction.init(args);

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyDirectoryAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyDirectoryAction.java
@@ -49,7 +49,7 @@ public class TestCopyDirectoryAction extends MultiClusterHarness {
       Set<CopyPreservedAttributesAction.PreserveAttribute> preserveAttributes) throws Exception {
     Map<String, String> args = new HashMap<>();
     args.put(CopyDirectoryAction.FILE_PATH, src.toUri().getPath());
-    args.put(CopyDirectoryAction.DEST_PATH, pathToActionArg(dest));
+    args.put(CopyDirectoryAction.DEST_PATH, dest.toString());
 
     if (!preserveAttributes.isEmpty()) {
       String attributesOption = preserveAttributes.stream()

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCopyFileAction.java
@@ -57,7 +57,7 @@ public class TestCopyFileAction extends MultiClusterHarness {
     copyFileAction.setContext(smartContext);
     Map<String, String> args = new HashMap<>();
     args.put(CopyFileAction.FILE_PATH, src.toUri().getPath());
-    args.put(CopyFileAction.DEST_PATH, pathToActionArg(dest));
+    args.put(CopyFileAction.DEST_PATH, dest.toString());
     args.put(CopyFileAction.LENGTH, "" + length);
     args.put(CopyFileAction.OFFSET_INDEX, "" + offset);
 

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestReadFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestReadFileAction.java
@@ -1,38 +1,24 @@
 package org.smartdata.hdfs.action;
 
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.smartdata.hdfs.MiniClusterHarness;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 public class TestReadFileAction extends MiniClusterHarness {
   protected void writeFile(String filePath, int length) throws IOException {
-    try {
-      int bufferSize = 64 * 1024;
-      final OutputStream out = dfsClient.create(filePath, true);
-      // generate random data with given length
-      byte[] buffer = new byte[bufferSize];
-      new Random().nextBytes(buffer);
-      // write to HDFS
-      for (int pos = 0; pos < length; pos += bufferSize) {
-        int writeLength = pos + bufferSize < length ? bufferSize : length - pos;
-        out.write(buffer, 0, writeLength);
-      }
-      out.close();
-    } catch (IOException e) {
-      System.err.println("WriteFile Action fails!\n" + e.getMessage());
-    }
+    DFSTestUtil.createFile(dfs, new Path(filePath), length, (short) 1, 0L);
   }
 
   @Test
-  public void testInit() throws IOException {
+  public void testInit() {
     ReadFileAction readFileAction = new ReadFileAction();
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     args.put(ReadFileAction.FILE_PATH, "Test");
     readFileAction.init(args);
     args.put(ReadFileAction.BUF_SIZE, "4096");
@@ -47,7 +33,7 @@ public class TestReadFileAction extends MiniClusterHarness {
     ReadFileAction readFileAction = new ReadFileAction();
     readFileAction.setDfsClient(dfsClient);
     readFileAction.setContext(smartContext);
-    Map<String, String> args = new HashMap();
+    Map<String, String> args = new HashMap<>();
     args.put(ReadFileAction.FILE_PATH, filePath);
     readFileAction.init(args);
     readFileAction.run();

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestRenameFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestRenameFileAction.java
@@ -17,8 +17,8 @@
  */
 package org.smartdata.hdfs.action;
 
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.smartdata.hdfs.MiniClusterHarness;
@@ -43,9 +43,8 @@ public class TestRenameFileAction extends MiniClusterHarness {
     //the parent dir need to be exist
     dfs.mkdirs(new Path(destPath));
     //write to DISK
-    final FSDataOutputStream out1 = dfs.create(new Path(srcPath + "/" + file1));
-    out1.writeChars("testCopy1");
-    out1.close();
+
+    DFSTestUtil.writeFile(dfs, new Path(srcPath + "/" + file1), "testCopy1");
     Assert.assertTrue(dfsClient.exists(srcPath + "/" + file1));
 
     RenameFileAction renameFileAction = new RenameFileAction();
@@ -72,9 +71,7 @@ public class TestRenameFileAction extends MiniClusterHarness {
     dfs.mkdirs(new Path(dfs.getUri() + destPath));
 
     // write to DISK
-    final FSDataOutputStream out1 = dfs.create(new Path( dfs.getUri() + srcPath + "/" + file1));
-    out1.writeChars("testCopy1");
-    out1.close();
+    DFSTestUtil.writeFile(dfs, new Path(dfs.getUri() + srcPath + "/" + file1), "testCopy1");
 
     RenameFileAction renameFileAction = new RenameFileAction();
     renameFileAction.setDfsClient(dfsClient);
@@ -100,12 +97,8 @@ public class TestRenameFileAction extends MiniClusterHarness {
     dfs.mkdirs(new Path(dfs.getUri() + destPath));
 
     // write to DISK
-    final FSDataOutputStream out1 = dfs.create(new Path(dfs.getUri() + src));
-    out1.writeChars("testCopy1");
-    out1.close();
-    final FSDataOutputStream out2 = dfs.create(new Path(dfs.getUri() + dest));
-    out2.writeChars("testCopy2");
-    out2.close();
+    DFSTestUtil.writeFile(dfs, new Path(dfs.getUri() + src), "testCopy1");
+    DFSTestUtil.writeFile(dfs, new Path(dfs.getUri() + dest), "testCopy2");
 
     verifyRenameFailed(src, dest);
   }
@@ -127,6 +120,6 @@ public class TestRenameFileAction extends MiniClusterHarness {
     args.put(RenameFileAction.DEST_PATH , dest);
     renameFileAction.init(args);
     renameFileAction.run();
-    Assert.assertTrue(renameFileAction.getActionStatus().getThrowable() != null);
+    Assert.assertNotNull(renameFileAction.getActionStatus().getThrowable());
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/file/equality/TestFileEqualityStrategy.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/file/equality/TestFileEqualityStrategy.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.file.equality;
+
+import java.io.IOException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.smartdata.hdfs.MultiClusterHarness;
+import org.smartdata.model.FileInfo;
+
+import static org.smartdata.hdfs.MultiClusterHarness.TestType.INTER_CLUSTER;
+import static org.smartdata.hdfs.MultiClusterHarness.TestType.INTRA_CLUSTER;
+import static org.smartdata.hdfs.file.equality.FileEqualityStrategy.Strategy.CHECKSUM;
+import static org.smartdata.hdfs.file.equality.FileEqualityStrategy.Strategy.FILE_LENGTH;
+
+@RunWith(Parameterized.class)
+public class TestFileEqualityStrategy extends MultiClusterHarness {
+
+  private FileEqualityStrategy fileEqualityStrategy;
+
+  @Parameter(1)
+  public FileEqualityStrategy.Strategy strategy;
+
+  @Before
+  public void initStrategy() {
+    fileEqualityStrategy = FileEqualityStrategy.of(
+        strategy, smartContext.getConf());
+  }
+
+  @Parameters(name = "Test type - {0}, Strategy - {1}")
+  public static Object[] parameters() {
+    return new Object[][] {
+        {INTRA_CLUSTER, FILE_LENGTH},
+        {INTRA_CLUSTER, CHECKSUM},
+        {INTER_CLUSTER, CHECKSUM}
+    };
+  }
+
+  @Test
+  public void testCompareFilesWithDifferentLength() throws IOException {
+    Path srcPath = new Path("/src");
+    Path destPath = anotherClusterPath("/", "dest");
+
+    DFSTestUtil.writeFile(dfs, srcPath, "data");
+    DFSTestUtil.writeFile(anotherDfs, destPath, "data, but a little bit longer");
+
+    boolean areFilesEqual = checkFilesEquality(srcPath, destPath);
+    Assert.assertFalse(areFilesEqual);
+  }
+
+  @Test
+  public void testCompareEqualFiles() throws IOException {
+    Path srcPath = new Path("/src");
+    Path destPath = anotherClusterPath("/", "dest");
+
+    DFSTestUtil.writeFile(dfs, srcPath, "another data");
+    DFSTestUtil.writeFile(anotherDfs, destPath, "another data");
+
+    boolean areFilesEqual = checkFilesEquality(srcPath, destPath);
+    Assert.assertTrue(areFilesEqual);
+  }
+
+  @Test
+  public void testCompareFileWithItself() throws IOException {
+    Assume.assumeTrue(testType == INTRA_CLUSTER);
+
+    Path srcPath = new Path("/src");
+    DFSTestUtil.writeFile(dfs, srcPath, "data");
+
+    boolean areFilesEqual = checkFilesEquality(srcPath, anotherClusterPath(srcPath));
+    Assert.assertTrue(areFilesEqual);
+  }
+
+  @Test
+  public void testCompareNotEqualFilesWithEqualLength() throws IOException {
+    Assume.assumeTrue(strategy == CHECKSUM);
+
+    Path srcPath = new Path("/src");
+    Path destPath = anotherClusterPath("/", "dest");
+
+    DFSTestUtil.writeFile(dfs, srcPath, "12345678");
+    DFSTestUtil.writeFile(anotherDfs, destPath, "87654321");
+
+    boolean areFilesEqual = checkFilesEquality(srcPath, destPath);
+    Assert.assertFalse(areFilesEqual);
+  }
+
+  private boolean checkFilesEquality(Path srcPath, Path destPath) throws IOException {
+    FileStatus srcFileStatus = dfs.getFileStatus(srcPath);
+    FileInfo srcFileInfo = FileInfo.newBuilder()
+        .setPath(srcPath.toUri().getPath())
+        .setLength(srcFileStatus.getLen())
+        .build();
+    FileStatus destFileStatus = anotherDfs.getFileStatus(destPath);
+
+    return fileEqualityStrategy.areEqual(srcFileInfo, destFileStatus);
+  }
+}


### PR DESCRIPTION
- Added 2 strategies for checking whether the files with same relative path in the source and target clusters are equal during scheduling of the sync action:
  - `FILE_LENGTH` - equality check based on the file length. This strategy is fast alternative to comparing file contents/checksums, but have some corner cases when two different files with the same length but with different content are considered equal.
  - `CHECKSUM` - equality check based on the file checksum. This strategy is more resource-intensive, but it doesn't return false positive results, like previous one. Default strategy.
- Fixed bug of undefined SSM behaviour after scheduling the `delete` action of a "dirty" remote file (a file in a remote cluster that is longer than the corresponding file in the src cluster). The scheduling of the "delete" actions has been removed, since the "copy" action always transfers the contents of the src file with the "overwrite" flag set to true.
- Fixed memory leak in tests that use MiniDFSCluster caused by HDFS metrics system.
- Changed GC used by surefire to `G1`.