### PR TITLE
[ADH-4424] Refactor smart-client module and add tests

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -517,4 +517,21 @@
     <value>8081</value>
     <description>SSM Rest Server port</description>
   </property>
+
+  <property>
+    <name>smart.client.report.tasks.timeout.ms</name>
+    <value>2000</value>
+    <description>
+      Timeout in milliseconds for the successful file access report.
+      Has an effect only if the 'smart.client.concurrent.report.enabled' option is set to true.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.client.active.server.cache.path</name>
+    <value>/tmp/active_smart_server</value>
+    <description>
+      Local filesystem path of the active Smart Server address file-based cache.
+    </description>
+  </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <spring.version>5.3.31</spring.version>
     <antlr4.version>4.6</antlr4.version>
     <hazelcast.version>4.2.8</hazelcast.version>
-    <guava.version>15.0</guava.version>
+    <guava.version>20.0</guava.version>
     <gson.version>2.10.1</gson.version>
     <test.build.dir>${project.build.directory}/test-dir</test.build.dir>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>

--- a/smart-client/pom.xml
+++ b/smart-client/pom.xml
@@ -41,6 +41,11 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/smart-client/src/main/java/org/smartdata/client/SmartClient.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartClient.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,202 +15,101 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.smartdata.client;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
-import org.smartdata.SmartConstants;
+import org.smartdata.client.activeserver.ActiveServerAddressCache;
+import org.smartdata.client.fileaccess.FileAccessReportStrategy;
 import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.metrics.FileAccessEvent;
 import org.smartdata.model.FileState;
 import org.smartdata.model.NormalFileState;
+import org.smartdata.model.PathChecker;
 import org.smartdata.protocol.SmartClientProtocol;
 import org.smartdata.protocol.protobuffer.ClientProtocolClientSideTranslator;
 import org.smartdata.protocol.protobuffer.ClientProtocolProtoBuffer;
-import org.smartdata.utils.StringUtil;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.concurrent.Callable;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
-public class SmartClient implements java.io.Closeable, SmartClientProtocol {
+import static org.smartdata.utils.ConfigUtil.getSsmRpcAddresses;
+
+public class SmartClient implements Closeable, SmartClientProtocol {
   private static final long VERSION = 1;
-  private Configuration conf;
-  /** The server queue keeps server's order according to active status. **/
-  private Deque<SmartClientProtocol> serverQue;
-  /** The map from server to its rpc address in "hostname:port" format. **/
-  private Map<SmartClientProtocol, String> serverToRpcAddr;
+  private static final int SINGLE_IGNORE_FILES_INITIAL_CAPACITY = 200;
+
+  private final Configuration conf;
+  private final SmartServerHandles smartServerHandles;
+  private final Set<String> singleIgnoreFiles;
+  private final PathChecker pathChecker;
+  private final FileAccessReportStrategy fileAccessReportStrategy;
+  private final ActiveServerAddressCache activeServerAddressCache;
   private volatile boolean running = true;
-  private List<String> ignoreAccessEventDirs;
-  private Map<String, Integer> singleIgnoreList;
-  private List<String> coverAccessEventDirs;
-  public static final String ACTIVE_SMART_SERVER_FILE_PATH = "/tmp/active_smart_server";
 
   public SmartClient(Configuration conf) throws IOException {
-    this.conf = conf;
-    this.serverQue = new LinkedList<>();
-    this.serverToRpcAddr = new HashMap<>();
-    this.ignoreAccessEventDirs = new ArrayList<>();
-    this.coverAccessEventDirs = new ArrayList<>();
-    this.singleIgnoreList = new ConcurrentHashMap<>(200);
-
-    String[] rpcConfValue =
-        conf.getTrimmedStrings(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    if (rpcConfValue == null || rpcConfValue.length == 0) {
-      throw new IOException("SmartServer address not found. Please configure "
-          + "it through " + SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
-    }
-    List<InetSocketAddress> addrList = new LinkedList<>();
-    for (String rpcValue : rpcConfValue) {
-      String[] hostAndPort = rpcValue.split(":");
-      try {
-        InetSocketAddress smartServerAddress = new InetSocketAddress(
-            hostAndPort[hostAndPort.length - 2],
-            Integer.parseInt(hostAndPort[hostAndPort.length - 1]));
-        addrList.add(smartServerAddress);
-      } catch (Exception e) {
-        throw new IOException("Incorrect SmartServer address. Please follow "
-            + "IP/Hostname:Port format");
-      }
-    }
-    initialize(addrList.toArray(new InetSocketAddress[addrList.size()]));
+    this(conf, getSsmRpcAddresses(conf));
   }
 
-  public SmartClient(Configuration conf, InetSocketAddress address)
+  public SmartClient(Configuration conf, InetSocketAddress ssmRpcAddress) throws IOException {
+    this(conf, Collections.singletonList(ssmRpcAddress));
+  }
+
+  public SmartClient(Configuration conf, List<InetSocketAddress> ssmRpcAddresses)
+      throws IOException {
+    this(conf, ssmRpcAddresses, ActiveServerAddressCache.fileCache(conf));
+  }
+
+  public SmartClient(
+      Configuration conf,
+      List<InetSocketAddress> ssmRpcAddresses,
+      ActiveServerAddressCache activeServerAddressCache)
       throws IOException {
     this.conf = conf;
-    this.serverQue = new LinkedList<>();
-    this.serverToRpcAddr = new HashMap<>();
-    this.ignoreAccessEventDirs = new ArrayList<>();
-    this.coverAccessEventDirs = new ArrayList<>();
-    this.singleIgnoreList = new ConcurrentHashMap<>(200);
-
-    initialize(new InetSocketAddress[]{address});
+    this.singleIgnoreFiles = ConcurrentHashMap.newKeySet(SINGLE_IGNORE_FILES_INITIAL_CAPACITY);
+    this.pathChecker = new PathChecker(conf);
+    this.activeServerAddressCache = activeServerAddressCache;
+    this.smartServerHandles = new SmartServerHandles(
+        initializeServerHandles(ssmRpcAddresses));
+    this.fileAccessReportStrategy = FileAccessReportStrategy.from(conf, smartServerHandles);
   }
 
-  public SmartClient(Configuration conf, InetSocketAddress[] addrs)
-      throws IOException {
-    this.conf = conf;
-    this.serverQue = new LinkedList<>();
-    this.serverToRpcAddr = new HashMap<>();
-    this.ignoreAccessEventDirs = new ArrayList<>();
-    this.coverAccessEventDirs = new ArrayList<>();
-    this.singleIgnoreList = new ConcurrentHashMap<>(200);
-
-    initialize(addrs);
-  }
-
-  private void initialize(InetSocketAddress[] addrs) throws IOException {
-    RPC.setProtocolEngine(conf, ClientProtocolProtoBuffer.class,
-        ProtobufRpcEngine.class);
-    List<InetSocketAddress> orderedAddrs = new ArrayList<>();
-    InetSocketAddress recordedActiveAddr = getActiveServerAddress();
-    if (recordedActiveAddr != null) {
-      orderedAddrs.add(recordedActiveAddr);
+  private List<SmartServerHandle> initializeServerHandles(
+      List<InetSocketAddress> addresses) throws IOException {
+    if (CollectionUtils.isEmpty(addresses)) {
+      throw new IllegalArgumentException("Empty list of SSM RPC addresses");
     }
-    for (InetSocketAddress addr : addrs) {
-      if (!addr.equals(recordedActiveAddr)) {
-        orderedAddrs.add(addr);
-      }
-    }
-    for (InetSocketAddress addr : orderedAddrs) {
+
+    RPC.setProtocolEngine(
+        conf, ClientProtocolProtoBuffer.class, ProtobufRpcEngine.class);
+
+    Iterable<InetSocketAddress> orderedAddresses = activeServerAddressCache.get()
+        .map(activeServerAddress ->
+            getOrderedServerAddresses(activeServerAddress, addresses))
+        .orElse(addresses);
+
+    List<SmartServerHandle> serverHandles = new ArrayList<>();
+
+    for (InetSocketAddress addr : orderedAddresses) {
       ClientProtocolProtoBuffer proxy = RPC.getProxy(
           ClientProtocolProtoBuffer.class, VERSION, addr, conf);
       SmartClientProtocol server = new ClientProtocolClientSideTranslator(proxy);
-      serverQue.addLast(server);
-      serverToRpcAddr.put(server, addr.getHostName() + ":" + addr.getPort());
+      serverHandles.add(new SmartServerHandle(server, addr));
     }
-
-    // SMART_IGNORE_DIRS_KEY and SMART_WORK_DIR_KEY should be configured on
-    // application side if its dfsClient is replaced by SmartDfsClient.
-    Collection<String> ignoreDirs = conf.getTrimmedStringCollection(
-        SmartConfKeys.SMART_IGNORE_DIRS_KEY);
-    // The system folder and SSM work folder should be ignored to
-    // report access count.
-    ignoreDirs.add(SmartConstants.SYSTEM_FOLDER);
-    ignoreDirs.add(conf.get(SmartConfKeys.SMART_WORK_DIR_KEY,
-        SmartConfKeys.SMART_WORK_DIR_DEFAULT));
-    for (String s : ignoreDirs) {
-      ignoreAccessEventDirs.add(s + (s.endsWith("/") ? "" : "/"));
-    }
-
-    Collection<String> coverDirs = conf.getTrimmedStringCollection(
-        SmartConfKeys.SMART_COVER_DIRS_KEY);
-    for (String s : coverDirs) {
-      coverAccessEventDirs.add(s + (s.endsWith("/") ? "" : "/"));
-    }
-  }
-
-  private void checkOpen() throws IOException {
-    if (!running) {
-      throw new IOException("SmartClient closed");
-    }
-  }
-
-  /**
-   * Record active server (hostname:port) currently found into a local file.
-   * This file can be dropped by OS, but considering it's just used for
-   * optimization, the lack of recorded active server doesn't cause critical
-   * issue.
-   */
-  private void recordActiveServerAddr(String addr) {
-    FileWriter fw = null;
-    try {
-      if (!new File(ACTIVE_SMART_SERVER_FILE_PATH).exists()) {
-        new File(ACTIVE_SMART_SERVER_FILE_PATH).createNewFile();
-      }
-      fw = new FileWriter(ACTIVE_SMART_SERVER_FILE_PATH);
-      fw.write(addr);
-    } catch (IOException e) {
-      // Nothing to do.
-    } finally {
-      if (fw != null) {
-        try {
-          fw.close();
-        } catch (IOException e) {
-          // Nothing to do.
-        }
-      }
-    }
-  }
-
-  /**
-   * Get recorded active server address (hostname:port).
-   *
-   * @return active server address if found. Otherwise, null.
-   */
-  private InetSocketAddress getActiveServerAddress() {
-    try {
-      Scanner scanner = new Scanner(new File(ACTIVE_SMART_SERVER_FILE_PATH));
-      if (scanner.hasNextLine()) {
-        String address = scanner.nextLine();
-        String[] strings = address.split(":");
-        return new InetSocketAddress(strings[0], Integer.valueOf(strings[1]));
-      }
-    } catch (FileNotFoundException e) {
-      return null;
-    }
-    return null;
+    return serverHandles;
   }
 
   /**
@@ -225,9 +124,6 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
    * next time a SmartClient is created with this Configuration instance,
    * active server will be put in the head of a queue and it will be picked
    * up firstly.
-   *
-   * @param event
-   * @throws IOException
    */
   @Override
   public void reportFileAccessEvent(FileAccessEvent event)
@@ -236,93 +132,77 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
       return;
     }
     checkOpen();
-    if (conf.getBoolean(SmartConfKeys.SMART_CLIENT_CONCURRENT_REPORT_ENABLED,
-        SmartConfKeys.SMART_CLIENT_CONCURRENT_REPORT_ENABLED_DEFAULT)) {
-      reportFileAccessEventConcurrently(event);
-    } else {
-      reportFileAccessEventSimply(event);
-    }
+
+    SmartServerHandle reportedServerHandle =
+        fileAccessReportStrategy.reportFileAccessEvent(event);
+
+    maybeUpdateActiveSmartServer(reportedServerHandle);
   }
 
-  /**
-   * A simple report strategy that tries to connect to smart server one by one.
-   * And active smart server address will be updated in a local file for new
-   * client to use henceforth.
-   * @param event
-   * @throws IOException
-   */
-  private void reportFileAccessEventSimply(FileAccessEvent event)
-      throws IOException {
-    int failedServerNum = 0;
-    while (true) {
+  @Override
+  public FileState getFileState(String filePath) throws IOException {
+    checkOpen();
+
+    for (SmartServerHandle serverHandle : smartServerHandles.handles()) {
       try {
-        SmartClientProtocol server = serverQue.getFirst();
-        server.reportFileAccessEvent(event);
-        if (failedServerNum != 0) {
-          onNewActiveSmartServer();
-        }
-        break;
-      } catch (ConnectException e) {
-        failedServerNum++;
-        // If all servers has been tried but still fail,
-        // throw an exception.
-        if (failedServerNum == serverQue.size()) {
-          throw new ConnectException("Tried to connect to configured SSM "
-              + "server(s), but failed." + e.getMessage());
-        }
-        // Move the first server to last.
-        serverQue.addLast(serverQue.pollFirst());
+        FileState fileState = serverHandle.getProtocol().getFileState(filePath);
+        maybeUpdateActiveSmartServer(serverHandle);
+        return fileState;
+      } catch (ConnectException exception) {
+        // try next server
       }
+    }
+
+    // client cannot connect to servers
+    // don't report access event for this file this time
+    singleIgnoreFiles.add(filePath);
+
+    // Assume the given file is normal, but serious error can occur if
+    // the file is compacted or compressed by SSM.
+    return new NormalFileState(filePath);
+  }
+
+  public boolean shouldIgnore(String path) {
+    if (singleIgnoreFiles.remove(path)) {
+      // this report should be ignored
+      return true;
+    }
+    return pathChecker.isIgnored(path)
+        || !pathChecker.isCovered(path);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (running) {
+      running = false;
+      for (SmartServerHandle server : smartServerHandles.handles()) {
+        RPC.stopProxy(server.getProtocol());
+      }
+
+      fileAccessReportStrategy.close();
     }
   }
 
-  /**
-   * Report file access event concurrently. Only one server is active, so
-   * reporting to this server will be successful.
-   * @param event
-   */
-  private void reportFileAccessEventConcurrently(FileAccessEvent event)
-      throws IOException {
-    int num = serverQue.size();
-    ExecutorService executorService = Executors.newFixedThreadPool(num);
-    Future<Void>[] futures = new Future[num];
-    int index = 0;
-    for (SmartClientProtocol server : serverQue) {
-      futures[index] = executorService.submit(new Callable<Void>() {
-        @Override
-        public Void call() throws IOException {
-          server.reportFileAccessEvent(event);
-          return null;
-        }
-      });
-      index++;
+  private Collection<InetSocketAddress> getOrderedServerAddresses(
+      InetSocketAddress activeServerAddress,
+      Collection<InetSocketAddress> serverAddresses) {
+
+    Set<InetSocketAddress> orderedServers = new LinkedHashSet<>();
+    // last active server address should be first
+    orderedServers.add(activeServerAddress);
+    orderedServers.addAll(serverAddresses);
+    return orderedServers;
+  }
+
+  private void checkOpen() throws IOException {
+    if (!running) {
+      throw new IOException("SmartClient closed");
     }
-    boolean isReported = false;
-    byte tryNum = 0;
-    while (tryNum++ < 10) {
-      for (Future<Void> future : futures) {
-        try {
-          // A short timeout value for performance consideration.
-          future.get(200, TimeUnit.MILLISECONDS);
-          isReported = true;
-          break;
-          // ExecutionException will be thrown if IOException inside #call is
-          // thrown. Multiple calling #get with exception thrown behaves
-          // consistently.
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-          continue;
-        }
-      }
-      if (isReported) {
-        break;
-      }
-    }
-    // Cancel the report tasks. No impact on the successfully executed task.
-    for (Future<Void> future : futures) {
-      future.cancel(true);
-    }
-    if (!isReported) {
-      throw new IOException("Failed to report access event to Smart Server!");
+  }
+
+  private void maybeUpdateActiveSmartServer(SmartServerHandle newActiveServer) {
+    if (!newActiveServer.equals(smartServerHandles.activeServer())) {
+      onNewActiveSmartServer(newActiveServer);
     }
   }
 
@@ -330,73 +210,17 @@ public class SmartClient implements java.io.Closeable, SmartClientProtocol {
    * Reset smart server address in conf and a local file to reflect the
    * changes of active smart server in fail over.
    */
-  public void onNewActiveSmartServer() {
-    List<String> rpcAddrs = new LinkedList<>();
-    for (SmartClientProtocol s : serverQue) {
-      rpcAddrs.add(serverToRpcAddr.get(s));
-    }
-    conf.set(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY,
-        StringUtil.join(",", rpcAddrs));
-    String addr = serverToRpcAddr.get(serverQue.getFirst());
-    recordActiveServerAddr(addr);
-  }
+  private void onNewActiveSmartServer(SmartServerHandle newActiveServer) {
+    smartServerHandles.withNewActiveServer(newActiveServer);
 
-  @Override
-  public FileState getFileState(String filePath) throws IOException {
-    checkOpen();
-    int triedServerNum = 0;
-    while (true) {
-      try {
-        SmartClientProtocol server = serverQue.getFirst();
-        return server.getFileState(filePath);
-      } catch (ConnectException e) {
-        triedServerNum++;
-        // If all servers has been tried, interrupt and throw the exception.
-        if (triedServerNum == serverQue.size()) {
-          // client cannot connect to server
-          // don't report access event for this file this time
-          singleIgnoreList.put(filePath, 0);
-          // Assume the given file is normal, but serious error can occur if
-          // the file is compacted or compressed by SSM.
-          return new NormalFileState(filePath);
-        }
-        // Put the first server to last, and will pick the second one to try.
-        serverQue.addLast(serverQue.pollFirst());
-      }
-    }
-  }
+    String joinedSsmAddresses = smartServerHandles.handles()
+        .stream()
+        .map(SmartServerHandle::getAddress)
+        .map(InetSocketAddress::toString)
+        .collect(Collectors.joining(","));
 
-  public boolean shouldIgnore(String path) {
-    if (singleIgnoreList.containsKey(path)) {
-      // this report should be ignored
-      singleIgnoreList.remove(path);
-      return true;
-    }
-    String toCheck = path.endsWith("/") ? path : path + "/";
-    for (String s : ignoreAccessEventDirs) {
-      if (toCheck.startsWith(s)) {
-        return true;
-      }
-    }
-    if (coverAccessEventDirs.isEmpty()) {
-      return false;
-    }
-    for (String s : coverAccessEventDirs) {
-      if (toCheck.startsWith(s)) {
-        return false;
-      }
-    }
-    return true;
-  }
+    conf.set(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY, joinedSsmAddresses);
 
-  @Override
-  public void close() {
-    if (running) {
-      running = false;
-      for (SmartClientProtocol server : serverQue) {
-        RPC.stopProxy(server);
-      }
-      serverQue = null;
-    }
+    activeServerAddressCache.put(newActiveServer.getAddress());
   }
 }

--- a/smart-client/src/main/java/org/smartdata/client/SmartServerHandle.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartServerHandle.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client;
+
+import org.smartdata.protocol.SmartClientProtocol;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+public class SmartServerHandle {
+  private final SmartClientProtocol protocol;
+
+  private final InetSocketAddress address;
+
+  public SmartServerHandle(SmartClientProtocol protocol, InetSocketAddress address) {
+    this.protocol = protocol;
+    this.address = address;
+  }
+
+  public SmartClientProtocol getProtocol() {
+    return protocol;
+  }
+
+  public InetSocketAddress getAddress() {
+    return address;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SmartServerHandle that = (SmartServerHandle) o;
+    return Objects.equals(address, that.address);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(address);
+  }
+
+  @Override
+  public String toString() {
+    return "SmartServerHandle{"
+        + "address=" + address
+        + '}';
+  }
+}

--- a/smart-client/src/main/java/org/smartdata/client/SmartServerHandles.java
+++ b/smart-client/src/main/java/org/smartdata/client/SmartServerHandles.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SmartServerHandles {
+
+  private volatile List<SmartServerHandle> serverHandles;
+
+  public SmartServerHandles(List<SmartServerHandle> serverHandles) {
+    if (CollectionUtils.isEmpty(serverHandles)) {
+      throw new IllegalStateException("Server handles shouldn't be empty");
+    }
+    this.serverHandles = serverHandles;
+  }
+
+  public void withNewActiveServer(SmartServerHandle activeServer) {
+    List<SmartServerHandle> newHandles = new ArrayList<>();
+    newHandles.add(activeServer);
+
+    for (SmartServerHandle handle: serverHandles) {
+      if (!handle.equals(activeServer)) {
+        newHandles.add(activeServer);
+      }
+    }
+    this.serverHandles = newHandles;
+  }
+
+  /**
+   * Returns the list of smart server handles,
+   * with the handle of the active server in the first position.
+   */
+  public List<SmartServerHandle> handles() {
+    return serverHandles;
+  }
+
+  public SmartServerHandle activeServer() {
+    return serverHandles.get(0);
+  }
+}

--- a/smart-client/src/main/java/org/smartdata/client/activeserver/ActiveServerAddressCache.java
+++ b/smart-client/src/main/java/org/smartdata/client/activeserver/ActiveServerAddressCache.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.activeserver;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.InetSocketAddress;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.smartdata.conf.SmartConfKeys.SMART_CLIENT_ACTIVE_SERVER_CACHE_PATH_DEFAULT;
+import static org.smartdata.conf.SmartConfKeys.SMART_CLIENT_ACTIVE_SERVER_CACHE_PATH_KEY;
+
+public interface ActiveServerAddressCache {
+  void put(InetSocketAddress serverAddress);
+
+  Optional<InetSocketAddress> get();
+
+  static ActiveServerAddressCache fileCache(Configuration conf) {
+    String cacheFilePath = conf.get(
+        SMART_CLIENT_ACTIVE_SERVER_CACHE_PATH_KEY,
+        SMART_CLIENT_ACTIVE_SERVER_CACHE_PATH_DEFAULT);
+
+    return new ActiveServerAddressFileCache(Paths.get(cacheFilePath));
+  }
+}

--- a/smart-client/src/main/java/org/smartdata/client/activeserver/ActiveServerAddressFileCache.java
+++ b/smart-client/src/main/java/org/smartdata/client/activeserver/ActiveServerAddressFileCache.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.activeserver;
+
+import com.google.common.net.HostAndPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+
+/**
+ * Record active server (hostname:port) into a local file.
+ * This file can be dropped by OS, but considering it's just used for
+ * optimization, the lack of the recorded active server doesn't cause critical
+ * issue.
+ */
+public class ActiveServerAddressFileCache implements ActiveServerAddressCache {
+  static final Logger LOG = LoggerFactory.getLogger(ActiveServerAddressFileCache.class);
+
+  private final Path filePath;
+
+  public ActiveServerAddressFileCache(Path filePath) {
+    this.filePath = filePath;
+  }
+
+  @Override
+  public void put(InetSocketAddress serverAddress) {
+    try {
+      Files.write(
+          filePath,
+          serverAddress.toString().getBytes(StandardCharsets.UTF_8),
+          StandardOpenOption.CREATE);
+    } catch (IOException exception) {
+      // we log to debug to avoid messing up hdfs cli commands output
+      LOG.debug("Error saving active server address in the file {}", filePath, exception);
+    }
+  }
+
+  @Override
+  public Optional<InetSocketAddress> get() {
+    try {
+      byte[] addressBytes = Files.readAllBytes(filePath);
+      HostAndPort hostAndPort = HostAndPort.fromString(
+          new String(addressBytes, StandardCharsets.UTF_8));
+      InetSocketAddress serverAddress =
+          new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort());
+      return Optional.of(serverAddress);
+    } catch (Exception exception) {
+      // we log to debug to avoid messing up hdfs cli commands output
+      LOG.debug("Error fetching active server address from the file {}", filePath, exception);
+      return Optional.empty();
+    }
+  }
+}

--- a/smart-client/src/main/java/org/smartdata/client/activeserver/ActiveServerAddressFileCache.java
+++ b/smart-client/src/main/java/org/smartdata/client/activeserver/ActiveServerAddressFileCache.java
@@ -64,7 +64,7 @@ public class ActiveServerAddressFileCache implements ActiveServerAddressCache {
       HostAndPort hostAndPort = HostAndPort.fromString(
           new String(addressBytes, StandardCharsets.UTF_8));
       InetSocketAddress serverAddress =
-          new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort());
+          new InetSocketAddress(hostAndPort.getHost(), hostAndPort.getPort());
       return Optional.of(serverAddress);
     } catch (Exception exception) {
       // we log to debug to avoid messing up hdfs cli commands output

--- a/smart-client/src/main/java/org/smartdata/client/fileaccess/FileAccessReportStrategy.java
+++ b/smart-client/src/main/java/org/smartdata/client/fileaccess/FileAccessReportStrategy.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.fileaccess;
+
+import org.apache.hadoop.conf.Configuration;
+import org.smartdata.client.SmartServerHandle;
+import org.smartdata.client.SmartServerHandles;
+import org.smartdata.conf.SmartConfKeys;
+import org.smartdata.metrics.FileAccessEvent;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface FileAccessReportStrategy extends Closeable {
+
+  /**
+   * Reports file access event to the active Smart Server.
+   * @return Handle of the Smart Server to which the event was successfully sent.
+   */
+  SmartServerHandle reportFileAccessEvent(FileAccessEvent event) throws IOException;
+
+  static FileAccessReportStrategy from(
+      Configuration config, SmartServerHandles smartServerHandles) {
+    boolean parallelReportEnabled = config.getBoolean(
+        SmartConfKeys.SMART_CLIENT_CONCURRENT_REPORT_ENABLED,
+        SmartConfKeys.SMART_CLIENT_CONCURRENT_REPORT_ENABLED_DEFAULT);
+
+    if (parallelReportEnabled) {
+      long reportTasksTimeoutMs = config.getLong(
+          SmartConfKeys.SMART_CLIENT_REPORT_TASKS_TIMEOUT_MS_KEY,
+          SmartConfKeys.SMART_CLIENT_REPORT_TASKS_TIMEOUT_MS_DEFAULT);
+
+      return new ParallelFileAccessReportStrategy(
+          smartServerHandles, reportTasksTimeoutMs);
+    }
+
+    return new SequentialFileAccessReportStrategy(smartServerHandles);
+  }
+}

--- a/smart-client/src/main/java/org/smartdata/client/fileaccess/ParallelFileAccessReportStrategy.java
+++ b/smart-client/src/main/java/org/smartdata/client/fileaccess/ParallelFileAccessReportStrategy.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.fileaccess;
+
+import org.smartdata.client.SmartServerHandle;
+import org.smartdata.client.SmartServerHandles;
+import org.smartdata.metrics.FileAccessEvent;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Report file access event concurrently. Only one server is active, so
+ * reporting to this server should be successful.
+ */
+public class ParallelFileAccessReportStrategy implements FileAccessReportStrategy {
+  private final SmartServerHandles smartServerHandles;
+  private final ExecutorService accessReportExecutor;
+  private final long reportTasksTimeoutMs;
+
+  public ParallelFileAccessReportStrategy(
+      SmartServerHandles smartServerHandles,
+      long reportTasksTimeoutMs) {
+    this.smartServerHandles = smartServerHandles;
+    this.reportTasksTimeoutMs = reportTasksTimeoutMs;
+    this.accessReportExecutor = Executors.newFixedThreadPool(
+        smartServerHandles.handles().size());
+  }
+
+  private Callable<SmartServerHandle> reportFileAccessTask(
+      SmartServerHandle serverHandle, FileAccessEvent event) {
+    return () -> {
+      serverHandle.getProtocol().reportFileAccessEvent(event);
+      return serverHandle;
+    };
+  }
+
+  @Override
+  public SmartServerHandle reportFileAccessEvent(
+      FileAccessEvent event) throws IOException {
+    Collection<Callable<SmartServerHandle>> reportFileTasks = smartServerHandles
+        .handles()
+        .stream()
+        .map(server -> reportFileAccessTask(server, event))
+        .collect(Collectors.toList());
+
+    try {
+      return accessReportExecutor.invokeAny(
+          reportFileTasks, reportTasksTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      throw new IOException("Failed to report access event to SSM servers", e);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    accessReportExecutor.shutdownNow();
+  }
+}

--- a/smart-client/src/main/java/org/smartdata/client/fileaccess/SequentialFileAccessReportStrategy.java
+++ b/smart-client/src/main/java/org/smartdata/client/fileaccess/SequentialFileAccessReportStrategy.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.fileaccess;
+
+import org.smartdata.client.SmartServerHandle;
+import org.smartdata.client.SmartServerHandles;
+import org.smartdata.metrics.FileAccessEvent;
+
+import java.io.IOException;
+
+/**
+ * A simple report strategy that tries to connect to smart servers one by one.
+ */
+public class SequentialFileAccessReportStrategy implements FileAccessReportStrategy {
+
+  private final SmartServerHandles smartServerHandles;
+
+  public SequentialFileAccessReportStrategy(
+      SmartServerHandles smartServerHandles) {
+    this.smartServerHandles = smartServerHandles;
+  }
+
+  @Override
+  public SmartServerHandle reportFileAccessEvent(FileAccessEvent event) throws IOException {
+    Exception lastException = null;
+
+    for (SmartServerHandle serverHandle: smartServerHandles.handles()) {
+      try {
+        serverHandle.getProtocol().reportFileAccessEvent(event);
+        return serverHandle;
+      } catch (IOException exception) {
+        lastException = exception;
+      }
+    }
+
+    throw new IOException(
+        "Failed to report access event to SSM servers", lastException);
+  }
+
+  @Override
+  public void close() throws IOException {
+    // do nothing
+  }
+}

--- a/smart-client/src/test/java/org/smartdata/client/MockSmartServer.java
+++ b/smart-client/src/test/java/org/smartdata/client/MockSmartServer.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.client;
+
+import org.smartdata.metrics.FileAccessEvent;
+import org.smartdata.model.FileState;
+import org.smartdata.protocol.SmartClientProtocol;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockSmartServer implements SmartClientProtocol {
+  private final boolean failReportAccessEvent;
+  private final boolean failGetFileState;
+  private final long delayMs;
+  private final Map<String, FileState> expectedFileStates;
+  private final Map<String, Integer> reportedAccessCounts;
+
+  private MockSmartServer(
+      boolean failReportAccessEvent,
+      boolean failGetFileState,
+      long delayMs,
+      Map<String, FileState> expectedFileStates) {
+    this.failReportAccessEvent = failReportAccessEvent;
+    this.failGetFileState = failGetFileState;
+    this.expectedFileStates = expectedFileStates;
+    this.delayMs = delayMs;
+    this.reportedAccessCounts = new HashMap<>();
+  }
+
+  @Override
+  public void reportFileAccessEvent(FileAccessEvent event) throws IOException {
+    if (failReportAccessEvent) {
+      throw new IOException();
+    }
+
+    maybeSleep();
+    reportedAccessCounts.merge(event.getPath(), 1, Integer::sum);
+  }
+
+  @Override
+  public FileState getFileState(String filePath) throws IOException {
+    if (failGetFileState) {
+      throw new IOException();
+    }
+
+    maybeSleep();
+    return expectedFileStates.get(filePath);
+  }
+
+  private void maybeSleep() {
+    if (delayMs <= 0) {
+      return;
+    }
+
+    try {
+      Thread.sleep(delayMs);
+    } catch (InterruptedException ignore) {
+      // no-op
+    }
+  }
+
+  public Map<String, Integer> getReportedAccessCounts() {
+    return reportedAccessCounts;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static MockSmartServer standbyServer() {
+    return builder()
+        .failReportAccessEvent()
+        .failGetFileState()
+        .build();
+  }
+
+  public static MockSmartServer activeServer() {
+    return builder().build();
+  }
+
+  public static SmartServerHandle standbyServerHandle(InetSocketAddress address) {
+    return new SmartServerHandle(standbyServer(), address);
+  }
+
+  public static SmartServerHandle activeServerHandle(InetSocketAddress address) {
+    return new SmartServerHandle(activeServer(), address);
+  }
+
+  public static class Builder {
+    private boolean failReportAccessEvent;
+    private boolean failGetFileState;
+    private long delayMs;
+    private Map<String, FileState> expectedFileStates;
+
+    private Builder() {
+      this.failReportAccessEvent = false;
+      this.failGetFileState = false;
+      this.delayMs = 0;
+      this.expectedFileStates = new HashMap<>();
+    }
+
+    public Builder failReportAccessEvent() {
+      this.failReportAccessEvent = true;
+      return this;
+    }
+
+    public Builder failGetFileState() {
+      this.failGetFileState = true;
+      return this;
+    }
+
+    public Builder returnFileState(String path, FileState state) {
+      expectedFileStates.put(path, state);
+      return this;
+    }
+
+    public Builder returnFileStates(Map<String, FileState> fileStates) {
+      this.expectedFileStates = fileStates;
+      return this;
+    }
+
+    public Builder withDelay(long delayMs) {
+      this.delayMs = delayMs;
+      return this;
+    }
+
+    public MockSmartServer build() {
+      return new MockSmartServer(
+          failReportAccessEvent,
+          failGetFileState,
+          delayMs,
+          expectedFileStates
+      );
+    }
+  }
+}

--- a/smart-client/src/test/java/org/smartdata/client/SmartServerHandlesTest.java
+++ b/smart-client/src/test/java/org/smartdata/client/SmartServerHandlesTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.client;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class SmartServerHandlesTest {
+
+  private List<SmartServerHandle> serverHandlesList;
+
+  @Before
+  public void init() {
+    serverHandlesList = IntStream.range(0, 10)
+        .mapToObj(this::smartServerHandle)
+        .collect(Collectors.toList());
+  }
+
+  @Test
+  public void testSetNewActiveServer() {
+    serverHandlesList.forEach(this::testSetNewActiveServer);
+  }
+
+  private void testSetNewActiveServer(SmartServerHandle newActiveServerHandle) {
+    SmartServerHandles serverHandles = new SmartServerHandles(
+        new ArrayList<>(serverHandlesList));
+    serverHandles.withNewActiveServer(newActiveServerHandle);
+
+    assertEquals(newActiveServerHandle, serverHandles.activeServer());
+  }
+
+  private SmartServerHandle smartServerHandle(int id) {
+    return new SmartServerHandle(null, new InetSocketAddress(id));
+  }
+}

--- a/smart-client/src/test/java/org/smartdata/client/activeserver/ActiveServerAddressFileCacheTest.java
+++ b/smart-client/src/test/java/org/smartdata/client/activeserver/ActiveServerAddressFileCacheTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.activeserver;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ActiveServerAddressFileCacheTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void testPutReadAddress() throws IOException {
+    File cacheFile = folder.newFile("testFile");
+
+    ActiveServerAddressFileCache fileCache =
+        new ActiveServerAddressFileCache(Paths.get(cacheFile.toURI()));
+
+    InetSocketAddress expectedAddress =
+        InetSocketAddress.createUnresolved("test", 81);
+
+    fileCache.put(expectedAddress);
+    Optional<InetSocketAddress> actualAddress = fileCache.get();
+
+    assertTrue(actualAddress.isPresent());
+    assertEquals(expectedAddress, actualAddress.get());
+  }
+
+  @Test
+  public void testOverwriteAddress() throws IOException {
+    File cacheFile = folder.newFile("overwriteFile");
+
+    ActiveServerAddressFileCache fileCache =
+        new ActiveServerAddressFileCache(Paths.get(cacheFile.toURI()));
+
+    InetSocketAddress expectedAddress =
+        InetSocketAddress.createUnresolved("host", 9);
+
+    IntStream.range(0, 10)
+        .mapToObj(port -> InetSocketAddress.createUnresolved("host", port))
+        .forEach(fileCache::put);
+
+    Optional<InetSocketAddress> actualAddress = fileCache.get();
+
+    assertTrue(actualAddress.isPresent());
+    assertEquals(expectedAddress, actualAddress.get());
+  }
+
+  @Test
+  public void testReturnEmptyAddressIfFileNotFound() throws IOException {
+    File cacheFile = folder.newFile("anotherFile");
+
+    ActiveServerAddressFileCache fileCache =
+        new ActiveServerAddressFileCache(Paths.get(cacheFile.toURI()));
+
+    Optional<InetSocketAddress> actualAddress = fileCache.get();
+
+    assertFalse(actualAddress.isPresent());
+  }
+
+  @Test
+  public void testReturnEmptyAddressIfFileIsCorrupt() throws IOException {
+    File cacheFile = folder.newFile("corruptFile");
+    Path cacheFilePath = Paths.get(cacheFile.toURI());
+
+    Files.write(cacheFilePath, "blabla".getBytes(StandardCharsets.UTF_8));
+
+    ActiveServerAddressFileCache fileCache =
+        new ActiveServerAddressFileCache(cacheFilePath);
+
+    Optional<InetSocketAddress> actualAddress = fileCache.get();
+
+    assertFalse(actualAddress.isPresent());
+  }
+}

--- a/smart-client/src/test/java/org/smartdata/client/fileaccess/FileAccessReportStrategyTest.java
+++ b/smart-client/src/test/java/org/smartdata/client/fileaccess/FileAccessReportStrategyTest.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.fileaccess;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.smartdata.client.MockSmartServer;
+import org.smartdata.client.SmartServerHandle;
+import org.smartdata.client.SmartServerHandles;
+import org.smartdata.metrics.FileAccessEvent;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.smartdata.client.MockSmartServer.activeServerHandle;
+import static org.smartdata.client.MockSmartServer.standbyServerHandle;
+
+public abstract class FileAccessReportStrategyTest {
+
+  protected abstract Configuration getConfig();
+
+  @Test
+  public void testReportFileAccess() throws IOException {
+    List<SmartServerHandle> serverHandles = Arrays.asList(
+        activeServerHandle(new InetSocketAddress(1)),
+        standbyServerHandle(new InetSocketAddress(2)),
+        standbyServerHandle(new InetSocketAddress(3))
+    );
+
+    testReportFileAccessInternal(serverHandles, 0);
+  }
+
+  @Test
+  public void testReportFileAccessWithNewActiveServer() throws IOException {
+    List<SmartServerHandle> serverHandles = Arrays.asList(
+        standbyServerHandle(new InetSocketAddress(2)),
+        standbyServerHandle(new InetSocketAddress(3)),
+        activeServerHandle(new InetSocketAddress(1))
+    );
+
+    testReportFileAccessInternal(serverHandles, 2);
+  }
+
+  @Test
+  public void testFailIfNoActiveServer() {
+    List<SmartServerHandle> serverHandles = Arrays.asList(
+        standbyServerHandle(new InetSocketAddress(2)),
+        standbyServerHandle(new InetSocketAddress(3)),
+        standbyServerHandle(new InetSocketAddress(1))
+    );
+
+    IOException exception = assertThrows(
+        IOException.class,
+        () -> testReportFileAccessInternal(serverHandles, 0));
+    assertEquals(
+        "Failed to report access event to SSM servers",
+        exception.getMessage());
+  }
+
+  protected void testReportFileAccessInternal(
+      List<SmartServerHandle> serverHandlesList,
+      int activeServerIdx) throws IOException {
+
+    SmartServerHandle activeServerHandle = serverHandlesList.get(activeServerIdx);
+
+    Map<String, Integer> expectedFileAccessCounts = buildExpectedFileAccessCounts();
+
+    try (FileAccessReportStrategy strategy = FileAccessReportStrategy.from(
+        getConfig(), new SmartServerHandles(serverHandlesList))) {
+
+      for (String file : expectedFileAccessCounts.keySet()) {
+        FileAccessEvent fileAccessEvent = new FileAccessEvent(file);
+        SmartServerHandle reportedServer =
+            strategy.reportFileAccessEvent(fileAccessEvent);
+
+        assertEquals(reportedServer, activeServerHandle);
+      }
+    }
+
+    MockSmartServer activeServer = getTestSmartServer(activeServerHandle);
+    assertEquals(expectedFileAccessCounts,
+        activeServer.getReportedAccessCounts());
+  }
+
+  private Map<String, Integer> buildExpectedFileAccessCounts() {
+    return IntStream.range(0, 10)
+        .mapToObj(val -> "/test" + val)
+        .collect(Collectors.toMap(
+            Function.identity(),
+            ignore -> 1
+        ));
+  }
+
+  private MockSmartServer getTestSmartServer(SmartServerHandle serverHandle) {
+    return (MockSmartServer) serverHandle.getProtocol();
+  }
+}

--- a/smart-client/src/test/java/org/smartdata/client/fileaccess/ParallelFileAccessReportStrategyTest.java
+++ b/smart-client/src/test/java/org/smartdata/client/fileaccess/ParallelFileAccessReportStrategyTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.client.fileaccess;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.smartdata.client.MockSmartServer;
+import org.smartdata.client.SmartServerHandle;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.smartdata.client.MockSmartServer.standbyServerHandle;
+import static org.smartdata.conf.SmartConfKeys.SMART_CLIENT_CONCURRENT_REPORT_ENABLED;
+import static org.smartdata.conf.SmartConfKeys.SMART_CLIENT_REPORT_TASKS_TIMEOUT_MS_KEY;
+
+public class ParallelFileAccessReportStrategyTest extends FileAccessReportStrategyTest {
+
+  public static final long REPORT_TASKS_TIMEOUT_MS = 1000;
+
+  @Override
+  protected Configuration getConfig() {
+    Configuration config = new Configuration();
+    config.setBoolean(SMART_CLIENT_CONCURRENT_REPORT_ENABLED, true);
+    config.setLong(SMART_CLIENT_REPORT_TASKS_TIMEOUT_MS_KEY, REPORT_TASKS_TIMEOUT_MS);
+    return config;
+  }
+
+  @Test
+  public void testReportFileAccessWithSlowActiveServer() throws IOException {
+    List<SmartServerHandle> serverHandles = Arrays.asList(
+        standbyServerHandle(new InetSocketAddress(2)),
+        delayedActiveServerHandle(REPORT_TASKS_TIMEOUT_MS / 2),
+        standbyServerHandle(new InetSocketAddress(3))
+    );
+
+    testReportFileAccessInternal(serverHandles, 1);
+  }
+
+  @Test
+  public void testFailIfTimeout() {
+    List<SmartServerHandle> serverHandles = Arrays.asList(
+        delayedActiveServerHandle(REPORT_TASKS_TIMEOUT_MS * 2),
+        standbyServerHandle(new InetSocketAddress(3)),
+        standbyServerHandle(new InetSocketAddress(1))
+    );
+
+    IOException exception = assertThrows(
+        IOException.class,
+        () -> testReportFileAccessInternal(serverHandles, 0));
+
+    assertEquals(
+        "Failed to report access event to SSM servers",
+        exception.getMessage());
+  }
+
+  private SmartServerHandle delayedActiveServerHandle(long delayMs) {
+    MockSmartServer activeSmartServer = MockSmartServer.builder()
+        .withDelay(delayMs)
+        .build();
+
+    return new SmartServerHandle(
+        activeSmartServer, new InetSocketAddress(11));
+  }
+}

--- a/smart-client/src/test/java/org/smartdata/client/fileaccess/SequentialFileAccessReportStrategyTest.java
+++ b/smart-client/src/test/java/org/smartdata/client/fileaccess/SequentialFileAccessReportStrategyTest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.client.fileaccess;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.smartdata.conf.SmartConfKeys.SMART_CLIENT_CONCURRENT_REPORT_ENABLED;
+
+public class SequentialFileAccessReportStrategyTest extends FileAccessReportStrategyTest {
+
+  @Override
+  protected Configuration getConfig() {
+    Configuration config = new Configuration();
+    config.setBoolean(SMART_CLIENT_CONCURRENT_REPORT_ENABLED, false);
+    return config;
+  }
+}

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
@@ -20,7 +20,7 @@ package org.smartdata.conf;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.smartdata.utils.PathUtil;
+import org.smartdata.utils.ConfigUtil;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -51,10 +51,7 @@ public class SmartConf extends Configuration {
   }
 
   public List<String> getCoverDirs() {
-    return getTrimmedStringCollection(SmartConfKeys.SMART_COVER_DIRS_KEY)
-        .stream()
-        .map(PathUtil::addPathSeparator)
-        .collect(Collectors.toList());
+    return ConfigUtil.getCoverDirs(this);
   }
 
   /**

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConfKeys.java
@@ -289,4 +289,14 @@ public class SmartConfKeys {
   public static final String SMART_CLIENT_CONCURRENT_REPORT_ENABLED =
       "smart.client.concurrent.report.enabled";
   public static final boolean SMART_CLIENT_CONCURRENT_REPORT_ENABLED_DEFAULT = true;
+
+  public static final String SMART_CLIENT_REPORT_TASKS_TIMEOUT_MS_KEY =
+      "smart.client.report.tasks.timeout.ms";
+  public static final long SMART_CLIENT_REPORT_TASKS_TIMEOUT_MS_DEFAULT = 2000;
+
+  public static final String SMART_CLIENT_ACTIVE_SERVER_CACHE_PATH_KEY =
+      "smart.client.active.server.cache.path";
+  public static final String SMART_CLIENT_ACTIVE_SERVER_CACHE_PATH_DEFAULT =
+      "/tmp/active_smart_server";
+
 }

--- a/smart-common/src/main/java/org/smartdata/model/PathChecker.java
+++ b/smart-common/src/main/java/org/smartdata/model/PathChecker.java
@@ -19,8 +19,9 @@ package org.smartdata.model;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.smartdata.conf.SmartConf;
+import org.smartdata.SmartConstants;
 import org.smartdata.conf.SmartConfKeys;
+import org.smartdata.utils.ConfigUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,8 +44,8 @@ public class PathChecker {
   private final ThreadLocal<Matcher> patternMatcherThreadLocal;
   private final List<String> coverDirs;
 
-  public PathChecker(SmartConf configuration) {
-    this(getIgnorePatterns(configuration), configuration.getCoverDirs());
+  public PathChecker(Configuration configuration) {
+    this(getIgnorePatterns(configuration), ConfigUtil.getCoverDirs(configuration));
   }
 
   public PathChecker(List<String> ignoredPathPatterns, List<String> coverDirs) {
@@ -77,6 +78,9 @@ public class PathChecker {
     Set<String> ignoredPathTemplates = new HashSet<>(
         parseIgnoredPathOptions(configuration, SMART_IGNORED_PATH_TEMPLATES_KEY)
     );
+
+    // add system directory
+    ignoredPathTemplates.add(dirToPathTemplate(SmartConstants.SYSTEM_FOLDER));
 
     // add legacy ignored dirs
     parseIgnoredPathOptions(configuration, SMART_IGNORE_DIRS_KEY)

--- a/smart-common/src/main/java/org/smartdata/utils/ConfigUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/ConfigUtil.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.smartdata.utils;
 
+import com.google.common.net.HostAndPort;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.smartdata.conf.SmartConfKeys;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.smartdata.SmartConstants.DISTRIBUTED_FILE_SYSTEM;
 import static org.smartdata.SmartConstants.FS_HDFS_IMPL;
@@ -31,5 +41,34 @@ public class ConfigUtil {
     }
 
     return remoteConfig;
+  }
+
+  public static List<InetSocketAddress> getSsmRpcAddresses(
+      Configuration configuration) throws IOException {
+    Collection<String> rawRpcAddresses = configuration
+        .getTrimmedStringCollection(SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
+
+    if (CollectionUtils.isEmpty(rawRpcAddresses)) {
+      throw new IOException("SmartServer address not found. Please configure "
+          + "it through " + SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY);
+    }
+
+    try {
+      return rawRpcAddresses.stream()
+          .map(HostAndPort::fromString)
+          .map(hostAndPort -> new InetSocketAddress(
+              hostAndPort.getHostText(), hostAndPort.getPort()))
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new IOException("Incorrect SmartServer address. Please follow "
+          + "IP/Hostname:Port format");
+    }
+  }
+
+  public static List<String> getCoverDirs(Configuration configuration) {
+    return configuration.getTrimmedStringCollection(SmartConfKeys.SMART_COVER_DIRS_KEY)
+        .stream()
+        .map(PathUtil::addPathSeparator)
+        .collect(Collectors.toList());
   }
 }

--- a/smart-common/src/main/java/org/smartdata/utils/ConfigUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/ConfigUtil.java
@@ -57,7 +57,7 @@ public class ConfigUtil {
       return rawRpcAddresses.stream()
           .map(HostAndPort::fromString)
           .map(hostAndPort -> new InetSocketAddress(
-              hostAndPort.getHostText(), hostAndPort.getPort()))
+              hostAndPort.getHost(), hostAndPort.getPort()))
           .collect(Collectors.toList());
     } catch (Exception e) {
       throw new IOException("Incorrect SmartServer address. Please follow "

--- a/smart-hadoop-support/smart-hadoop-client-3/src/main/java/org/smartdata/hdfs/client/SmartDFSClient.java
+++ b/smart-hadoop-support/smart-hadoop-client-3/src/main/java/org/smartdata/hdfs/client/SmartDFSClient.java
@@ -65,55 +65,9 @@ public class SmartDFSClient extends DFSClient {
   private SmartClient smartClient = null;
   private boolean healthy = false;
 
-  public SmartDFSClient(InetSocketAddress nameNodeAddress, Configuration conf,
-      InetSocketAddress smartServerAddress) throws IOException {
-    super(nameNodeAddress, conf);
-    if (isSmartClientDisabled()) {
-      return;
-    }
-    try {
-      smartClient = new SmartClient(conf, smartServerAddress);
-      healthy = true;
-    } catch (IOException e) {
-      super.close();
-      throw e;
-    }
-  }
-
   public SmartDFSClient(final URI nameNodeUri, final Configuration conf,
       final InetSocketAddress smartServerAddress) throws IOException {
     super(nameNodeUri, conf);
-    if (isSmartClientDisabled()) {
-      return;
-    }
-    try {
-      smartClient = new SmartClient(conf, smartServerAddress);
-      healthy = true;
-    } catch (IOException e) {
-      super.close();
-      throw e;
-    }
-  }
-
-  public SmartDFSClient(URI nameNodeUri, Configuration conf,
-      FileSystem.Statistics stats, InetSocketAddress smartServerAddress)
-      throws IOException {
-    super(nameNodeUri, conf, stats);
-    if (isSmartClientDisabled()) {
-      return;
-    }
-    try {
-      smartClient = new SmartClient(conf, smartServerAddress);
-      healthy = true;
-    } catch (IOException e) {
-      super.close();
-      throw e;
-    }
-  }
-
-  public SmartDFSClient(Configuration conf,
-      InetSocketAddress[] smartServerAddress) throws IOException {
-    super(conf);
     if (isSmartClientDisabled()) {
       return;
     }


### PR DESCRIPTION
- Refactored `SmartClient`: moved out logic of reporting file access events, saving currently active `SmartServer` address in file-backed cache, fixed concurrency issues, etc.
- Fixed bug with thread leak when the `smart.client.concurrent.report.enabled` option is set to true. The reason was that threads were spawned inside the thread pool during each file access event and were not released after the event was reported.