### PR TITLE
[Hotfix] Fix max connection pool size in smart-metastore tests

### DIFF
--- a/smart-metastore/src/test/resources/druid-template.xml
+++ b/smart-metastore/src/test/resources/druid-template.xml
@@ -6,9 +6,9 @@
     <entry key="username">""</entry>
     <entry key="password">""</entry>
 
-    <entry key="initialSize">8</entry>
-    <entry key="minIdle">4</entry>
-    <entry key="maxActive">16</entry>
+    <entry key="initialSize">1</entry>
+    <entry key="minIdle">1</entry>
+    <entry key="maxActive">1</entry>
 
     <entry key="maxWait">60000</entry>
     <entry key="timeBetweenEvictionRunsMillis">90000</entry>


### PR DESCRIPTION
JDBC connection pool settings for tests were updated in #87 . However, we should use old settings before #73 will be merged, to avoid issues related to multiple connections to SQLite 