### PR TITLE
[ADH-4364] Add SPNEGO, basic kerberos and basic predefined authentication

### DIFF
--- a/conf/smart-default.xml
+++ b/conf/smart-default.xml
@@ -534,4 +534,46 @@
       Local filesystem path of the active Smart Server address file-based cache.
     </description>
   </property>
+
+  <property>
+    <name>smart.rest.server.security.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable SSM REST server security.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.rest.server.auth.spnego.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable SSM REST server SPNEGO authentication method support.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.rest.server.auth.kerberos.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable SSM REST server basic Kerberos authentication method support.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.rest.server.auth.predefined.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable SSM REST server basic authentication with users,
+      predefined in the 'smart.rest.server.auth.predefined.users' option.
+    </description>
+  </property>
+
+  <property>
+    <name>smart.rest.server.auth.predefined.users</name>
+    <value>false</value>
+    <description>
+      Comma-separated list of predefined user credentials in the form of 'user:password',
+      to be used in SSM REST server basic authentication.
+    </description>
+  </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <springdoc.openapi.version>1.7.0</springdoc.openapi.version>
     <hibernate.validator.version>6.2.5.Final</hibernate.validator.version>
     <spring.boot.version>2.7.18</spring.boot.version>
+    <spring.boot.security.kerberos.version>1.0.1.RELEASE</spring.boot.security.kerberos.version>
     <openapi.generator.version>6.6.0</openapi.generator.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
@@ -95,6 +95,12 @@ public class SmartConf extends Configuration {
         ));
   }
 
+  public String getNonNull(String key) {
+    return Optional.of(get(key))
+        .orElseThrow(() ->
+            new IllegalArgumentException("Required option not provided: " + key));
+  }
+
   public Map<String, String> asMap() {
     return asMap(key -> true);
   }

--- a/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
@@ -96,7 +96,7 @@ public class SmartConf extends Configuration {
   }
 
   public String getNonNull(String key) {
-    return Optional.of(get(key))
+    return Optional.ofNullable(get(key))
         .orElseThrow(() ->
             new IllegalArgumentException("Required option not provided: " + key));
   }

--- a/smart-web-server/pom.xml
+++ b/smart-web-server/pom.xml
@@ -67,6 +67,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.security.kerberos</groupId>
+      <artifactId>spring-security-kerberos-web</artifactId>
+      <version>${spring.boot.security.kerberos.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security.kerberos</groupId>
+      <artifactId>spring-security-kerberos-client</artifactId>
+      <version>${spring.boot.security.kerberos.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
@@ -115,6 +127,12 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok-mapstruct-binding</artifactId>
       <version>${lombok-mapstruct-binding.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/smart-web-server/src/main/java/org/smartdata/server/config/ConfigKeys.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/ConfigKeys.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.config;
+
+public class ConfigKeys {
+  public static final String WEB_SECURITY_ENABLED = "smart.rest.server.security.enabled";
+
+  public static final String SPNEGO_AUTH_ENABLED = "smart.rest.server.auth.spnego.enabled";
+
+  public static final String KERBEROS_BASIC_AUTH_ENABLED =
+      "smart.rest.server.auth.kerberos.enabled";
+
+  public static final String PREDEFINED_BASIC_AUTH_ENABLED =
+      "smart.rest.server.auth.predefined.enabled";
+
+  public static final String PREDEFINED_USERS = "smart.rest.server.auth.predefined.users";
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/config/KerberosBasicAuthSecurityConfiguration.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/KerberosBasicAuthSecurityConfiguration.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.kerberos.authentication.KerberosAuthenticationProvider;
+import org.springframework.security.kerberos.authentication.KerberosClient;
+import org.springframework.security.kerberos.authentication.sun.SunJaasKerberosClient;
+
+import static org.smartdata.server.config.ConfigKeys.KERBEROS_BASIC_AUTH_ENABLED;
+import static org.smartdata.server.config.ConfigKeys.WEB_SECURITY_ENABLED;
+
+@Configuration
+@ConditionalOnProperty(
+    name = {WEB_SECURITY_ENABLED, KERBEROS_BASIC_AUTH_ENABLED},
+    havingValue = "true")
+public class KerberosBasicAuthSecurityConfiguration {
+  @Bean
+  public SsmAuthHttpConfigurer kerberosBasicAuthHttpConfigurer() {
+    return new SecurityConfiguration.BasicAuthHttpConfigurer();
+  }
+
+  @Bean
+  public AuthenticationProvider kerberosAuthenticationProvider() {
+    KerberosAuthenticationProvider provider = new KerberosAuthenticationProvider();
+    KerberosClient client = new SunJaasKerberosClient();
+    provider.setKerberosClient(client);
+    provider.setUserDetailsService(kerberosUserDetailsService());
+    return provider;
+  }
+
+  public static UserDetailsService kerberosUserDetailsService() {
+    return username -> User.withUsername(username)
+        .password("")
+        .roles()
+        .build();
+  }
+
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/config/PredefinedUsersSecurityConfiguration.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/PredefinedUsersSecurityConfiguration.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.config;
+
+import org.smartdata.conf.SmartConf;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+import java.util.List;
+
+import static org.smartdata.server.config.ConfigKeys.PREDEFINED_BASIC_AUTH_ENABLED;
+import static org.smartdata.server.config.ConfigKeys.WEB_SECURITY_ENABLED;
+import static org.smartdata.server.util.ConfigUtils.parsePredefinedUsers;
+
+@Configuration
+@ConditionalOnProperty(
+    name = {WEB_SECURITY_ENABLED, PREDEFINED_BASIC_AUTH_ENABLED},
+    havingValue = "true")
+public class PredefinedUsersSecurityConfiguration {
+
+  @Bean
+  public AuthenticationProvider predefinedUsersAuthenticationProvider(
+      SmartConf smartConf) {
+    DaoAuthenticationProvider predefinedUsersProvider = new DaoAuthenticationProvider();
+    List<UserDetails> predefinedUsers = parsePredefinedUsers(smartConf);
+    predefinedUsersProvider.setUserDetailsService(
+        new InMemoryUserDetailsManager(predefinedUsers));
+    return predefinedUsersProvider;
+  }
+
+  @Bean
+  public SsmAuthHttpConfigurer basicAuthHttpConfigurer() {
+    return new SecurityConfiguration.BasicAuthHttpConfigurer();
+  }
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/config/SecurityConfiguration.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/SecurityConfiguration.java
@@ -17,7 +17,6 @@
  */
 package org.smartdata.server.config;
 
-import lombok.RequiredArgsConstructor;
 import org.smartdata.server.security.SmartPrincipalInitializerFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -84,7 +83,6 @@ public class SecurityConfiguration {
     return http.build();
   }
 
-  @RequiredArgsConstructor
   public static class BasicAuthHttpConfigurer extends SsmAuthHttpConfigurer {
     @Override
     public void init(HttpSecurity http) throws Exception {

--- a/smart-web-server/src/main/java/org/smartdata/server/config/SsmAuthHttpConfigurer.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/SsmAuthHttpConfigurer.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.config;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+
+/**
+ * Marker class for beans conditionally modifying {@link HttpSecurity}.
+ */
+public abstract class SsmAuthHttpConfigurer
+    extends AbstractHttpConfigurer<SsmAuthHttpConfigurer, HttpSecurity> {
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/security/SmartPrincipalInitializerFilter.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/security/SmartPrincipalInitializerFilter.java
@@ -41,6 +41,7 @@ public class SmartPrincipalInitializerFilter extends OncePerRequestFilter {
 
     Optional.ofNullable(SecurityContextHolder.getContext())
         .map(SecurityContext::getAuthentication)
+        .filter(Authentication::isAuthenticated)
         .map(Authentication::getName)
         .map(SmartPrincipal::new)
         .ifPresent(SmartPrincipalHolder::setCurrentPrincipal);

--- a/smart-web-server/src/main/java/org/smartdata/server/util/ConfigUtils.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/util/ConfigUtils.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.util;
+
+import org.smartdata.conf.SmartConf;
+import org.smartdata.server.config.ConfigKeys;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ConfigUtils {
+  private static final String USERNAME_PASSWORD_DELIMITER = ":";
+  private static final String NO_OP_ENCODER_PREFIX = "{noop}";
+
+  public static List<UserDetails> parsePredefinedUsers(SmartConf smartConf) {
+    return smartConf.getStringCollection(ConfigKeys.PREDEFINED_USERS)
+        .stream()
+        .map(ConfigUtils::parsePredefinedUser)
+        .collect(Collectors.toList());
+  }
+
+  private static UserDetails parsePredefinedUser(String rawUser) {
+    String[] userParts = rawUser.split(USERNAME_PASSWORD_DELIMITER);
+    if (userParts.length != 2) {
+      throw new IllegalArgumentException(
+          "Wrong user definition syntax, should be 'username:password'");
+    }
+
+    return User.withUsername(userParts[0])
+        .password(NO_OP_ENCODER_PREFIX + userParts[1])
+        .authorities(Collections.emptyList())
+        .build();
+  }
+}

--- a/smart-web-server/src/main/resources/application.yaml
+++ b/smart-web-server/src/main/resources/application.yaml
@@ -4,3 +4,8 @@ springdoc:
   swagger-ui:
     url: /ssm-api.yaml
     disable-swagger-default-url: true
+server:
+  servlet:
+    session:
+      cookie:
+        name: SSM_SESSION_ID

--- a/smart-web-server/src/test/java/org/smartdata/server/util/ConfigUtilsTest.java
+++ b/smart-web-server/src/test/java/org/smartdata/server/util/ConfigUtilsTest.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.util;
+
+import org.junit.Test;
+import org.smartdata.conf.SmartConf;
+import org.smartdata.server.config.ConfigKeys;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.smartdata.server.util.ConfigUtils.parsePredefinedUsers;
+
+public class ConfigUtilsTest {
+
+  @Test
+  public void testParseNullUsers() {
+    List<UserDetails> users = parsePredefinedUsers(new SmartConf());
+    assertTrue(users.isEmpty());
+  }
+
+  @Test
+  public void testParseEmptyUsers() {
+    SmartConf conf = new SmartConf();
+    conf.set(ConfigKeys.PREDEFINED_USERS, "");
+
+    List<UserDetails> users = parsePredefinedUsers(conf);
+    assertTrue(users.isEmpty());
+  }
+
+  @Test
+  public void testParseSingleUser() {
+    SmartConf conf = new SmartConf();
+    conf.set(ConfigKeys.PREDEFINED_USERS, "user:pass");
+
+    List<UserDetails> users = parsePredefinedUsers(conf);
+    List<UserDetails> expectedUsers = Collections.singletonList(
+        buildUser("user", "pass")
+    );
+    assertEquals(expectedUsers, users);
+  }
+
+  @Test
+  public void testParseUsers() {
+    SmartConf conf = new SmartConf();
+    conf.set(ConfigKeys.PREDEFINED_USERS, "admin:admin,user:pass");
+
+    List<UserDetails> users = parsePredefinedUsers(conf);
+    List<UserDetails> expectedUsers = Arrays.asList(
+        buildUser("admin", "admin"),
+        buildUser("user", "pass")
+    );
+
+    assertEquals(expectedUsers, users);
+  }
+
+  private UserDetails buildUser(String user, String password) {
+    return User.withUsername(user)
+        .password("{noop}" + password)
+        .roles()
+        .build();
+  }
+}


### PR DESCRIPTION
- Added support for several types of user authentication: SPNEGO, Kerberos basic authentication and basic authentication with users, predefined in the SSM config
- Added following config options to control the aforementioned authentication methods:
  - `smart.rest.server.security.enabled`
  - `smart.rest.server.auth.spnego.enabled`
  - `smart.rest.server.auth.kerberos.enabled`
  - `smart.rest.server.auth.predefined.enabled`
  - `smart.rest.server.auth.predefined.users`