### PR TITLE
[ADH-4549] Implement endpoint for retrieving information about the logged-in user

### DIFF
--- a/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
+++ b/smart-common/src/main/java/org/smartdata/conf/SmartConf.java
@@ -17,6 +17,7 @@
  */
 package org.smartdata.conf;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,10 +96,14 @@ public class SmartConf extends Configuration {
         ));
   }
 
-  public String getNonNull(String key) {
+  public String getNonEmpty(String key) {
+    return getNonEmpty(key, "Required option not provided: " + key);
+  }
+
+  public String getNonEmpty(String key, String errorText) {
     return Optional.ofNullable(get(key))
-        .orElseThrow(() ->
-            new IllegalArgumentException("Required option not provided: " + key));
+        .filter(StringUtils::isNotBlank)
+        .orElseThrow(() -> new IllegalArgumentException(errorText));
   }
 
   public Map<String, String> asMap() {

--- a/smart-common/src/main/java/org/smartdata/security/SmartPrincipalHolder.java
+++ b/smart-common/src/main/java/org/smartdata/security/SmartPrincipalHolder.java
@@ -20,6 +20,8 @@ package org.smartdata.security;
 import java.util.Optional;
 
 public class SmartPrincipalHolder {
+  private static final SmartPrincipal ANONYMOUS = new SmartPrincipal("anonymous");
+
   private static final ThreadLocal<SmartPrincipal> CURRENT_PRINCIPAL_THREAD_LOCAL =
       new ThreadLocal<>();
 
@@ -31,11 +33,12 @@ public class SmartPrincipalHolder {
     CURRENT_PRINCIPAL_THREAD_LOCAL.remove();
   }
 
-  public static Optional<SmartPrincipal> getCurrentPrincipal() {
-    return Optional.ofNullable(CURRENT_PRINCIPAL_THREAD_LOCAL.get());
+  public static SmartPrincipal getCurrentPrincipal() {
+    return Optional.ofNullable(CURRENT_PRINCIPAL_THREAD_LOCAL.get())
+        .orElse(ANONYMOUS);
   }
 
-  public static Optional<String> getCurrentPrincipalName() {
-    return getCurrentPrincipal().map(SmartPrincipal::getName);
+  public static SmartPrincipal anonymous() {
+    return ANONYMOUS;
   }
 }

--- a/smart-engine/src/main/java/org/smartdata/server/engine/audit/aspect/AuditAspect.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/audit/aspect/AuditAspect.java
@@ -113,8 +113,8 @@ public class AuditAspect {
   private UserActivityEvent.Builder eventBuilder(
       Audit audit, Long objectId) {
     String currentUserName = SmartPrincipalHolder
-        .getCurrentPrincipalName()
-        .orElse(null);
+        .getCurrentPrincipal()
+        .getName();
 
     return UserActivityEvent.builder()
         .objectId(objectId)

--- a/smart-web-server/src/main/java/org/smartdata/server/config/ConfigKeys.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/config/ConfigKeys.java
@@ -29,4 +29,7 @@ public class ConfigKeys {
       "smart.rest.server.auth.predefined.enabled";
 
   public static final String PREDEFINED_USERS = "smart.rest.server.auth.predefined.users";
+
+  public static final String SMART_REST_SERVER_KEYTAB_FILE_KEY =
+      "smart.rest.server.auth.spnego.keytab";
 }

--- a/smart-web-server/src/main/java/org/smartdata/server/controller/SystemControllerDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/controller/SystemControllerDelegate.java
@@ -15,11 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.smartdata.security;
+package org.smartdata.server.controller;
 
-import lombok.Data;
+import org.smartdata.security.SmartPrincipalHolder;
+import org.smartdata.server.generated.api.SystemApiDelegate;
+import org.smartdata.server.generated.model.UserInfoDto;
+import org.springframework.stereotype.Component;
 
-@Data
-public class SmartPrincipal {
-  private final String name;
+@Component
+public class SystemControllerDelegate implements SystemApiDelegate {
+  @Override
+  public UserInfoDto getCurrentUser() {
+    String username = SmartPrincipalHolder.getCurrentPrincipal().getName();
+    return new UserInfoDto(username);
+  }
 }

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/ActionsApi.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/ActionsApi.java
@@ -28,10 +28,8 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.ActionDto;
 import org.smartdata.server.generated.model.ActionInfoDto;
 import org.smartdata.server.generated.model.ActionSortDto;
@@ -52,6 +50,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
 @Tag(name = "Actions", description = "the Actions API")
@@ -67,6 +70,7 @@ public interface ActionsApi {
      * @param id Id of the resource (required)
      * @return OK (status code 200)
      *         or Action with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getAction",
@@ -76,7 +80,11 @@ public interface ActionsApi {
             @ApiResponse(responseCode = "200", description = "OK", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ActionDto.class))
             }),
-            @ApiResponse(responseCode = "404", description = "Action with specified id not found")
+            @ApiResponse(responseCode = "404", description = "Action with specified id not found"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -106,6 +114,7 @@ public interface ActionsApi {
      * @param completionTime Time interval in which the action was finished (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getActions",
@@ -117,7 +126,11 @@ public interface ActionsApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -147,6 +160,7 @@ public interface ActionsApi {
      * @param submitActionRequestDto  (required)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "submitAction",
@@ -158,7 +172,11 @@ public interface ActionsApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/ActionsApiDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/ActionsApiDelegate.java
@@ -17,10 +17,6 @@
  */
 package org.smartdata.server.generated.api;
 
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.ActionDto;
 import org.smartdata.server.generated.model.ActionInfoDto;
 import org.smartdata.server.generated.model.ActionSortDto;
@@ -32,6 +28,12 @@ import org.smartdata.server.generated.model.PageRequestDto;
 import org.smartdata.server.generated.model.SubmissionTimeIntervalDto;
 import org.smartdata.server.generated.model.SubmitActionRequestDto;
 import org.springframework.web.context.request.NativeWebRequest;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link ActionsApiController}}.
@@ -50,6 +52,7 @@ public interface ActionsApiDelegate {
      * @param id Id of the resource (required)
      * @return OK (status code 200)
      *         or Action with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      * @see ActionsApi#getAction
      */
     default ActionDto getAction(Long id) throws Exception {
@@ -70,6 +73,7 @@ public interface ActionsApiDelegate {
      * @param completionTime Time interval in which the action was finished (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see ActionsApi#getActions
      */
     default ActionsDto getActions(PageRequestDto pageRequest,
@@ -90,6 +94,7 @@ public interface ActionsApiDelegate {
      * @param submitActionRequestDto  (required)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see ActionsApi#submitAction
      */
     default ActionInfoDto submitAction(SubmitActionRequestDto submitActionRequestDto) throws Exception {

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/AuditApi.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/AuditApi.java
@@ -28,10 +28,8 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.AuditEventResultDto;
 import org.smartdata.server.generated.model.AuditEventsDto;
 import org.smartdata.server.generated.model.AuditObjectTypeDto;
@@ -46,6 +44,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
@@ -69,6 +72,7 @@ public interface AuditApi {
      * @param results List of audit event results (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getAuditEvents",
@@ -80,7 +84,11 @@ public interface AuditApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/AuditApiDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/AuditApiDelegate.java
@@ -17,10 +17,6 @@
  */
 package org.smartdata.server.generated.api;
 
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.AuditEventResultDto;
 import org.smartdata.server.generated.model.AuditEventsDto;
 import org.smartdata.server.generated.model.AuditObjectTypeDto;
@@ -29,6 +25,12 @@ import org.smartdata.server.generated.model.AuditSortDto;
 import org.smartdata.server.generated.model.EventTimeIntervalDto;
 import org.smartdata.server.generated.model.PageRequestDto;
 import org.springframework.web.context.request.NativeWebRequest;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link AuditApiController}}.
@@ -54,6 +56,7 @@ public interface AuditApiDelegate {
      * @param results List of audit event results (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see AuditApi#getAuditEvents
      */
     default AuditEventsDto getAuditEvents(PageRequestDto pageRequest,

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/ClusterApiDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/ClusterApiDelegate.java
@@ -17,15 +17,17 @@
  */
 package org.smartdata.server.generated.api;
 
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.ClusterNodesDto;
 import org.smartdata.server.generated.model.ClusterSortDto;
 import org.smartdata.server.generated.model.PageRequestDto;
 import org.smartdata.server.generated.model.RegistrationTimeIntervalDto;
 import org.springframework.web.context.request.NativeWebRequest;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link ClusterApiController}}.
@@ -46,6 +48,7 @@ public interface ClusterApiDelegate {
      * @param registrationTime Time interval in which node was registered in master (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see ClusterApi#getClusterNodes
      */
     default ClusterNodesDto getClusterNodes(PageRequestDto pageRequest,

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/CmdletsApi.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/CmdletsApi.java
@@ -28,10 +28,8 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.CmdletDto;
 import org.smartdata.server.generated.model.CmdletSortDto;
 import org.smartdata.server.generated.model.CmdletStateDto;
@@ -50,6 +48,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
 @Tag(name = "Cmdlets", description = "the Cmdlets API")
@@ -65,6 +68,7 @@ public interface CmdletsApi {
      * @param submitCmdletRequestDto  (required)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "addCmdlet",
@@ -76,7 +80,11 @@ public interface CmdletsApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -100,6 +108,7 @@ public interface CmdletsApi {
      * @param id Id of the resource (required)
      * @return Cmdlet has been removed (status code 200)
      *         or Cmdlet with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "deleteCmdlet",
@@ -107,7 +116,11 @@ public interface CmdletsApi {
         tags = { "Cmdlets" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Cmdlet has been removed"),
-            @ApiResponse(responseCode = "404", description = "Cmdlet with specified id not found")
+            @ApiResponse(responseCode = "404", description = "Cmdlet with specified id not found"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -129,6 +142,7 @@ public interface CmdletsApi {
      * @param id Id of the resource (required)
      * @return OK (status code 200)
      *         or Cmdlet with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getCmdlet",
@@ -138,7 +152,11 @@ public interface CmdletsApi {
             @ApiResponse(responseCode = "200", description = "OK", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = CmdletDto.class))
             }),
-            @ApiResponse(responseCode = "404", description = "Cmdlet with specified id not found")
+            @ApiResponse(responseCode = "404", description = "Cmdlet with specified id not found"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -167,6 +185,7 @@ public interface CmdletsApi {
      * @param stateChangedTime Time interval in which the state of the cmdlet was changed (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getCmdlets",
@@ -178,7 +197,11 @@ public interface CmdletsApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -207,6 +230,7 @@ public interface CmdletsApi {
      * @param id Id of the resource (required)
      * @return Cmdlet has been stopped (status code 200)
      *         or Cmdlet with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "stopCmdlet",
@@ -214,7 +238,11 @@ public interface CmdletsApi {
         tags = { "Cmdlets" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Cmdlet has been stopped"),
-            @ApiResponse(responseCode = "404", description = "Cmdlet with specified id not found")
+            @ApiResponse(responseCode = "404", description = "Cmdlet with specified id not found"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/CmdletsApiDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/CmdletsApiDelegate.java
@@ -17,10 +17,6 @@
  */
 package org.smartdata.server.generated.api;
 
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.CmdletDto;
 import org.smartdata.server.generated.model.CmdletSortDto;
 import org.smartdata.server.generated.model.CmdletStateDto;
@@ -30,6 +26,12 @@ import org.smartdata.server.generated.model.StateChangeTimeIntervalDto;
 import org.smartdata.server.generated.model.SubmissionTimeIntervalDto;
 import org.smartdata.server.generated.model.SubmitCmdletRequestDto;
 import org.springframework.web.context.request.NativeWebRequest;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link CmdletsApiController}}.
@@ -48,6 +50,7 @@ public interface CmdletsApiDelegate {
      * @param submitCmdletRequestDto  (required)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see CmdletsApi#addCmdlet
      */
     default CmdletDto addCmdlet(SubmitCmdletRequestDto submitCmdletRequestDto) throws Exception {
@@ -61,6 +64,7 @@ public interface CmdletsApiDelegate {
      * @param id Id of the resource (required)
      * @return Cmdlet has been removed (status code 200)
      *         or Cmdlet with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      * @see CmdletsApi#deleteCmdlet
      */
     default void deleteCmdlet(Long id) throws Exception {
@@ -74,6 +78,7 @@ public interface CmdletsApiDelegate {
      * @param id Id of the resource (required)
      * @return OK (status code 200)
      *         or Cmdlet with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      * @see CmdletsApi#getCmdlet
      */
     default CmdletDto getCmdlet(Long id) throws Exception {
@@ -93,6 +98,7 @@ public interface CmdletsApiDelegate {
      * @param stateChangedTime Time interval in which the state of the cmdlet was changed (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see CmdletsApi#getCmdlets
      */
     default CmdletsDto getCmdlets(PageRequestDto pageRequest,
@@ -112,6 +118,7 @@ public interface CmdletsApiDelegate {
      * @param id Id of the resource (required)
      * @return Cmdlet has been stopped (status code 200)
      *         or Cmdlet with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      * @see CmdletsApi#stopCmdlet
      */
     default void stopCmdlet(Long id) throws Exception {

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/FilesApi.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/FilesApi.java
@@ -28,10 +28,8 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.CachedFileSortDto;
 import org.smartdata.server.generated.model.CachedFilesDto;
 import org.smartdata.server.generated.model.CachedTimeIntervalDto;
@@ -46,6 +44,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
@@ -65,6 +68,7 @@ public interface FilesApi {
      * @param lastAccessedTime Time interval in which the file was accessed (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getAccessCounts",
@@ -76,7 +80,11 @@ public interface FilesApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -106,6 +114,7 @@ public interface FilesApi {
      * @param cachedTime Time interval in which the file was cached (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getCachedFiles",
@@ -117,7 +126,11 @@ public interface FilesApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/FilesApiDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/FilesApiDelegate.java
@@ -17,10 +17,6 @@
  */
 package org.smartdata.server.generated.api;
 
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.CachedFileSortDto;
 import org.smartdata.server.generated.model.CachedFilesDto;
 import org.smartdata.server.generated.model.CachedTimeIntervalDto;
@@ -29,6 +25,12 @@ import org.smartdata.server.generated.model.HotFileSortDto;
 import org.smartdata.server.generated.model.LastAccessedTimeIntervalDto;
 import org.smartdata.server.generated.model.PageRequestDto;
 import org.springframework.web.context.request.NativeWebRequest;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link FilesApiController}}.
@@ -50,6 +52,7 @@ public interface FilesApiDelegate {
      * @param lastAccessedTime Time interval in which the file was accessed (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see FilesApi#getAccessCounts
      */
     default FileAccessCountsDto getAccessCounts(PageRequestDto pageRequest,
@@ -70,6 +73,7 @@ public interface FilesApiDelegate {
      * @param cachedTime Time interval in which the file was cached (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see FilesApi#getCachedFiles
      */
     default CachedFilesDto getCachedFiles(PageRequestDto pageRequest,

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/RulesApi.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/RulesApi.java
@@ -28,10 +28,8 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.ErrorResponseDto;
 import org.smartdata.server.generated.model.LastActivationTimeIntervalDto;
 import org.smartdata.server.generated.model.PageRequestDto;
@@ -50,6 +48,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
 @Tag(name = "Rules", description = "the Rules API")
@@ -65,6 +68,7 @@ public interface RulesApi {
      * @param submitRuleRequestDto  (required)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "addRule",
@@ -76,7 +80,11 @@ public interface RulesApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -100,6 +108,7 @@ public interface RulesApi {
      * @param id Id of the resource (required)
      * @return Rule has been removed (status code 200)
      *         or Rule with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "deleteRule",
@@ -107,7 +116,11 @@ public interface RulesApi {
         tags = { "Rules" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Rule has been removed"),
-            @ApiResponse(responseCode = "404", description = "Rule with specified id not found")
+            @ApiResponse(responseCode = "404", description = "Rule with specified id not found"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -129,6 +142,7 @@ public interface RulesApi {
      * @param id Id of the resource (required)
      * @return OK (status code 200)
      *         or Rule with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getRule",
@@ -138,7 +152,11 @@ public interface RulesApi {
             @ApiResponse(responseCode = "200", description = "OK", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = RuleDto.class))
             }),
-            @ApiResponse(responseCode = "404", description = "Rule with specified id not found")
+            @ApiResponse(responseCode = "404", description = "Rule with specified id not found"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -166,6 +184,7 @@ public interface RulesApi {
      * @param lastActivationTime Time interval in which the rule was activated (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "getRules",
@@ -177,7 +196,11 @@ public interface RulesApi {
             }),
             @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -206,6 +229,7 @@ public interface RulesApi {
      * @return Rule has been started (status code 200)
      *         or Rule with specified id not found (status code 404)
      *         or Unsupported state transition (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "startRule",
@@ -216,7 +240,11 @@ public interface RulesApi {
             @ApiResponse(responseCode = "404", description = "Rule with specified id not found"),
             @ApiResponse(responseCode = "400", description = "Unsupported state transition", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(
@@ -240,6 +268,7 @@ public interface RulesApi {
      * @return Rule has been stopped (status code 200)
      *         or Rule with specified id not found (status code 404)
      *         or Unsupported state transition (status code 400)
+     *         or Unauthorized (status code 401)
      */
     @Operation(
         operationId = "stopRule",
@@ -250,7 +279,11 @@ public interface RulesApi {
             @ApiResponse(responseCode = "404", description = "Rule with specified id not found"),
             @ApiResponse(responseCode = "400", description = "Unsupported state transition", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
-            })
+            }),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        },
+        security = {
+            @SecurityRequirement(name = "basicAuth")
         }
     )
     @RequestMapping(

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/RulesApiDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/RulesApiDelegate.java
@@ -17,10 +17,6 @@
  */
 package org.smartdata.server.generated.api;
 
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.Generated;
-import javax.validation.Valid;
 import org.smartdata.server.generated.model.LastActivationTimeIntervalDto;
 import org.smartdata.server.generated.model.PageRequestDto;
 import org.smartdata.server.generated.model.RuleDto;
@@ -30,6 +26,12 @@ import org.smartdata.server.generated.model.RulesDto;
 import org.smartdata.server.generated.model.SubmissionTimeIntervalDto;
 import org.smartdata.server.generated.model.SubmitRuleRequestDto;
 import org.springframework.web.context.request.NativeWebRequest;
+
+import javax.annotation.Generated;
+import javax.validation.Valid;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link RulesApiController}}.
@@ -48,6 +50,7 @@ public interface RulesApiDelegate {
      * @param submitRuleRequestDto  (required)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see RulesApi#addRule
      */
     default RuleDto addRule(SubmitRuleRequestDto submitRuleRequestDto) throws Exception {
@@ -61,6 +64,7 @@ public interface RulesApiDelegate {
      * @param id Id of the resource (required)
      * @return Rule has been removed (status code 200)
      *         or Rule with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      * @see RulesApi#deleteRule
      */
     default void deleteRule(Long id) throws Exception {
@@ -74,6 +78,7 @@ public interface RulesApiDelegate {
      * @param id Id of the resource (required)
      * @return OK (status code 200)
      *         or Rule with specified id not found (status code 404)
+     *         or Unauthorized (status code 401)
      * @see RulesApi#getRule
      */
     default RuleDto getRule(Long id) throws Exception {
@@ -92,6 +97,7 @@ public interface RulesApiDelegate {
      * @param lastActivationTime Time interval in which the rule was activated (optional)
      * @return OK (status code 200)
      *         or Data is filled incorrectly (status code 400)
+     *         or Unauthorized (status code 401)
      * @see RulesApi#getRules
      */
     default RulesDto getRules(PageRequestDto pageRequest,
@@ -111,6 +117,7 @@ public interface RulesApiDelegate {
      * @return Rule has been started (status code 200)
      *         or Rule with specified id not found (status code 404)
      *         or Unsupported state transition (status code 400)
+     *         or Unauthorized (status code 401)
      * @see RulesApi#startRule
      */
     default void startRule(Long id) throws Exception {
@@ -125,6 +132,7 @@ public interface RulesApiDelegate {
      * @return Rule has been stopped (status code 200)
      *         or Rule with specified id not found (status code 404)
      *         or Unsupported state transition (status code 400)
+     *         or Unauthorized (status code 401)
      * @see RulesApi#stopRule
      */
     default void stopRule(Long id) throws Exception {

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/SystemApi.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/SystemApi.java
@@ -23,59 +23,42 @@
 package org.smartdata.server.generated.api;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.smartdata.server.generated.model.ClusterNodesDto;
-import org.smartdata.server.generated.model.ClusterSortDto;
-import org.smartdata.server.generated.model.ErrorResponseDto;
-import org.smartdata.server.generated.model.PageRequestDto;
-import org.smartdata.server.generated.model.RegistrationTimeIntervalDto;
+import org.smartdata.server.generated.model.UserInfoDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.annotation.Generated;
-import javax.validation.Valid;
-
-import java.util.List;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Cluster", description = "the Cluster API")
-public interface ClusterApi {
+@Tag(name = "System", description = "the System API")
+public interface SystemApi {
 
-    default ClusterApiDelegate getDelegate() {
-        return new ClusterApiDelegate() {};
+    default SystemApiDelegate getDelegate() {
+        return new SystemApiDelegate() {};
     }
 
     /**
-     * GET /api/v2/cluster/nodes : List all cluster nodes
+     * GET /api/v2/system/current-user : Get current logged in user
      *
-     * @param pageRequest  (optional)
-     * @param sort Sort field names prefixed with &#39;-&#39; for descending order (optional)
-     * @param registrationTime Time interval in which node was registered in master (optional)
      * @return OK (status code 200)
-     *         or Data is filled incorrectly (status code 400)
      *         or Unauthorized (status code 401)
      */
     @Operation(
-        operationId = "getClusterNodes",
-        summary = "List all cluster nodes",
-        tags = { "Cluster" },
+        operationId = "getCurrentUser",
+        summary = "Get current logged in user",
+        tags = { "System" },
         responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = {
-                @Content(mediaType = "application/json", schema = @Schema(implementation = ClusterNodesDto.class))
-            }),
-            @ApiResponse(responseCode = "400", description = "Data is filled incorrectly", content = {
-                @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))
+                @Content(mediaType = "application/json", schema = @Schema(implementation = UserInfoDto.class))
             }),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
         },
@@ -85,17 +68,15 @@ public interface ClusterApi {
     )
     @RequestMapping(
         method = RequestMethod.GET,
-        value = "/api/v2/cluster/nodes",
+        value = "/api/v2/system/current-user",
         produces = { "application/json" }
     )
     @ResponseStatus(HttpStatus.OK)
     
-    default ClusterNodesDto getClusterNodes(
-        @Parameter(name = "pageRequest", description = "", in = ParameterIn.QUERY) @Valid PageRequestDto pageRequest,
-        @Parameter(name = "sort", description = "Sort field names prefixed with '-' for descending order", in = ParameterIn.QUERY) @Valid @RequestParam(value = "sort", required = false) List<@Valid ClusterSortDto> sort,
-        @Parameter(name = "registrationTime", description = "Time interval in which node was registered in master", in = ParameterIn.QUERY) @Valid RegistrationTimeIntervalDto registrationTime
+    default UserInfoDto getCurrentUser(
+        
     ) throws Exception {
-        return getDelegate().getClusterNodes(pageRequest, sort, registrationTime);
+        return getDelegate().getCurrentUser();
     }
 
 }

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/SystemApiController.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/SystemApiController.java
@@ -28,16 +28,16 @@ import java.util.Optional;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @RestController
 @RequestMapping("${openapi.sSMAPIDocumentation.base-path:}")
-public class CmdletsApiController implements CmdletsApi {
+public class SystemApiController implements SystemApi {
 
-    private final CmdletsApiDelegate delegate;
+    private final SystemApiDelegate delegate;
 
-    public CmdletsApiController(@Autowired(required = false) CmdletsApiDelegate delegate) {
-        this.delegate = Optional.ofNullable(delegate).orElse(new CmdletsApiDelegate() {});
+    public SystemApiController(@Autowired(required = false) SystemApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new SystemApiDelegate() {});
     }
 
     @Override
-    public CmdletsApiDelegate getDelegate() {
+    public SystemApiDelegate getDelegate() {
         return delegate;
     }
 

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/api/SystemApiDelegate.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/api/SystemApiDelegate.java
@@ -17,28 +17,34 @@
  */
 package org.smartdata.server.generated.api;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.smartdata.server.generated.model.UserInfoDto;
+import org.springframework.web.context.request.NativeWebRequest;
 
 import javax.annotation.Generated;
 
 import java.util.Optional;
 
+/**
+ * A delegate to be called by the {@link SystemApiController}}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
+ */
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
-@RestController
-@RequestMapping("${openapi.sSMAPIDocumentation.base-path:}")
-public class CmdletsApiController implements CmdletsApi {
+public interface SystemApiDelegate {
 
-    private final CmdletsApiDelegate delegate;
-
-    public CmdletsApiController(@Autowired(required = false) CmdletsApiDelegate delegate) {
-        this.delegate = Optional.ofNullable(delegate).orElse(new CmdletsApiDelegate() {});
+    default Optional<NativeWebRequest> getRequest() {
+        return Optional.empty();
     }
 
-    @Override
-    public CmdletsApiDelegate getDelegate() {
-        return delegate;
+    /**
+     * GET /api/v2/system/current-user : Get current logged in user
+     *
+     * @return OK (status code 200)
+     *         or Unauthorized (status code 401)
+     * @see SystemApi#getCurrentUser
+     */
+    default UserInfoDto getCurrentUser() throws Exception {
+        throw new IllegalArgumentException("Not implemented");
+
     }
 
 }

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/model/UserInfoDto.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/model/UserInfoDto.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.server.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.annotation.Generated;
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+/**
+ * UserInfoDto
+ */
+
+@JsonTypeName("UserInfo")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class UserInfoDto {
+
+  private String name;
+
+  public UserInfoDto() {
+    super();
+  }
+
+  /**
+   * Constructor with only required parameters
+   */
+  public UserInfoDto(String name) {
+    this.name = name;
+  }
+
+  public UserInfoDto name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Name of the user
+   * @return name
+  */
+  @NotNull 
+  @Schema(name = "name", description = "Name of the user", requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UserInfoDto userInfo = (UserInfoDto) o;
+    return Objects.equals(this.name, userInfo.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class UserInfoDto {\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/smart-web-server/src/main/java/org/smartdata/server/security/SmartPrincipalInitializerFilter.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/security/SmartPrincipalInitializerFilter.java
@@ -39,12 +39,14 @@ public class SmartPrincipalInitializerFilter extends OncePerRequestFilter {
       HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
 
-    Optional.ofNullable(SecurityContextHolder.getContext())
+    SmartPrincipal principal = Optional.ofNullable(SecurityContextHolder.getContext())
         .map(SecurityContext::getAuthentication)
         .filter(Authentication::isAuthenticated)
         .map(Authentication::getName)
         .map(SmartPrincipal::new)
-        .ifPresent(SmartPrincipalHolder::setCurrentPrincipal);
+        .orElseGet(SmartPrincipalHolder::anonymous);
+
+    SmartPrincipalHolder.setCurrentPrincipal(principal);
 
     filterChain.doFilter(request, response);
 

--- a/smart-web-server/src/main/resources/api/resources/action.yaml
+++ b/smart-web-server/src/main/resources/api/resources/action.yaml
@@ -14,3 +14,5 @@ get:
             $ref: '../schemas/actions/Action.yaml'
     '404':
       description: Action with specified id not found
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/actions.yaml
+++ b/smart-web-server/src/main/resources/api/resources/actions.yaml
@@ -34,6 +34,8 @@ get:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized
 post:
   tags:
     - Actions
@@ -58,3 +60,5 @@ post:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/audit-events.yaml
+++ b/smart-web-server/src/main/resources/api/resources/audit-events.yaml
@@ -34,3 +34,5 @@ get:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/cluster-nodes.yaml
+++ b/smart-web-server/src/main/resources/api/resources/cluster-nodes.yaml
@@ -29,3 +29,5 @@ get:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/cmdlet-stop.yaml
+++ b/smart-web-server/src/main/resources/api/resources/cmdlet-stop.yaml
@@ -10,3 +10,5 @@ post:
       description: Cmdlet has been stopped
     '404':
       description: Cmdlet with specified id not found
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/cmdlet.yaml
+++ b/smart-web-server/src/main/resources/api/resources/cmdlet.yaml
@@ -14,6 +14,8 @@ get:
             $ref: '../schemas/cmdlets/Cmdlet.yaml'
     '404':
       description: Cmdlet with specified id not found
+    '401':
+      description: Unauthorized
 delete:
   tags:
     - Cmdlets
@@ -26,3 +28,5 @@ delete:
       description: Cmdlet has been removed
     '404':
       description: Cmdlet with specified id not found
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/cmdlets.yaml
+++ b/smart-web-server/src/main/resources/api/resources/cmdlets.yaml
@@ -33,6 +33,8 @@ get:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized
 post:
   tags:
     - Cmdlets
@@ -57,3 +59,5 @@ post:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/current-user.yaml
+++ b/smart-web-server/src/main/resources/api/resources/current-user.yaml
@@ -1,0 +1,14 @@
+get:
+  tags:
+    - System
+  summary: Get current logged in user
+  operationId: getCurrentUser
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/system/UserInfo.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/files-access-counts.yaml
+++ b/smart-web-server/src/main/resources/api/resources/files-access-counts.yaml
@@ -30,3 +30,5 @@ get:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/files-cached.yaml
+++ b/smart-web-server/src/main/resources/api/resources/files-cached.yaml
@@ -31,3 +31,5 @@ get:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/rule-start.yaml
+++ b/smart-web-server/src/main/resources/api/resources/rule-start.yaml
@@ -16,3 +16,5 @@ post:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/rule-stop.yaml
+++ b/smart-web-server/src/main/resources/api/resources/rule-stop.yaml
@@ -16,3 +16,5 @@ post:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/rule.yaml
+++ b/smart-web-server/src/main/resources/api/resources/rule.yaml
@@ -14,6 +14,8 @@ get:
             $ref: '../schemas/rules/Rule.yaml'
     '404':
       description: Rule with specified id not found
+    '401':
+      description: Unauthorized
 delete:
   tags:
     - Rules
@@ -26,3 +28,5 @@ delete:
       description: Rule has been removed
     '404':
       description: Rule with specified id not found
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/resources/rules.yaml
+++ b/smart-web-server/src/main/resources/api/resources/rules.yaml
@@ -32,6 +32,8 @@ get:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized
 post:
   tags:
     - Rules
@@ -56,3 +58,5 @@ post:
         application/json:
           schema:
             $ref: '../schemas/common/ErrorResponse.yaml'
+    '401':
+      description: Unauthorized

--- a/smart-web-server/src/main/resources/api/schemas/system/UserInfo.yaml
+++ b/smart-web-server/src/main/resources/api/schemas/system/UserInfo.yaml
@@ -1,0 +1,8 @@
+title: UserInfo
+type: object
+properties:
+  name:
+    type: string
+    description: Name of the user
+required:
+  - name

--- a/smart-web-server/src/main/resources/api/ssm-api.yaml
+++ b/smart-web-server/src/main/resources/api/ssm-api.yaml
@@ -10,6 +10,7 @@ tags:
   - name: Files
   - name: Cluster
   - name: Audit
+  - name: System
 
 servers:
   - url: http://localhost:8081
@@ -53,3 +54,16 @@ paths:
   # Audit
   /api/v2/audit/events:
     $ref: './resources/audit-events.yaml'
+
+  # System
+  /api/v2/system/current-user:
+    $ref: './resources/current-user.yaml'
+
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+
+security:
+  - basicAuth: []

--- a/smart-web-server/src/main/resources/static/ssm-api.yaml
+++ b/smart-web-server/src/main/resources/static/ssm-api.yaml
@@ -6,6 +6,8 @@ info:
 servers:
 - description: Local SSM server url
   url: http://localhost:8081
+security:
+- basicAuth: []
 tags:
 - name: Rules
 - name: Cmdlets
@@ -13,6 +15,7 @@ tags:
 - name: Files
 - name: Cluster
 - name: Audit
+- name: System
 paths:
   /api/v2/rules:
     get:
@@ -72,6 +75,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: List all rules
       tags:
       - Rules
@@ -96,6 +101,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: Submit rule
       tags:
       - Rules
@@ -116,6 +123,8 @@ paths:
           description: Rule has been removed
         "404":
           description: Rule with specified id not found
+        "401":
+          description: Unauthorized
       summary: Delete rule by id
       tags:
       - Rules
@@ -139,6 +148,8 @@ paths:
           description: OK
         "404":
           description: Rule with specified id not found
+        "401":
+          description: Unauthorized
       summary: Get rule by id
       tags:
       - Rules
@@ -165,6 +176,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Unsupported state transition
+        "401":
+          description: Unauthorized
       summary: Start or continue specified rule
       tags:
       - Rules
@@ -191,6 +204,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Unsupported state transition
+        "401":
+          description: Unauthorized
       summary: Stop specified rule
       tags:
       - Rules
@@ -261,6 +276,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: List all cmdlets
       tags:
       - Cmdlets
@@ -285,6 +302,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: Submit cmdlet
       tags:
       - Cmdlets
@@ -305,6 +324,8 @@ paths:
           description: Cmdlet has been removed
         "404":
           description: Cmdlet with specified id not found
+        "401":
+          description: Unauthorized
       summary: Delete cmdlet by id
       tags:
       - Cmdlets
@@ -328,6 +349,8 @@ paths:
           description: OK
         "404":
           description: Cmdlet with specified id not found
+        "401":
+          description: Unauthorized
       summary: Get cmdlet by id
       tags:
       - Cmdlets
@@ -348,6 +371,8 @@ paths:
           description: Cmdlet has been stopped
         "404":
           description: Cmdlet with specified id not found
+        "401":
+          description: Unauthorized
       summary: Stop specified cmdlet
       tags:
       - Cmdlets
@@ -425,6 +450,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: List all actions
       tags:
       - Actions
@@ -449,6 +476,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: Submit action
       tags:
       - Actions
@@ -473,6 +502,8 @@ paths:
           description: OK
         "404":
           description: Action with specified id not found
+        "401":
+          description: Unauthorized
       summary: Get action by id
       tags:
       - Actions
@@ -520,6 +551,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: List access counts of files
       tags:
       - Files
@@ -573,6 +606,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: List cached files
       tags:
       - Files
@@ -613,6 +648,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: List all cluster nodes
       tags:
       - Cluster
@@ -692,9 +729,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Data is filled incorrectly
+        "401":
+          description: Unauthorized
       summary: List all audit events
       tags:
       - Audit
+  /api/v2/system/current-user:
+    get:
+      operationId: getCurrentUser
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserInfo'
+          description: OK
+        "401":
+          description: Unauthorized
+      summary: Get current logged in user
+      tags:
+      - System
 components:
   parameters:
     page-request:
@@ -1512,6 +1566,17 @@ components:
       - username
       title: AuditEvent
       type: object
+    UserInfo:
+      example:
+        name: name
+      properties:
+        name:
+          description: Name of the user
+          type: string
+      required:
+      - name
+      title: UserInfo
+      type: object
     ExecutorType:
       description: Type of the cmdlet executor
       enum:
@@ -1840,3 +1905,7 @@ components:
           timestamp: 1
           objectType: null
       title: AuditEvents
+  securitySchemes:
+    basicAuth:
+      scheme: basic
+      type: http


### PR DESCRIPTION
- Added endpoint for retrieving information about the logged-in user
- Replaced `null` user with `anonymous` one in case of disabled authentication
- Added `smart.rest.server.auth.spnego.keytab` config to optionally provide SSM server keytab for `HTTP` principal separately from SSM service keytab (`smart.server.keytab.file`)