### PR TITLE
[ADH-4404] Add MetastoreQuery DSL

### DIFF
--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/MetastoreQuery.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/MetastoreQuery.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.smartdata.metastore.queries.expression.MetastoreQueryExpression;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+/**
+ * Builds SQL SELECT query with named placeholders for later use by NamedJdbcTemplate.
+ * */
+public class MetastoreQuery {
+  private final StringBuilder queryBuilder;
+  private final Map<String, Object> parameters;
+
+  private MetastoreQuery(String baseQuery) {
+    this.queryBuilder = new StringBuilder();
+    this.parameters = new HashMap<>();
+
+    queryBuilder.append(baseQuery).append("\n");
+  }
+
+  public static MetastoreQuery selectAll() {
+    return select("*");
+  }
+
+  public static MetastoreQuery select(String... fields) {
+    return new MetastoreQuery("SELECT " + String.join(", ", fields));
+  }
+
+  public MetastoreQuery from(String table) {
+    queryBuilder.append("FROM ")
+        .append(table)
+        .append("\n");
+    return this;
+  }
+
+  public MetastoreQuery where(MetastoreQueryExpression operator) {
+    String operatorSql = operator.build();
+
+    if (StringUtils.isNotBlank(operatorSql)) {
+      queryBuilder.append("WHERE ")
+          .append(operatorSql)
+          .append("\n");
+
+      parameters.putAll(operator.getParameters());
+    }
+
+    return this;
+  }
+
+  public MetastoreQuery withPagination(PageRequest pageRequest) {
+    Optional.ofNullable(pageRequest.getLimit())
+        .ifPresent(this::limit);
+
+    Optional.ofNullable(pageRequest.getOffset())
+        .ifPresent(this::offset);
+
+    orderBy(pageRequest.getSortColumns());
+    return this;
+  }
+
+  public MetastoreQuery limit(long limit) {
+    queryBuilder.append("LIMIT ")
+        .append(limit)
+        .append("\n");
+    return this;
+  }
+
+  public MetastoreQuery offset(long offset) {
+    queryBuilder.append("OFFSET ")
+        .append(offset)
+        .append("\n");
+    return this;
+  }
+
+  public MetastoreQuery orderBy(List<Sorting> sortColumns) {
+    if (CollectionUtils.isEmpty(sortColumns)) {
+      return this;
+    }
+
+    queryBuilder.append("ORDER BY ");
+
+    String columnsSql = sortColumns.stream()
+        .map(Sorting::toString)
+        .collect(Collectors.joining(", "));
+    queryBuilder.append(columnsSql).append("\n");
+
+    return this;
+  }
+
+  public <T> List<T> execute(NamedParameterJdbcTemplate jdbcTemplate, RowMapper<T> rowMapper) {
+    return jdbcTemplate.query(toSqlQuery(), parameters, rowMapper);
+  }
+
+  public String toSqlQuery() {
+    return queryBuilder.toString();
+  }
+
+  public Map<String, Object> getParameters() {
+    return parameters;
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/PageRequest.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/PageRequest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PageRequest {
+  private final Long offset;
+  private final Long limit;
+
+  private final List<Sorting> sortColumns;
+
+  public PageRequest(Long offset, Long limit, List<Sorting> sortColumns) {
+    this.offset = offset;
+    this.limit = limit;
+    this.sortColumns = sortColumns;
+  }
+
+  public Long getOffset() {
+    return offset;
+  }
+
+  public Long getLimit() {
+    return limit;
+  }
+
+  public List<Sorting> getSortColumns() {
+    return sortColumns;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long offset;
+    private Long limit;
+    private List<Sorting> sortColumns;
+
+    public Builder() {
+      this.sortColumns = new ArrayList<>();
+    }
+
+    public Builder offset(Long offset) {
+      this.offset = offset;
+      return this;
+    }
+
+    public Builder limit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder sortByAsc(String column) {
+      return addSorting(column, Sorting.Order.ASC);
+    }
+
+    public Builder sortByDesc(String column) {
+      return addSorting(column, Sorting.Order.DESC);
+    }
+
+    public Builder sortColumns(List<Sorting> sortColumns) {
+      this.sortColumns = sortColumns;
+      return this;
+    }
+
+    public Builder addSorting(String column, Sorting.Order order) {
+      this.sortColumns.add(new Sorting(column, order));
+      return this;
+    }
+
+    public PageRequest build() {
+      return new PageRequest(offset, limit, sortColumns);
+    }
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/Sorting.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/Sorting.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries;
+
+public class Sorting {
+  public enum Order {
+    ASC,
+    DESC
+  }
+
+  private final String column;
+  private final Order order;
+
+  public Sorting(String column, Order order) {
+    this.column = column;
+    this.order = order;
+  }
+
+  @Override
+  public String toString() {
+    return column + " " + order;
+  }
+
+  public String getColumn() {
+    return column;
+  }
+
+  public Order getOrder() {
+    return order;
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryDsl.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryDsl.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries.expression;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * DSL for convenient writing of SQL queries with multiple
+ * (possibly optional) filters. if null value is provided
+ * to any of the operator constructor methods, then such operator will be ignored.
+ * */
+public class MetastoreQueryDsl {
+
+  private static final MetastoreQueryExpression EMPTY_EXPRESSION = () -> "";
+
+  public static MetastoreQueryExpression or(MetastoreQueryExpression... expressions) {
+    return operator("OR", expressions);
+  }
+
+  public static MetastoreQueryExpression and(MetastoreQueryExpression... expressions) {
+    return operator("AND", expressions);
+  }
+
+  public static <T> MetastoreQueryExpression greaterThan(String column, T value) {
+    return binaryOpWithPlaceholder(">", column, value);
+  }
+
+  public static <T> MetastoreQueryExpression greaterThanEqual(String column, T value) {
+    return binaryOpWithPlaceholder(">=", column, value);
+  }
+
+  public static <T> MetastoreQueryExpression lessThan(String column, T value) {
+    return binaryOpWithPlaceholder("<", column, value);
+  }
+
+  public static <T> MetastoreQueryExpression lessThanEqual(String column, T value) {
+    return binaryOpWithPlaceholder("<=", column, value);
+  }
+
+  public static <T> MetastoreQueryExpression equal(String column, T value) {
+    return binaryOpWithPlaceholder("=", column, value);
+  }
+
+  public static <T> MetastoreQueryExpression in(String column, List<T> values) {
+    return binaryOpWithPlaceholder("IN", column, values);
+  }
+
+  public static <T> MetastoreQueryExpression like(String column, T value) {
+    return Optional.ofNullable(value)
+        .map(val -> binaryOpWithPlaceholder("LIKE", column, "%" + val + "%"))
+        .orElse(EMPTY_EXPRESSION);
+  }
+
+  private static MetastoreQueryExpression operator(
+      String operator, MetastoreQueryExpression... expressions) {
+    List<MetastoreQueryExpression> nonEmptyExpressions = Arrays.stream(expressions)
+        .filter(expression -> !EMPTY_EXPRESSION.equals(expression))
+        .collect(Collectors.toList());
+
+    if (nonEmptyExpressions.isEmpty()) {
+      return EMPTY_EXPRESSION;
+    }
+
+    return new MetastoreQueryOperator(operator, nonEmptyExpressions);
+  }
+
+  private static <T> MetastoreQueryExpression binaryOpWithPlaceholder(
+      String operator, String column, T value) {
+    if (value == null) {
+      return EMPTY_EXPRESSION;
+    }
+
+    return new MetastoreQueryOperator(operator,
+        Arrays.asList(
+            () -> column,
+            new MetastoreQueryPlaceholder<>(column, value)
+        )
+    );
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryExpression.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryExpression.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries.expression;
+
+import java.util.Collections;
+import java.util.Map;
+
+public interface MetastoreQueryExpression {
+  String build();
+
+  default Map<String, Object> getParameters() {
+     return Collections.emptyMap();
+   }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryOperator.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryOperator.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries.expression;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+
+public class MetastoreQueryOperator implements MetastoreQueryExpression {
+  private final StringJoiner builder;
+  private final Map<String, Object> parameters = new HashMap<>();
+
+  public MetastoreQueryOperator(String delimiter, List<MetastoreQueryExpression> operators) {
+    this.builder = new StringJoiner(" " + delimiter + " ", "(", ")");
+    operators.forEach(this::withArg);
+  }
+
+  public void withArg(MetastoreQueryExpression operator) {
+    builder.add(operator.build());
+    parameters.putAll(operator.getParameters());
+  }
+
+  @Override
+  public String build() {
+    return builder.toString();
+  }
+
+  @Override
+  public Map<String, Object> getParameters() {
+    return parameters;
+  }
+}

--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryPlaceholder.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/expression/MetastoreQueryPlaceholder.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries.expression;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MetastoreQueryPlaceholder<T> implements MetastoreQueryExpression {
+
+  private final String column;
+  private final T value;
+
+  public MetastoreQueryPlaceholder(String column, T value) {
+    this.column = column;
+    this.value = value;
+  }
+
+  public String build() {
+    return "(:" + column + ")";
+  }
+
+  @Override
+  public Map<String, Object> getParameters() {
+    return Collections.singletonMap(column, value);
+  }
+}

--- a/smart-metastore/src/test/java/org/smartdata/metastore/queries/MetastoreQueryTest.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/queries/MetastoreQueryTest.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries;
+
+import org.apache.curator.shaded.com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.smartdata.metastore.queries.MetastoreQuery.select;
+import static org.smartdata.metastore.queries.MetastoreQuery.selectAll;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.and;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.equal;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.greaterThan;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.greaterThanEqual;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.in;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.lessThan;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.lessThanEqual;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.like;
+import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.or;
+
+public class MetastoreQueryTest {
+
+  @Test
+  public void testAllOperators() throws IOException {
+    PageRequest pageRequest = PageRequest.builder()
+        .offset(0L)
+        .limit(10L)
+        .sortByAsc("id")
+        .sortByAsc("ascColumn")
+        .sortByDesc("descColumn")
+        .build();
+
+    MetastoreQuery query =
+        select("id", "anotherColumn")
+            .from("testTable")
+            .where(
+                or(
+                    and(
+                        greaterThan("gtColumn", 1),
+                        lessThan("ltColumn", 2L),
+                        greaterThanEqual("gteColumn", 3.0),
+                        lessThanEqual("lteColumn", 4.0F)
+                    ),
+                    equal("anotherColumn", "str_val"),
+                    in("listMember", Arrays.asList(1, 2)),
+                    like("strColumn", "pattern")
+                )
+            ).withPagination(pageRequest);
+
+    Map<String, Object> expectedParams = ImmutableMap.<String, Object>builder()
+        .put("gtColumn", 1)
+        .put("ltColumn", 2L)
+        .put("gteColumn", 3.0)
+        .put("lteColumn", 4.0F)
+        .put("anotherColumn", "str_val")
+        .put("listMember", Arrays.asList(1, 2))
+        .put("strColumn", "%pattern%")
+        .build();
+
+    assertQuery("allOperators", query, expectedParams);
+  }
+
+  @Test
+  public void testRemoveNullFilters() throws IOException {
+    MetastoreQuery query =
+        selectAll()
+            .from("tableName")
+            .where(
+                and(
+                    equal("nullColumn1", null),
+                    like("nonNullColumn1", "test"),
+                    or(
+                        greaterThan("nonNullColumn2", 777),
+                        in("nullColumn2", null)
+                    )
+                )
+            )
+            .limit(12L);
+
+    Map<String, Object> expectedParams = ImmutableMap.of(
+        "nonNullColumn1", "%test%",
+        "nonNullColumn2", 777
+    );
+    assertQuery("ignoredNullFilters", query, expectedParams);
+  }
+
+  @Test
+  public void testCollapseWhereIfAllFiltersAreNull() throws IOException {
+    MetastoreQuery query =
+        selectAll()
+            .from("tableName")
+            .where(
+                or(
+                    and(
+                        greaterThan("field3", null),
+                        in("listField", null)
+                    ),
+                    equal("column", null),
+                    like("test", null)
+                )
+            );
+
+    assertQuery("collapsedQuery", query, Collections.emptyMap());
+  }
+
+  private void assertQuery(
+      String queryName, MetastoreQuery query, Map<String, Object> expectedParams)
+      throws IOException {
+    String expectedSqlQuery = getTestQuery(queryName);
+
+    assertEquals(expectedSqlQuery, query.toSqlQuery());
+    assertEquals(expectedParams, query.getParameters());
+  }
+
+  private String getTestQuery(String name) throws IOException {
+    Path queryPath = Optional.ofNullable(getClass().getClassLoader().getResource("queries"))
+        .map(confDir -> Paths.get(confDir.getPath(), name + ".sql"))
+        .orElseThrow(() -> new RuntimeException("Resource not found"));
+
+    return new String(Files.readAllBytes(queryPath), StandardCharsets.UTF_8);
+  }
+}

--- a/smart-metastore/src/test/resources/queries/allOperators.sql
+++ b/smart-metastore/src/test/resources/queries/allOperators.sql
@@ -1,0 +1,6 @@
+SELECT id, anotherColumn
+FROM testTable
+WHERE (((gtColumn > (:gtColumn)) AND (ltColumn < (:ltColumn)) AND (gteColumn >= (:gteColumn)) AND (lteColumn <= (:lteColumn))) OR (anotherColumn = (:anotherColumn)) OR (listMember IN (:listMember)) OR (strColumn LIKE (:strColumn)))
+LIMIT 10
+OFFSET 0
+ORDER BY id ASC, ascColumn ASC, descColumn DESC

--- a/smart-metastore/src/test/resources/queries/collapsedQuery.sql
+++ b/smart-metastore/src/test/resources/queries/collapsedQuery.sql
@@ -1,0 +1,2 @@
+SELECT *
+FROM tableName

--- a/smart-metastore/src/test/resources/queries/ignoredNullFilters.sql
+++ b/smart-metastore/src/test/resources/queries/ignoredNullFilters.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM tableName
+WHERE ((nonNullColumn1 LIKE (:nonNullColumn1)) AND ((nonNullColumn2 > (:nonNullColumn2))))
+LIMIT 12


### PR DESCRIPTION
- Added `MetastoreQuery` - entity that creates sql queries with named placeholders for later use by `NamedJdbcTemplate` 
- Added DSL for convenient writing of SQL queries with multiple (possibly optional) filters in the WHERE clause