### PR TITLE
[ADH-4781] Fix CRUD filtering bugs

### DIFF
--- a/smart-metastore/src/main/java/org/smartdata/metastore/queries/JoinedTable.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/queries/JoinedTable.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.metastore.queries;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class JoinedTable {
+  private final String table;
+
+  private final Map<String, String> joinColumns;
+}

--- a/smart-web-server/src/main/java/org/smartdata/server/generated/model/EventTimeIntervalDto.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/generated/model/EventTimeIntervalDto.java
@@ -20,9 +20,11 @@ package org.smartdata.server.generated.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Objects;
+
 import javax.annotation.Generated;
 import javax.validation.constraints.Min;
+
+import java.util.Objects;
 
 /**
  * EventTimeIntervalDto
@@ -32,50 +34,50 @@ import javax.validation.constraints.Min;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class EventTimeIntervalDto {
 
-  private Long timestampFrom = null;
+  private Long eventTimeFrom = null;
 
-  private Long timestampTo = null;
+  private Long eventTimeTo = null;
 
-  public EventTimeIntervalDto timestampFrom(Long timestampFrom) {
-    this.timestampFrom = timestampFrom;
+  public EventTimeIntervalDto eventTimeFrom(Long eventTimeFrom) {
+    this.eventTimeFrom = eventTimeFrom;
     return this;
   }
 
   /**
    * UNIX timestamp (UTC) of the interval start
    * minimum: 0
-   * @return timestampFrom
-  */
-  @Min(0L) 
-  @Schema(name = "timestampFrom", description = "UNIX timestamp (UTC) of the interval start", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("timestampFrom")
-  public Long getTimestampFrom() {
-    return timestampFrom;
+   * @return eventTimeFrom
+   */
+  @Min(0L)
+  @Schema(name = "eventTimeFrom", description = "UNIX timestamp (UTC) of the interval start", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("eventTimeFrom")
+  public Long getEventTimeFrom() {
+    return eventTimeFrom;
   }
 
-  public void setTimestampFrom(Long timestampFrom) {
-    this.timestampFrom = timestampFrom;
+  public void setEventTimeFrom(Long eventTimeFrom) {
+    this.eventTimeFrom = eventTimeFrom;
   }
 
-  public EventTimeIntervalDto timestampTo(Long timestampTo) {
-    this.timestampTo = timestampTo;
+  public EventTimeIntervalDto eventTimeTo(Long eventTimeTo) {
+    this.eventTimeTo = eventTimeTo;
     return this;
   }
 
   /**
    * UNIX timestamp (UTC) of the interval end
    * minimum: 0
-   * @return timestampTo
-  */
-  @Min(0L) 
-  @Schema(name = "timestampTo", description = "UNIX timestamp (UTC) of the interval end", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("timestampTo")
-  public Long getTimestampTo() {
-    return timestampTo;
+   * @return eventTimeTo
+   */
+  @Min(0L)
+  @Schema(name = "eventTimeTo", description = "UNIX timestamp (UTC) of the interval end", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("eventTimeTo")
+  public Long getEventTimeTo() {
+    return eventTimeTo;
   }
 
-  public void setTimestampTo(Long timestampTo) {
-    this.timestampTo = timestampTo;
+  public void setEventTimeTo(Long eventTimeTo) {
+    this.eventTimeTo = eventTimeTo;
   }
 
   @Override
@@ -87,21 +89,21 @@ public class EventTimeIntervalDto {
       return false;
     }
     EventTimeIntervalDto eventTimeInterval = (EventTimeIntervalDto) o;
-    return Objects.equals(this.timestampFrom, eventTimeInterval.timestampFrom) &&
-        Objects.equals(this.timestampTo, eventTimeInterval.timestampTo);
+    return Objects.equals(this.eventTimeFrom, eventTimeInterval.eventTimeFrom) &&
+        Objects.equals(this.eventTimeTo, eventTimeInterval.eventTimeTo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(timestampFrom, timestampTo);
+    return Objects.hash(eventTimeFrom, eventTimeTo);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class EventTimeIntervalDto {\n");
-    sb.append("    timestampFrom: ").append(toIndentedString(timestampFrom)).append("\n");
-    sb.append("    timestampTo: ").append(toIndentedString(timestampTo)).append("\n");
+    sb.append("    eventTimeFrom: ").append(toIndentedString(eventTimeFrom)).append("\n");
+    sb.append("    eventTimeTo: ").append(toIndentedString(eventTimeTo)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/smart-web-server/src/main/java/org/smartdata/server/mappers/AuditEventMapper.java
+++ b/smart-web-server/src/main/java/org/smartdata/server/mappers/AuditEventMapper.java
@@ -50,7 +50,7 @@ public interface AuditEventMapper extends SmartMapper {
       List<@Valid AuditOperationDto> operations,
       List<@Valid AuditEventResultDto> results);
 
-  @Mapping(source = "timestampFrom", target = "from")
-  @Mapping(source = "timestampTo", target = "to")
+  @Mapping(source = "eventTimeFrom", target = "from")
+  @Mapping(source = "eventTimeTo", target = "to")
   TimeInterval toTimeInterval(EventTimeIntervalDto intervalDto);
 }

--- a/smart-web-server/src/main/resources/api/parameters/audit/event-time.yaml
+++ b/smart-web-server/src/main/resources/api/parameters/audit/event-time.yaml
@@ -6,14 +6,14 @@ schema:
   title: EventTimeInterval
   type: object
   properties:
-    timestampFrom:
+    eventTimeFrom:
       type: integer
       format: int64
       nullable: true
       default: null
       minimum: 0
       description: UNIX timestamp (UTC) of the interval start
-    timestampTo:
+    eventTimeTo:
       type: integer
       format: int64
       nullable: true

--- a/smart-web-server/src/main/resources/static/ssm-api.yaml
+++ b/smart-web-server/src/main/resources/static/ssm-api.yaml
@@ -1898,13 +1898,13 @@ components:
       title: ClusterNodes
     EventTimeInterval:
       properties:
-        timestampFrom:
+        eventTimeFrom:
           description: UNIX timestamp (UTC) of the interval start
           format: int64
           minimum: 0
           nullable: true
           type: integer
-        timestampTo:
+        eventTimeTo:
           description: UNIX timestamp (UTC) of the interval end
           format: int64
           minimum: 0


### PR DESCRIPTION
- Added correct joins handling in the SQL count metastore query generation, that fixes the filtering file access counts by path error 
- Renamed the `timestampFrom` and `timestampTo` query parameters of the audit events listing request to the `eventTimeFrom` and `eventTimeTo` respectively