### PR TITLE
[ADH-5196] Properly handle file transfer errors

### DIFF
--- a/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
@@ -17,15 +17,20 @@
  */
 package org.smartdata.utils;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
+
+import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
 
 public class PathUtil {
   private static final String DIR_SEP = "/";
   private static final String HDFS_SCHEME = "hdfs";
-  private static final String[] GLOBS = new String[] {
+  private static final String[] GLOBS = new String[]{
       "*", "?"
   };
 
@@ -69,9 +74,14 @@ public class PathUtil {
   // todo replace 'stringPath.startsWith("hdfs")' calls with this method
   public static boolean isAbsoluteRemotePath(Path path) {
     return Optional.ofNullable(path)
-            .map(Path::toUri)
-            .filter(PathUtil::isAbsoluteRemotePath)
-            .isPresent();
+        .map(Path::toUri)
+        .filter(PathUtil::isAbsoluteRemotePath)
+        .isPresent();
+  }
+
+  public static FileSystem getRemoteFileSystem(
+      Path path, Configuration conf) throws IOException {
+    return path.getFileSystem(toRemoteClusterConfig(conf));
   }
 
   public static boolean isAbsoluteRemotePath(URI uri) {

--- a/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MultiClusterHarness.java
+++ b/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MultiClusterHarness.java
@@ -65,6 +65,7 @@ public abstract class MultiClusterHarness extends MiniClusterHarness {
     if (testType == INTRA_CLUSTER) {
       anotherDfs = dfs;
       anotherDfsClient = dfsClient;
+      anotherCluster = cluster;
       return;
     }
     Configuration clusterConfig = new Configuration(smartContext.getConf());

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyFileAction.java
@@ -153,7 +153,7 @@ public class CopyFileAction extends CopyPreservedAttributesAction {
   }
 
   private void copyWithOffset(String src, String dest, int bufferSize,
-                              long offset, long length) throws IOException {
+      long offset, long length) throws IOException {
     appendLog(
         String.format("Copy with offset %s and length %s", offset, length));
 
@@ -222,9 +222,11 @@ public class CopyFileAction extends CopyPreservedAttributesAction {
 
   private FileStatus validateDestFile(FileStatus destFileStatus) {
     if (destFileStatus.getLen() < offset) {
-      throw new IllegalStateException("Destination file " + destFileStatus.getPath()
-          + " is shorter than it should be - expected min length: "
-          + offset + ", actual length: " + destFileStatus.getLen());
+      String errorMessage = String.format(
+          "Destination file %s is shorter than it should be "
+              + "- expected min length: %d, actual length: %d",
+          destFileStatus.getPath(), offset, destFileStatus.getLen());
+      throw new IllegalStateException(errorMessage);
     }
 
     return destFileStatus;

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyPreservedAttributesAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/CopyPreservedAttributesAction.java
@@ -18,19 +18,22 @@
 package org.smartdata.hdfs.action;
 
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.smartdata.model.FileInfoDiff;
+
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.smartdata.model.FileInfoDiff;
 
 
 /**
@@ -105,6 +108,14 @@ public abstract class CopyPreservedAttributesAction extends HdfsAction {
       return fs.getFileStatus(new Path(fileName));
     }
     return (FileStatus) dfsClient.getFileInfo(fileName);
+  }
+
+  protected Optional<FileStatus> getFileStatusSafely(String fileName) throws IOException {
+    try {
+      return Optional.ofNullable(getFileStatus(fileName));
+    } catch (FileNotFoundException fileNotFoundException) {
+      return Optional.empty();
+    }
   }
 
   public enum PreserveAttribute {

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/ChecksumFileEqualityStrategy.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/ChecksumFileEqualityStrategy.java
@@ -17,8 +17,6 @@
  */
 package org.smartdata.hdfs.file.equality;
 
-import java.io.IOException;
-import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
@@ -29,7 +27,10 @@ import org.slf4j.LoggerFactory;
 import org.smartdata.hdfs.HadoopUtil;
 import org.smartdata.model.FileInfo;
 
-import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.smartdata.utils.PathUtil.getRemoteFileSystem;
 import static org.smartdata.utils.PathUtil.isAbsoluteRemotePath;
 
 public class ChecksumFileEqualityStrategy implements FileEqualityStrategy {
@@ -46,7 +47,7 @@ public class ChecksumFileEqualityStrategy implements FileEqualityStrategy {
 
   private FileSystem getFileSystem(Path path, Configuration conf) throws IOException {
     return isAbsoluteRemotePath(path)
-        ? path.getFileSystem(toRemoteClusterConfig(conf))
+        ? getRemoteFileSystem(path, conf)
         : FileSystem.get(HadoopUtil.getNameNodeUri(conf), conf);
   }
 

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/apache/hadoop/hdfs/FailingDfsInputStream.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/apache/hadoop/hdfs/FailingDfsInputStream.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import java.io.IOException;
+
+public class FailingDfsInputStream extends DFSInputStream {
+
+  private final boolean shouldFail;
+
+  private int bytesToReadBeforeFail;
+  private boolean firstBytesRead;
+
+  public FailingDfsInputStream(DFSInputStream wrapped,
+                               boolean shouldFail,
+                               int readBytesBeforeFail) throws IOException {
+    super(wrapped.dfsClient, wrapped.src, wrapped.verifyChecksum, wrapped.getLocatedBlocks());
+
+    this.shouldFail = shouldFail;
+    this.bytesToReadBeforeFail = readBytesBeforeFail;
+  }
+
+  public int read(byte[] buff, int off, int len) throws IOException {
+    if (!shouldFail) {
+      return super.read(buff, off, len);
+    }
+    if (firstBytesRead) {
+      throw new IOException("Some error");
+    }
+    if (len < bytesToReadBeforeFail) {
+      bytesToReadBeforeFail -= len;
+      return super.read(buff, off, len);
+    }
+
+    firstBytesRead = true;
+    super.read(buff, off, bytesToReadBeforeFail);
+    return bytesToReadBeforeFail;
+  }
+}


### PR DESCRIPTION
Modified `FileCopyAction`: now the destination file is truncated before the `append()` is called in case if it's longer than the specified offset argument (start position of the source file append event)
