### PR TITLE
[ADH-4363] Add SSM principal holder and Spring Security support

### DIFF
--- a/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -88,12 +89,17 @@ public class SmartConf extends Configuration {
         .map(String::new);
   }
 
-  public Map<String, String> asMap() {
+  public Map<String, String> asMap(Predicate<String> keyFilter) {
     return StreamSupport.stream(spliterator(), false)
+        .filter(entry -> keyFilter.test(entry.getKey()))
         .collect(Collectors.toMap(
             Map.Entry::getKey,
             Map.Entry::getValue
         ));
+  }
+
+  public Map<String, String> asMap() {
+    return asMap(key -> true);
   }
 
   private void parseHostsFiles() {

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -21,6 +21,7 @@ package org.smartdata.conf;
  * This class contains the configure keys needed by SSM.
  */
 public class SmartConfKeys {
+  public static final String SMART_CONF_KEYS_PREFIX = "smart.";
   public static final String SMART_DFS_ENABLED = "smart.dfs.enabled";
   public static final boolean SMART_DFS_ENABLED_DEFAULT = true;
 

--- a/smart-common/src/main/java/org/smartdata/security/SmartPrincipal.java
+++ b/smart-common/src/main/java/org/smartdata/security/SmartPrincipal.java
@@ -1,0 +1,32 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.smartdata.security;
+
+public class SmartPrincipal {
+  private final String name;
+
+  public SmartPrincipal(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/smart-common/src/main/java/org/smartdata/security/SmartPrincipalHolder.java
+++ b/smart-common/src/main/java/org/smartdata/security/SmartPrincipalHolder.java
@@ -1,0 +1,39 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.smartdata.security;
+
+import java.util.Optional;
+
+public class SmartPrincipalHolder {
+  private static final ThreadLocal<SmartPrincipal> CURRENT_PRINCIPAL_THREAD_LOCAL =
+      new ThreadLocal<>();
+
+  public static void setCurrentPrincipal(SmartPrincipal principal) {
+    CURRENT_PRINCIPAL_THREAD_LOCAL.set(principal);
+  }
+
+  public static void unsetCurrentPrincipal() {
+    CURRENT_PRINCIPAL_THREAD_LOCAL.remove();
+  }
+
+  public static Optional<SmartPrincipal> getCurrentPrincipal() {
+    return Optional.ofNullable(CURRENT_PRINCIPAL_THREAD_LOCAL.get());
+  }
+}

--- a/smart-web-server/pom.xml
+++ b/smart-web-server/pom.xml
@@ -53,6 +53,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 

--- a/smart-web-server/src/main/java/org/smartdata/server/config/SecurityConfiguration.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/SecurityConfiguration.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.config;
+
+import org.smartdata.conf.SmartConfKeys;
+import org.smartdata.server.security.SmartPrincipalInitializerFilter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+
+@EnableWebSecurity
+@Configuration(proxyBeanMethods = false)
+public class SecurityConfiguration {
+  @Bean
+  @ConditionalOnProperty(
+      name = SmartConfKeys.SMART_SECURITY_ENABLE,
+      havingValue = "false",
+      matchIfMissing = true)
+  public SecurityFilterChain disabledSecurityFilterChain(HttpSecurity http) throws Exception {
+    http.authorizeRequests()
+        .anyRequest()
+        .permitAll();
+    return http.build();
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = SmartConfKeys.SMART_SECURITY_ENABLE, havingValue = "true")
+  public SecurityFilterChain kerberosSecurityFilterChain(HttpSecurity http) throws Exception {
+    http.addFilterBefore(
+        new SmartPrincipalInitializerFilter(), AnonymousAuthenticationFilter.class)
+        .authorizeRequests()
+        .anyRequest()
+        // todo ADH-4364: replace with SPNEGO filter registration
+        .permitAll();
+    return http.build();
+  }
+}
+

--- a/smart-web-server/src/main/java/org/smartdata/server/security/SmartPrincipalInitializerFilter.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/security/SmartPrincipalInitializerFilter.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.security;
+
+import org.smartdata.security.SmartPrincipal;
+import org.smartdata.security.SmartPrincipalHolder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class SmartPrincipalInitializerFilter extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    Optional.ofNullable(SecurityContextHolder.getContext())
+        .map(SecurityContext::getAuthentication)
+        .map(Authentication::getName)
+        .map(SmartPrincipal::new)
+        .ifPresent(SmartPrincipalHolder::setCurrentPrincipal);
+
+    filterChain.doFilter(request, response);
+
+    SmartPrincipalHolder.unsetCurrentPrincipal();
+  }
+}


### PR DESCRIPTION
- Added the `SmartPrincipal` class providing information about the current logged-in user and the `SmartPrincipalHolder`  for accessing and setting principals
- Added Spring Security support to the `smart-web-server` module
- Added the `SmartPrincipalInitializerFilter` to inject Spring principal to the `SmartPrincipalHolder`