### PR TITLE
Define source encoding in the project pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
   </modules>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4j.version>2.22.1</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
It is necessary for correct deployment of artifacts on a test stand via Gitlab CI.