### PR TITLE
[Backport] Add provided proto dependency to smart-server module

### DIFF
--- a/smart-server/pom.xml
+++ b/smart-server/pom.xml
@@ -110,6 +110,11 @@
             <version>${log4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j.version}</version>


### PR DESCRIPTION
Add provided protobuf dependency to the `smart-server` module to be able to build SSM on machines with the Arenadata version of HDFS 3.3.6 in the local .m2 repository