### PR TITLE
[ADH-4246] Add Spring based web server, implementing existing SSM REST API

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -511,4 +511,10 @@
           but it doesn't return false positive results, like previous one.
     </description>
   </property>
+
+  <property>
+    <name>smart.rest.server.port</name>
+    <value>8081</value>
+    <description>SSM Rest Server port</description>
+  </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,12 @@
     <module>smart-agent</module>
     <module>smart-dist</module>
     <module>smart-integration</module>
+    <module>smart-web-server</module>
   </modules>
 
   <properties>
     <log4j.version>2.22.1</log4j.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <hadoop.version>2.7.3</hadoop.version>
@@ -56,7 +57,7 @@
     <akka.version>2.5.32</akka.version>
     <akka.config.version>1.2.1</akka.config.version>
     <druid.version>1.1.3</druid.version>
-    <spring.version>4.3.9.RELEASE</spring.version>
+    <spring.version>5.3.31</spring.version>
     <antlr4.version>4.6</antlr4.version>
     <hazelcast.version>4.2.8</hazelcast.version>
     <guava.version>15.0</guava.version>
@@ -66,10 +67,12 @@
     <kerby.version>1.0.1</kerby.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <postgres.version>42.6.0</postgres.version>
+    <jackson.version>2.13.5</jackson.version>
     <mysql.version>5.1.42</mysql.version>
     <sqlite.version>3.34.0</sqlite.version>
     <commons-configuration.version>2.1.1</commons-configuration.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
+    <servlet.api.version>4.0.1</servlet.api.version>
   </properties>
 
   <profiles>
@@ -254,6 +257,21 @@
         <version>${postgres.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.alibaba</groupId>
         <artifactId>druid</artifactId>
         <version>${druid.version}</version>
@@ -261,11 +279,6 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jdbc</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
         <version>${spring.version}</version>
       </dependency>
       <dependency>
@@ -453,7 +466,11 @@
         <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>${servlet.api.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,9 @@
     <commons-configuration.version>2.1.1</commons-configuration.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <servlet.api.version>4.0.1</servlet.api.version>
+    <springdoc.openapi.version>1.7.0</springdoc.openapi.version>
+    <hibernate.validator.version>6.2.5.Final</hibernate.validator.version>
+    <spring.boot.version>2.7.18</spring.boot.version>
   </properties>
 
   <profiles>

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -56,13 +56,16 @@ public class SmartConfKeys {
       "smart.alluxio.master.journal.dir";
 
   // SSM
+  public static final String SMART_SERVER_VERSION_KEY = "smart.storage.manager.version";
+  public static final String SMART_SERVER_VERSION_CURRENT = "1.6.0-SNAPSHOT";
   public static final String SMART_SERVER_RPC_ADDRESS_KEY = "smart.server.rpc.address";
   public static final String SMART_SERVER_RPC_ADDRESS_DEFAULT = "0.0.0.0:7042";
   public static final String SMART_SERVER_RPC_HANDLER_COUNT_KEY = "smart.server.rpc.handler.count";
   public static final int SMART_SERVER_RPC_HANDLER_COUNT_DEFAULT = 80;
   public static final String SMART_SERVER_HTTP_ADDRESS_KEY = "smart.server.http.address";
   public static final String SMART_SERVER_HTTP_ADDRESS_DEFAULT = "0.0.0.0:7045";
-  public static final String SMART_SERVER_HTTPS_ADDRESS_KEY = "smart.server.https.address";
+  public static final String SMART_REST_SERVER_PORT_KEY = "smart.rest.server.port";
+  public static final int SMART_REST_SERVER_PORT_KEY_DEFAULT = 8081;
   public static final String SMART_SECURITY_ENABLE = "smart.security.enable";
   public static final String SMART_SERVER_KEYTAB_FILE_KEY = "smart.server.keytab.file";
   public static final String SMART_SERVER_KERBEROS_PRINCIPAL_KEY =

--- a/smart-engine/pom.xml
+++ b/smart-engine/pom.xml
@@ -115,10 +115,6 @@
             <artifactId>druid</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>

--- a/smart-engine/pom.xml
+++ b/smart-engine/pom.xml
@@ -119,10 +119,6 @@
             <artifactId>spring-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -979,38 +979,62 @@ public class CmdletManager extends AbstractService {
     }
   }
 
-  private class DetailedFileActionGroup {
-    private List<DetailedFileAction> detailedFileActions;
-    private long totalNumOfActions;
+  public static class DetailedFileActionGroup {
+    private final List<DetailedFileAction> detailedFileActions;
+    private final long totalNumOfActions;
 
     public DetailedFileActionGroup(List<DetailedFileAction> detailedFileActions,
                                    long totalNumOfActions) {
       this.detailedFileActions = detailedFileActions;
       this.totalNumOfActions = totalNumOfActions;
     }
+
+    public List<DetailedFileAction> getDetailedFileActions() {
+      return detailedFileActions;
+    }
+
+    public long getTotalNumOfActions() {
+      return totalNumOfActions;
+    }
   }
 
-  private class CmdletGroup {
-    private List<CmdletInfo> cmdlets;
-    private long totalNumOfCmdlets;
+  public static class CmdletGroup {
+    private final List<CmdletInfo> cmdlets;
+    private final long totalNumOfCmdlets;
 
     public CmdletGroup(List<CmdletInfo> cmdlets, long totalNumOfCmdlets) {
       this.cmdlets = cmdlets;
       this.totalNumOfCmdlets = totalNumOfCmdlets;
     }
+
+    public List<CmdletInfo> getCmdlets() {
+      return cmdlets;
+    }
+
+    public long getTotalNumOfCmdlets() {
+      return totalNumOfCmdlets;
+    }
   }
 
-  private class ActionGroup {
-    private List<ActionInfo> actions;
-    private long totalNumOfActions;
+  public static class ActionGroup {
+    private final List<ActionInfo> actions;
+    private final long totalNumOfActions;
 
     public ActionGroup() {
-      this.totalNumOfActions = 0;
+      this(null, 0);
     }
 
     public ActionGroup(List<ActionInfo> actions, long totalNumOfActions) {
       this.actions = actions;
       this.totalNumOfActions = totalNumOfActions;
+    }
+
+    public List<ActionInfo> getActions() {
+      return actions;
+    }
+
+    public long getTotalNumOfActions() {
+      return totalNumOfActions;
     }
   }
 
@@ -1039,15 +1063,16 @@ public class CmdletManager extends AbstractService {
   public ActionGroup searchAction(String path, long pageIndex, long numPerPage,
       List<String> orderBy, List<Boolean> isDesc) throws IOException {
     try {
-      if (pageIndex == Long.parseLong("0")) {
+      if (pageIndex == 0) {
         if (tmpActions.totalNumOfActions != 0) {
           return tmpActions;
-        } else {
-          pageIndex = 1;
         }
+        pageIndex = 1;
       }
+
       long[] total = new long[1];
-      List<ActionInfo> infos =  metaStore.searchAction(path, (pageIndex - 1) * numPerPage,
+      String escapedPath = path.replaceAll("[%_\"/']", "/$0");
+      List<ActionInfo> infos =  metaStore.searchAction(escapedPath, (pageIndex - 1) * numPerPage,
           numPerPage, orderBy, isDesc, total);
       for (ActionInfo info : infos) {
         LOG.debug("[metaStore search] " + info.getActionName());

--- a/smart-engine/src/main/java/org/smartdata/server/engine/StatesManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/StatesManager.java
@@ -135,8 +135,8 @@ public class StatesManager extends AbstractService implements Reconfigurable {
     return serverContext.getMetaStore().getCachedFileStatus();
   }
 
-  public List<AccessCountTable> getTablesInLast(long timeInMills) throws MetaStoreException {
-    return this.accessCountTableManager.getTables(timeInMills);
+  public List<AccessCountTable> getTablesForLast(long timeInMills) throws MetaStoreException {
+    return accessCountTableManager.getTables(timeInMills);
   }
 
   public void reportFileAccessEvent(FileAccessEvent event) {
@@ -154,6 +154,12 @@ public class StatesManager extends AbstractService implements Reconfigurable {
     }
     event.setTimeStamp(System.currentTimeMillis());
     this.fileAccessEventSource.insertEventFromSmartClient(event);
+  }
+
+  public List<FileAccessInfo> getHotFilesForLast(long timeInMills, int fileLimit)
+      throws IOException, MetaStoreException {
+    List<AccessCountTable> tables = getTablesForLast(timeInMills);
+    return getHotFiles(tables, fileLimit);
   }
 
   public List<FileAccessInfo> getHotFiles(List<AccessCountTable> tables,

--- a/smart-engine/src/main/java/org/smartdata/server/engine/rule/RuleExecutor.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/rule/RuleExecutor.java
@@ -294,7 +294,7 @@ public class RuleExecutor implements Runnable {
 
     List<AccessCountTable> accTables = null;
     try {
-      accTables = ruleManager.getStatesManager().getTablesInLast(lastInterval);
+      accTables = ruleManager.getStatesManager().getTablesForLast(lastInterval);
     } catch (MetaStoreException e) {
       LOG.error("Rule " + executionCtx.getRuleId() + " get access info tables exception", e);
     }

--- a/smart-hadoop-support/smart-hadoop/pom.xml
+++ b/smart-hadoop-support/smart-hadoop/pom.xml
@@ -276,13 +276,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.10.3</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>

--- a/smart-metastore/pom.xml
+++ b/smart-metastore/pom.xml
@@ -123,12 +123,6 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.10.3</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/smart-metastore/pom.xml
+++ b/smart-metastore/pom.xml
@@ -49,6 +49,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/smart-metastore/pom.xml
+++ b/smart-metastore/pom.xml
@@ -51,10 +51,6 @@
             <artifactId>spring-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>

--- a/smart-server/pom.xml
+++ b/smart-server/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.smartdata</groupId>
+            <artifactId>smart-web-server</artifactId>
+            <version>1.6.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.smartdata</groupId>
             <artifactId>smart-engine</artifactId>
             <version>1.6.0-SNAPSHOT</version>
             <exclusions>
@@ -210,12 +215,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.10.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/smart-server/src/main/java/org/smartdata/server/SmartServer.java
+++ b/smart-server/src/main/java/org/smartdata/server/SmartServer.java
@@ -236,7 +236,7 @@ public class SmartServer {
       zeppelinServer.start();
     }
 
-    if (restServer != null) {
+    if (enabled && restServer != null) {
       restServer.start();
     }
   }

--- a/smart-server/src/main/java/org/smartdata/server/SmartServer.java
+++ b/smart-server/src/main/java/org/smartdata/server/SmartServer.java
@@ -65,6 +65,7 @@ public class SmartServer {
 
   private SmartRpcServer rpcServer;
   private SmartZeppelinServer zeppelinServer;
+  private SmartRestServer restServer;
 
   static {
     SLF4JBridgeHandler.removeHandlersForRootLogger();
@@ -87,6 +88,7 @@ public class SmartServer {
     engine = new SmartEngine(context);
     rpcServer = new SmartRpcServer(this, conf);
     zeppelinServer = new SmartZeppelinServer(conf, engine);
+    restServer = new SmartRestServer(conf, engine);
 
     LOG.info("Finish Init Smart Server");
   }
@@ -233,6 +235,10 @@ public class SmartServer {
     if (zeppelinServer != null) {
       zeppelinServer.start();
     }
+
+    if (restServer != null) {
+      restServer.start();
+    }
   }
 
   private void startEngines() throws Exception {
@@ -280,6 +286,14 @@ public class SmartServer {
       }
     } catch (Exception exception) {
       LOG.error("Error during stopping Zeppelin server", exception);
+    }
+
+    try {
+      if (restServer != null) {
+        restServer.stop();
+      }
+    } catch (Exception exception) {
+      LOG.error("Error during stopping Spring REST server", exception);
     }
 
     try {

--- a/smart-server/src/test/java/org/smartdata/server/TestSmartServer.java
+++ b/smart-server/src/test/java/org/smartdata/server/TestSmartServer.java
@@ -59,7 +59,7 @@ public class TestSmartServer {
 
   @Test
   public void test() throws InterruptedException {
-    //Thread.sleep(1000000);
+    // Thread.sleep(1000000);
   }
 
   @After

--- a/smart-server/src/test/java/org/smartdata/server/TestSmartServer.java
+++ b/smart-server/src/test/java/org/smartdata/server/TestSmartServer.java
@@ -59,7 +59,7 @@ public class TestSmartServer {
 
   @Test
   public void test() throws InterruptedException {
-    // Thread.sleep(1000000);
+    //Thread.sleep(1000000);
   }
 
   @After

--- a/smart-web-server/pom.xml
+++ b/smart-web-server/pom.xml
@@ -27,10 +27,6 @@
 
   <artifactId>smart-web-server</artifactId>
 
-  <properties>
-    <spring.boot.version>2.7.18</spring.boot.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -63,13 +59,13 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-ui</artifactId>
-      <version>1.7.0</version>
+      <version>${springdoc.openapi.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>6.2.5.Final</version>
+      <version>${hibernate.validator.version}</version>
     </dependency>
 
     <!--  Use sl4j + log4j2 instead of logback and bridge classes -->

--- a/smart-web-server/pom.xml
+++ b/smart-web-server/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.smartdata</groupId>
+    <artifactId>smartdata-project</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>smart-web-server</artifactId>
+
+  <properties>
+    <spring.boot.version>2.7.18</spring.boot.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.smartdata</groupId>
+      <artifactId>smart-engine</artifactId>
+      <version>1.6.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-ui</artifactId>
+      <version>1.7.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>6.2.5.Final</version>
+    </dependency>
+
+    <!--  Use sl4j + log4j2 instead of logback and bridge classes -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
+  </dependencies>
+
+  <!-- TODO move checkstyle plugin configurations from this and other submodules to the base package -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>7.8.2</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <configLocation>../supports/tools/checkstyle.xml</configLocation>
+          <suppressionsLocation>../supports/tools/suppressions.xml</suppressionsLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <includeResources>false</includeResources>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <!--
+            Execute checkstyle after compilation but before tests.
+
+            This ensures that any parsing or type checking errors are from
+            javac, so they look as expected. Beyond that, we want to
+            fail as early as possible.
+          -->
+          <execution>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/smart-web-server/src/main/java/org/smartdata/server/SmartRestServer.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/SmartRestServer.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server;
+
+import org.smartdata.conf.SmartConf;
+import org.smartdata.server.config.SsmContextInitializer;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class SmartRestServer {
+  private final SpringApplication springApplication;
+
+  private volatile ConfigurableApplicationContext applicationContext;
+
+  public SmartRestServer(SmartConf ssmConfig, SmartEngine smartEngine) {
+    this.springApplication = new SpringApplication(RestServerApplication.class);
+
+    SsmContextInitializer contextInitializer =
+        new SsmContextInitializer(smartEngine, ssmConfig);
+    springApplication.addInitializers(contextInitializer);
+  }
+
+  public void start() {
+    applicationContext = springApplication.run();
+  }
+
+  public void stop() {
+    if (isRunning()) {
+      SpringApplication.exit(applicationContext);
+    }
+  }
+
+  private boolean isRunning() {
+    return applicationContext != null;
+  }
+
+  // todo remove embedded server autoconfig exclusion after zeppelin removal
+  @SpringBootApplication(exclude = EmbeddedWebServerFactoryCustomizerAutoConfiguration.class)
+  public static class RestServerApplication {
+    // empty class just to enable auto configs
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/SmartRestServer.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/SmartRestServer.java
@@ -21,6 +21,7 @@ import org.smartdata.conf.SmartConf;
 import org.smartdata.server.config.SsmContextInitializer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -51,8 +52,13 @@ public class SmartRestServer {
     return applicationContext != null;
   }
 
-  // todo remove embedded server autoconfig exclusion after zeppelin removal
-  @SpringBootApplication(exclude = EmbeddedWebServerFactoryCustomizerAutoConfiguration.class)
+  @SpringBootApplication(exclude = {
+      // todo remove exclusion after zeppelin removal
+      EmbeddedWebServerFactoryCustomizerAutoConfiguration.class,
+      // it's needed to prevent auto-registration of spring hazelcast node
+      // in the SSM hazelcast workers cluster
+      HazelcastAutoConfiguration.class
+  })
   public static class RestServerApplication {
     // empty class just to enable auto configs
   }

--- a/smart-web-server/src/main/java/org/smartdata/server/config/EmbeddedServerCustomizer.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/EmbeddedServerCustomizer.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.config;
+
+import org.smartdata.conf.SmartConf;
+import org.springframework.boot.web.server.ConfigurableWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.stereotype.Component;
+
+import static org.smartdata.conf.SmartConfKeys.SMART_REST_SERVER_PORT_KEY;
+import static org.smartdata.conf.SmartConfKeys.SMART_REST_SERVER_PORT_KEY_DEFAULT;
+
+@Component
+public class EmbeddedServerCustomizer
+    implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
+
+  private final SmartConf conf;
+
+  public EmbeddedServerCustomizer(SmartConf smartConf) {
+    this.conf = smartConf;
+  }
+
+  @Override
+  public void customize(ConfigurableWebServerFactory factory) {
+    int serverPort = conf.getInt(SMART_REST_SERVER_PORT_KEY,
+        SMART_REST_SERVER_PORT_KEY_DEFAULT);
+    factory.setPort(serverPort);
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/config/SsmContextInitializer.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/SsmContextInitializer.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.config;
+
+import org.smartdata.conf.SmartConf;
+import org.smartdata.server.SmartEngine;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class SsmContextInitializer implements
+    ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    private final SmartEngine smartEngine;
+
+    private final SmartConf conf;
+
+    public SsmContextInitializer(SmartEngine smartEngine, SmartConf conf) {
+      this.smartEngine = smartEngine;
+      this.conf = conf;
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+      ConfigurableListableBeanFactory beanFactory = applicationContext.getBeanFactory();
+      beanFactory.registerSingleton("smartConfig", conf);
+      beanFactory.registerSingleton("smartEngine", smartEngine);
+      beanFactory.registerSingleton("statesManager", smartEngine.getStatesManager());
+      beanFactory.registerSingleton("cmdletManager", smartEngine.getCmdletManager());
+      beanFactory.registerSingleton("ruleManager", smartEngine.getRuleManager());
+    }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/controller/ActionController.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/controller/ActionController.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.smartdata.action.ActionRegistry;
+import org.smartdata.metastore.MetaStoreException;
+import org.smartdata.model.ActionDescriptor;
+import org.smartdata.model.ActionInfo;
+import org.smartdata.model.DetailedFileAction;
+import org.smartdata.server.SmartEngine;
+import org.smartdata.server.engine.CmdletManager;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.Min;
+
+import java.io.IOException;
+import java.util.List;
+
+@Tag(name = "Actions")
+@RestController
+@RequestMapping(
+    value = "/api/v1/actions",
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@Validated
+public class ActionController {
+  private final CmdletManager cmdletManager;
+
+  public ActionController(SmartEngine smartEngine) {
+    this.cmdletManager = smartEngine.getCmdletManager();
+  }
+
+  @Operation(summary = "List supported actions")
+  @GetMapping("/registry/list")
+  public List<ActionDescriptor> getSupportedActions() throws IOException {
+    return ActionRegistry.supportedActions();
+  }
+
+  @Operation(summary = "List actions")
+  @GetMapping("/list/{pageIndex}/{numPerPage}/{orderBy}/{isDesc}")
+  public CmdletManager.ActionGroup getActions(
+      @PathVariable @Min(0) int pageIndex,
+      @PathVariable @Min(0) int numPerPage,
+      @PathVariable List<String> orderBy,
+      @PathVariable List<Boolean> isDesc) throws MetaStoreException, IOException {
+    return cmdletManager.listActions(pageIndex, numPerPage, orderBy, isDesc);
+  }
+
+  @Operation(summary = "Find actions by query")
+  @GetMapping("/search/{search}/{pageIndex}/{numPerPage}/{orderBy}/{isDesc}")
+  public CmdletManager.ActionGroup searchActions(
+      @PathVariable String search,
+      @PathVariable @Min(0) int pageIndex,
+      @PathVariable @Min(0) int numPerPage,
+      @PathVariable List<String> orderBy,
+      @PathVariable List<Boolean> isDesc) throws IOException {
+    return cmdletManager.searchAction(search, pageIndex, numPerPage, orderBy, isDesc);
+  }
+
+  @Operation(summary = "List actions of rule")
+  @GetMapping("/list/{actionLimit}/{ruleId}")
+  public List<ActionInfo> getActions(
+      @PathVariable @Min(0) int actionLimit,
+      @PathVariable long ruleId) throws IOException {
+    return cmdletManager.getActions(ruleId, actionLimit);
+  }
+
+  @Operation(summary = "List file actions of rule")
+  @GetMapping("/filelist/{ruleId}/{pageIndex}/{numPerPage}")
+  public CmdletManager.DetailedFileActionGroup getFileActions(
+      @PathVariable long ruleId,
+      @PathVariable @Min(0) int pageIndex,
+      @PathVariable @Min(0) int numPerPage) throws IOException, MetaStoreException {
+    return cmdletManager.getFileActions(ruleId, pageIndex, numPerPage);
+  }
+
+  @Operation(summary = "List file actions of rule")
+  @GetMapping("/filelist/{actionLimit}/{ruleId}")
+  public List<DetailedFileAction> getFileActions(
+      @PathVariable long ruleId,
+      @PathVariable @Min(0) int actionLimit) throws IOException {
+    return cmdletManager.getFileActions(ruleId, actionLimit);
+  }
+
+  @Operation(summary = "Get the last created instances of action")
+  @GetMapping("/type/{actionLimit}/{actionName}")
+  public List<ActionInfo> getLastActions(
+      @PathVariable @Min(0) int actionLimit,
+      @PathVariable String actionName) throws IOException {
+    return cmdletManager.listNewCreatedActions(actionName, actionLimit);
+  }
+
+  @Operation(summary = "Get detailed info about action")
+  @GetMapping("/{actionId}/info")
+  public ActionInfo getActionInfo(@PathVariable long actionId) throws IOException {
+    return cmdletManager.getActionInfo(actionId);
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/controller/ClusterController.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/controller/ClusterController.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.smartdata.conf.SmartConfKeys;
+import org.smartdata.metastore.MetaStoreException;
+import org.smartdata.metastore.utils.Constants;
+import org.smartdata.model.CachedFileStatus;
+import org.smartdata.model.FileAccessInfo;
+import org.smartdata.model.FileInfo;
+import org.smartdata.model.Utilization;
+import org.smartdata.server.SmartEngine;
+import org.smartdata.server.cluster.NodeCmdletMetrics;
+import org.smartdata.server.cluster.NodeInfo;
+import org.smartdata.server.engine.StatesManager;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.Min;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+@Tag(name = "Cluster")
+@RestController
+@RequestMapping(
+    value = "/api/v1/cluster/primary",
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@Validated
+public class ClusterController {
+  private final SmartEngine smartEngine;
+  private final StatesManager statesManager;
+
+  public ClusterController(SmartEngine smartEngine, StatesManager statesManager) {
+    this.smartEngine = smartEngine;
+    this.statesManager = statesManager;
+  }
+
+  @Operation(summary = "Get address of the HDFS NameNode")
+  @GetMapping
+  public String getNameNodeUrl() {
+    return smartEngine.getConf().
+        get(SmartConfKeys.SMART_DFS_NAMENODE_RPCSERVER_KEY);
+  }
+
+  @Operation(summary = "Get list of cached files")
+  @GetMapping("/cachedfiles")
+  public List<CachedFileStatus> getCachedFiles() throws IOException {
+    return statesManager.getCachedFileStatus();
+  }
+
+  @Operation(summary = "Get list of hot files for the last hour")
+  @GetMapping("/hotfiles")
+  public List<FileAccessInfo> getHotFiles() throws IOException, MetaStoreException {
+    //TODO: Make fileLimit settable on web UI.
+    //Currently, fileLimit=0 means that SSM will use the value configured in smart-default.xml
+    return statesManager.getHotFilesForLast(Constants.ONE_HOUR_IN_MILLIS, 0);
+  }
+
+  @Operation(summary = "Get utilization of specified resource")
+  @GetMapping("/utilization/{resourceName}")
+  public Utilization getResourceUtilization(@PathVariable String resourceName) throws IOException {
+    return smartEngine.getUtilization(resourceName);
+  }
+
+  /**
+   * @param timeGranularity Time interval of successive data points in milliseconds
+   * @param intervalStart   Begin timestamp in milliseconds.
+   *                        If <=0 denotes the value related to 'endTs'
+   * @param intervalEnd     Like 'beginTs'. If <= 0 denotes the time related to current server time.
+   */
+  @Operation(summary = "Get utilization of resource for specified time interval")
+  @GetMapping("/hist_utilization/{resourceName}/{timeGranularity}/{intervalStart}/{intervalEnd}")
+  public List<Utilization> getResourceUtilizationForInterval(
+      @PathVariable String resourceName,
+      @PathVariable @Min(0) long timeGranularity,
+      @PathVariable long intervalStart,
+      @PathVariable long intervalEnd) throws IOException {
+    if (intervalEnd <= 0) {
+      intervalEnd += System.currentTimeMillis();
+    }
+
+    if (intervalStart <= 0) {
+      intervalStart += intervalEnd;
+    }
+
+    if (intervalStart > intervalEnd) {
+      throw new IOException("Invalid time range");
+    }
+
+    return smartEngine.getHistUtilization(
+        resourceName, timeGranularity, intervalStart, intervalEnd);
+  }
+
+  @Operation(summary = "Get information about file")
+  @GetMapping("/fileinfo")
+  public FileInfo getFileInfo(@RequestBody String filePath) throws IOException {
+    return statesManager.getFileInfo(filePath);
+  }
+
+  @Operation(summary = "Get information about SSM nodes")
+  @GetMapping("/ssmnodesinfo")
+  public List<NodeInfo> getSsmNodesInfo() {
+    return smartEngine.getSsmNodesInfo();
+  }
+
+  @Operation(summary = "Get cmdlet metrics from SSM nodes")
+  @GetMapping("/ssmnodescmdletmetrics")
+  public Collection<NodeCmdletMetrics> getSsmNodesCmdletMetrics() {
+    return smartEngine.getCmdletManager().getAllNodeCmdletMetrics();
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/controller/CmdletController.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/controller/CmdletController.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.smartdata.model.CmdletInfo;
+import org.smartdata.server.engine.CmdletManager;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@Tag(name = "Cmdlets")
+@RestController
+@RequestMapping(
+    value = "/api/v1/cmdlets",
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+public class CmdletController {
+  private final CmdletManager cmdletManager;
+
+  public CmdletController(CmdletManager cmdletManager) {
+    this.cmdletManager = cmdletManager;
+  }
+
+  @Operation(summary = "Get detailed info about cmdlet")
+  @GetMapping("/{cmdletId}/info")
+  public CmdletInfo getCmdletInfo(@PathVariable long cmdletId) throws IOException {
+    return cmdletManager.getCmdletInfo(cmdletId);
+  }
+
+  @Operation(summary = "List cmdlets")
+  @GetMapping("/list")
+  public List<CmdletInfo> getCmdletInfos() throws IOException {
+    return cmdletManager.listCmdletsInfo(-1, null);
+  }
+
+  @Operation(summary = "Submit cmdlet")
+  @PostMapping("/submit")
+  public long submitCmdlet(@RequestBody String cmdlet) throws IOException {
+    return cmdletManager.submitCmdlet(cmdlet);
+  }
+
+  @Operation(summary = "Stop cmdlet")
+  @PostMapping("/{cmdletId}/stop")
+  public void stopCmdlet(@PathVariable Long cmdletId) throws IOException {
+    cmdletManager.disableCmdlet(cmdletId);
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/controller/ConfigController.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/controller/ConfigController.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.smartdata.conf.SmartConf;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Tag(name = "Config")
+@RestController
+public class ConfigController {
+  private final SmartConf smartConf;
+
+  public ConfigController(SmartConf smartConf) {
+    this.smartConf = smartConf;
+  }
+
+  @Operation(summary = "Get SSM config")
+  @GetMapping(value = "/api/v1/conf", produces = MediaType.APPLICATION_JSON_VALUE)
+  public Map<String, String> getConfig() {
+    return smartConf.asMap();
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/controller/RuleController.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/controller/RuleController.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.smartdata.metastore.MetaStoreException;
+import org.smartdata.model.CmdletInfo;
+import org.smartdata.model.DetailedRuleInfo;
+import org.smartdata.model.RuleInfo;
+import org.smartdata.model.RuleState;
+import org.smartdata.server.engine.CmdletManager;
+import org.smartdata.server.engine.RuleManager;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.Min;
+
+import java.io.IOException;
+import java.util.List;
+
+@Tag(name = "Rules")
+@RestController
+@RequestMapping(
+    value = "/api/v1/rules",
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@Validated
+public class RuleController {
+  private final RuleManager ruleManager;
+  private final CmdletManager cmdletManager;
+
+  public RuleController(RuleManager ruleManager, CmdletManager cmdletManager) {
+    this.ruleManager = ruleManager;
+    this.cmdletManager = cmdletManager;
+  }
+
+  @Operation(summary = "Submit rule")
+  @PostMapping("/add")
+  public long addRule(@RequestParam String ruleText) throws IOException {
+    return ruleManager.submitRule(ruleText, RuleState.NEW);
+  }
+
+  @Operation(summary = "Delete rule")
+  @DeleteMapping("/{ruleId}/delete")
+  public void deleteRule(@PathVariable long ruleId) throws IOException {
+    ruleManager.deleteRule(ruleId, false);
+  }
+
+  @Operation(summary = "Start/continue rule")
+  @PostMapping("/{ruleId}/start")
+  public void start(@PathVariable long ruleId) throws IOException {
+    ruleManager.activateRule(ruleId);
+  }
+
+  @Operation(summary = "Stop rule")
+  @PostMapping("/{ruleId}/stop")
+  public void stop(@PathVariable long ruleId) throws IOException {
+    ruleManager.disableRule(ruleId, true);
+  }
+
+  @Operation(summary = "Get detailed info about rule")
+  @GetMapping("/{ruleId}/info")
+  public RuleInfo getInfo(@PathVariable long ruleId) throws IOException {
+    return ruleManager.getRuleInfo(ruleId);
+  }
+
+  @Operation(summary = "List all cmdlets of specified rule")
+  @GetMapping("/{ruleId}/cmdlets")
+  public List<CmdletInfo> getCmdlets(@PathVariable long ruleId) throws IOException {
+    return cmdletManager.listCmdletsInfo(ruleId, null);
+  }
+
+  @Operation(summary = "List all rules")
+  @GetMapping("/list")
+  public List<RuleInfo> getRuleInfos() {
+    return ruleManager.listRulesInfo();
+  }
+
+  @Operation(summary = "List all move rules")
+  @GetMapping("/list/move")
+  public List<DetailedRuleInfo> getMoveRuleInfos() throws IOException {
+    return ruleManager.listRulesMoveInfo();
+  }
+
+  @Operation(summary = "List all sync rules")
+  @GetMapping("/list/sync")
+  public List<DetailedRuleInfo> getSyncRuleInfos() throws IOException {
+    return ruleManager.listRulesSyncInfo();
+  }
+
+  @Operation(summary = "List all cmdlets of specified rule")
+  @GetMapping("/{ruleId}/cmdlets/{pageIndex}/{numPerPage}/{orderBy}/{isDesc}")
+  public CmdletManager.CmdletGroup getCmdlets(
+      @PathVariable long ruleId,
+      @PathVariable @Min(0) int pageIndex,
+      @PathVariable @Min(0) int numPerPage,
+      @PathVariable List<String> orderBy,
+      @PathVariable List<Boolean> isDesc) throws MetaStoreException, IOException {
+    return cmdletManager.listCmdletsInfo(
+        ruleId, pageIndex, numPerPage, orderBy, isDesc);
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/controller/SystemController.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/controller/SystemController.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.smartdata.server.SmartEngine;
+import org.smartdata.server.engine.StandbyServerInfo;
+import org.smartdata.server.engine.cmdlet.agent.AgentInfo;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.smartdata.conf.SmartConfKeys.SMART_SERVER_VERSION_CURRENT;
+import static org.smartdata.conf.SmartConfKeys.SMART_SERVER_VERSION_KEY;
+
+@Tag(name = "System")
+@RestController
+@RequestMapping(
+    value = "/api/v1/system",
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+public class SystemController {
+
+  private final SmartEngine smartEngine;
+
+  public SystemController(SmartEngine smartEngine) {
+    this.smartEngine = smartEngine;
+  }
+
+  @Operation(summary = "Get version of SSM")
+  @GetMapping("/version")
+  public String getSsmVersion() {
+    return smartEngine.getConf().get(
+        SMART_SERVER_VERSION_KEY, SMART_SERVER_VERSION_CURRENT);
+  }
+
+  @Operation(summary = "List all SSM servers")
+  @GetMapping("/servers")
+  public List<StandbyServerInfo> getServers() {
+    return smartEngine.getStandbyServers();
+  }
+
+  @Operation(summary = "List all SSM server hosts")
+  @GetMapping("/allServerHosts")
+  public Set<String> getServerHosts() {
+    return smartEngine.getServerHosts();
+  }
+
+  @Operation(summary = "List all SSM agents")
+  @GetMapping("/agents")
+  public List<AgentInfo> getAgents() {
+    return smartEngine.getAgents();
+  }
+
+  @Operation(summary = "List all SSM agent hosts")
+  @GetMapping("/allAgentHosts")
+  public Set<String> getAgentHosts() {
+    return smartEngine.getAgentHosts();
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/error/ErrorDto.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/error/ErrorDto.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.error;
+
+public class ErrorDto<T> {
+  private final String code;
+  private final String message;
+  private final T errorBody;
+
+  public ErrorDto(String code, String message) {
+    this(code, message, null);
+  }
+
+  public ErrorDto(String code, String message, T errorBody) {
+    this.code = code;
+    this.message = message;
+    this.errorBody = errorBody;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public T getErrorBody() {
+    return errorBody;
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/error/SmartExceptionHandler.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/error/SmartExceptionHandler.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.error;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.smartdata.metastore.MetaStoreException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.validation.ConstraintViolationException;
+
+import java.io.IOException;
+
+@ControllerAdvice
+public class SmartExceptionHandler extends ResponseEntityExceptionHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(SmartExceptionHandler.class);
+
+  // TODO refactor error handling and status codes after api refactoring
+  @ExceptionHandler(value = {IOException.class, MetaStoreException.class})
+  protected ResponseEntity<Object> handleSsmExceptions(
+      RuntimeException exception, WebRequest request) {
+    return handleExceptionInternal(
+        exception,
+        request,
+        "SSM_ERROR",
+        HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(value = {ConstraintViolationException.class})
+  protected ResponseEntity<Object> handleValidationExceptions(
+      RuntimeException exception, WebRequest request) {
+    return handleExceptionInternal(
+        exception,
+        request,
+        "VALIDATION_ERROR",
+        HttpStatus.BAD_REQUEST);
+  }
+
+  private ResponseEntity<Object> handleExceptionInternal(
+      Exception exception, WebRequest request, String errorCode, HttpStatus status) {
+    LOG.error("Exception during handling request on {}",
+        request.getDescription(false), exception);
+
+    ErrorDto<String> errorBody = new ErrorDto<>(
+        errorCode,
+        exception.getMessage(),
+        ExceptionUtils.getStackTrace(exception));
+
+    return handleExceptionInternal(
+        exception,
+        errorBody,
+        new HttpHeaders(),
+        status,
+        request);
+  }
+}

--- a/smart-web-server/src/main/resources/application.yaml
+++ b/smart-web-server/src/main/resources/application.yaml
@@ -1,0 +1,5 @@
+springdoc:
+  api-docs:
+    path: /openapi-spec
+  swagger-ui:
+    disable-swagger-default-url: true

--- a/smart-zeppelin/zeppelin-server/pom.xml
+++ b/smart-zeppelin/zeppelin-server/pom.xml
@@ -119,6 +119,10 @@
           <groupId>com.sun.xml.bind</groupId>
           <artifactId>jaxb-impl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-javamail_1.4_spec</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -144,6 +148,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-servlet_3.0_spec</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/smart-zeppelin/zeppelin-server/src/main/java/org/smartdata/server/rest/ActionRestApi.java
+++ b/smart-zeppelin/zeppelin-server/src/main/java/org/smartdata/server/rest/ActionRestApi.java
@@ -93,15 +93,6 @@ public class ActionRestApi {
       @PathParam("pageIndex") String pageIndex,
       @PathParam("numPerPage") String numPerPage, @PathParam("orderBy") String orderBy,
       @PathParam("isDesc") String isDesc) {
-    String res = "";
-    for (Character i: path.toCharArray()) {
-      if (i == '%' || i == '_' || i == '"' || i == '/' || i == '\'') {
-        res += '/';
-      }
-      res += i;
-    }
-    path = res;
-
     try {
       List<String> orderByList = Arrays.asList(orderBy.split(","));
       List<String> isDescStringList = Arrays.asList(isDesc.split(","));

--- a/smart-zeppelin/zeppelin-server/src/main/java/org/smartdata/server/rest/ClusterRestApi.java
+++ b/smart-zeppelin/zeppelin-server/src/main/java/org/smartdata/server/rest/ClusterRestApi.java
@@ -21,8 +21,8 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartdata.conf.SmartConfKeys;
-import org.smartdata.metastore.dao.AccessCountTable;
 import org.smartdata.metastore.utils.Constants;
+import org.smartdata.model.FileAccessInfo;
 import org.smartdata.server.SmartEngine;
 import org.smartdata.server.rest.message.JsonResponse;
 
@@ -83,10 +83,9 @@ public class ClusterRestApi {
   @Path("/primary/hotfiles")
   public Response hotFiles() {
     try {
-      List<AccessCountTable> tables =
-          smartEngine.getStatesManager().getTablesInLast(Constants.ONE_HOUR_IN_MILLIS);
-      return new JsonResponse<>(Response.Status.OK,
-          smartEngine.getStatesManager().getHotFiles(tables, 0)).build();
+      List<FileAccessInfo> hotFilesInLastHour =
+          smartEngine.getStatesManager().getHotFilesForLast(Constants.ONE_HOUR_IN_MILLIS, 0);
+      return new JsonResponse<>(Response.Status.OK, hotFilesInLastHour).build();
     } catch (Exception e) {
       logger.error("Exception in ClusterRestApi while listing hot files", e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
- Added web-server based in Spring MVC, implementing existing SSM REST API. Server port can be configured by option `smart.rest.server.port` 
- Supported OpenAPI specification generation, can be accessed on `/openapi-spec.yaml`. Rendered view can be accessed on `/swagger-ui/index.html`