### PR TITLE
[ADH-5351] Use CreateEvent to add information about file to Metastore

### DIFF
--- a/smart-common/src/main/java/org/smartdata/model/FileInfoDiff.java
+++ b/smart-common/src/main/java/org/smartdata/model/FileInfoDiff.java
@@ -17,8 +17,11 @@
  */
 package org.smartdata.model;
 
-import java.util.Objects;
+import lombok.Data;
+import lombok.experimental.Accessors;
 
+@Data
+@Accessors(chain = true)
 public class FileInfoDiff {
   private String path;
   private Long length;
@@ -29,126 +32,5 @@ public class FileInfoDiff {
   private String owner;
   private String group;
   private Byte erasureCodingPolicy;
-
-  public String getPath() {
-    return path;
-  }
-
-  public FileInfoDiff setPath(String path) {
-    this.path = path;
-    return this;
-  }
-
-  public Long getLength() {
-    return length;
-  }
-
-  public FileInfoDiff setLength(Long length) {
-    this.length = length;
-    return this;
-  }
-
-  public Short getBlockReplication() {
-    return blockReplication;
-  }
-
-  public FileInfoDiff setBlockReplication(Short blockReplication) {
-    this.blockReplication = blockReplication;
-    return this;
-  }
-
-  public Long getModificationTime() {
-    return modificationTime;
-  }
-
-  public FileInfoDiff setModificationTime(Long modificationTime) {
-    this.modificationTime = modificationTime;
-    return this;
-  }
-
-  public Long getAccessTime() {
-    return accessTime;
-  }
-
-  public FileInfoDiff setAccessTime(Long accessTime) {
-    this.accessTime = accessTime;
-    return this;
-  }
-
-  public Short getPermission() {
-    return permission;
-  }
-
-  public FileInfoDiff setPermission(Short permission) {
-    this.permission = permission;
-    return this;
-  }
-
-  public String getOwner() {
-    return owner;
-  }
-
-  public FileInfoDiff setOwner(String owner) {
-    this.owner = owner;
-    return this;
-  }
-
-  public String getGroup() {
-    return group;
-  }
-
-  public FileInfoDiff setGroup(String group) {
-    this.group = group;
-    return this;
-  }
-
-  public Byte getErasureCodingPolicy() {
-    return erasureCodingPolicy;
-  }
-
-  public FileInfoDiff setErasureCodingPolicy(Byte erasureCodingPolicy) {
-    this.erasureCodingPolicy = erasureCodingPolicy;
-    return this;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    FileInfoDiff that = (FileInfoDiff) o;
-    return Objects.equals(path, that.path)
-        && Objects.equals(length, that.length)
-        && Objects.equals(blockReplication, that.blockReplication)
-        && Objects.equals(modificationTime, that.modificationTime)
-        && Objects.equals(accessTime, that.accessTime)
-        && Objects.equals(permission, that.permission)
-        && Objects.equals(owner, that.owner)
-        && Objects.equals(group, that.group)
-        && Objects.equals(erasureCodingPolicy, that.erasureCodingPolicy);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(path, length, blockReplication,
-        modificationTime, accessTime, permission, owner, group, erasureCodingPolicy);
-  }
-
-  @Override
-  public String toString() {
-    return "FileInfoDiff{"
-        + "path='" + path + '\''
-        + ", length=" + length
-        + ", blockReplication=" + blockReplication
-        + ", modificationTime=" + modificationTime
-        + ", accessTime=" + accessTime
-        + ", permission=" + permission
-        + ", owner='" + owner + '\''
-        + ", group='" + group + '\''
-        + ", erasureCodingPolicy=" + erasureCodingPolicy
-        + '}';
-  }
+  private Byte storagePolicy;
 }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/FileDiffGenerator.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/FileDiffGenerator.java
@@ -1,0 +1,265 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.metric.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.hdfs.inotify.Event;
+import org.smartdata.action.SyncAction;
+import org.smartdata.hdfs.action.CopyFileAction;
+import org.smartdata.metastore.MetaStore;
+import org.smartdata.metastore.MetaStoreException;
+import org.smartdata.model.FileDiff;
+import org.smartdata.model.FileDiffState;
+import org.smartdata.model.FileDiffType;
+import org.smartdata.model.FileInfo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import static org.smartdata.action.SyncAction.BASE_OPERATION;
+import static org.smartdata.hdfs.action.MetaDataAction.BLOCK_REPLICATION;
+import static org.smartdata.hdfs.action.MetaDataAction.GROUP_NAME;
+import static org.smartdata.hdfs.action.MetaDataAction.MTIME;
+import static org.smartdata.hdfs.action.MetaDataAction.OWNER_NAME;
+import static org.smartdata.hdfs.action.MetaDataAction.PERMISSION;
+import static org.smartdata.utils.PathUtil.addPathSeparator;
+
+@Slf4j
+@RequiredArgsConstructor
+public class FileDiffGenerator {
+
+  private final MetaStore metaStore;
+  private final Supplier<Long> currentTimeMsSupplier;
+
+  public Optional<FileDiff> onFileCreate(FileInfo file) throws MetaStoreException {
+    if (!inBackup(file.getPath())) {
+      return Optional.empty();
+    }
+
+    FileDiff createDiff = toCreateDiff(file, file.getPath());
+    return Optional.of(createDiff);
+  }
+
+  public Optional<FileDiff> onFileClose(Event.CloseEvent closeEvent) throws MetaStoreException {
+    if (!inBackup(closeEvent.getPath())) {
+      return Optional.empty();
+    }
+
+    FileInfo fileInfo = metaStore.getFile(closeEvent.getPath());
+    long currentLength = Optional.ofNullable(fileInfo)
+        .map(FileInfo::getLength)
+        .orElse(0L);
+
+    if (currentLength == closeEvent.getFileSize()) {
+      return Optional.empty();
+    }
+
+    FileDiff fileDiff = toAppendDiff(closeEvent.getPath(), currentLength, closeEvent.getFileSize());
+    return Optional.of(fileDiff);
+  }
+
+  public Optional<FileDiff> onMetadataUpdate(Event.MetadataUpdateEvent metadataUpdateEvent)
+      throws MetaStoreException {
+    if (!inBackup(metadataUpdateEvent.getPath())) {
+      return Optional.empty();
+    }
+
+    Map<String, String> parameters = new HashMap<>();
+    switch (metadataUpdateEvent.getMetadataType()) {
+      case TIMES:
+        if (metadataUpdateEvent.getMtime() > 0) {
+          parameters.put(MTIME, String.valueOf(metadataUpdateEvent.getMtime()));
+        }
+        break;
+      case OWNER:
+        Optional.ofNullable(metadataUpdateEvent.getOwnerName())
+            .ifPresent(name -> parameters.put(OWNER_NAME, name));
+        Optional.ofNullable(metadataUpdateEvent.getGroupName())
+            .ifPresent(name -> parameters.put(GROUP_NAME, name));
+        break;
+      case PERMS:
+        parameters.put(PERMISSION, String.valueOf(metadataUpdateEvent.getPerms().toShort()));
+        break;
+      case REPLICATION:
+        parameters.put(BLOCK_REPLICATION, String.valueOf(metadataUpdateEvent.getReplication()));
+        break;
+      default:
+        return Optional.empty();
+    }
+
+    if (parameters.isEmpty()) {
+      return Optional.empty();
+    }
+
+    FileDiff fileDiff = fileDiffBuilder(metadataUpdateEvent.getPath())
+        .diffType(FileDiffType.METADATA)
+        .parameters(parameters)
+        .build();
+    return Optional.of(fileDiff);
+  }
+
+  public List<FileDiff> onFileRename(
+      Event.RenameEvent renameEvent, FileInfo srcFileInfo) throws MetaStoreException {
+    boolean srcInBackup = inBackup(renameEvent.getSrcPath());
+    boolean destInBackup = inBackup(renameEvent.getDstPath());
+
+    if (!srcInBackup && !destInBackup) {
+      return Collections.emptyList();
+    }
+
+    if (srcFileInfo == null) {
+      log.error(
+          "Inconsistency in metastore and HDFS namespace, file not found: {}",
+          renameEvent.getSrcPath());
+      return Collections.emptyList();
+    }
+
+    List<FileDiff> fileDiffs;
+    if (srcInBackup) {
+      if (destInBackup) {
+        // if both src and dest are in backup directory,
+        // then generate rename diffs for all content under src
+        fileDiffs = visitFileRecursively(srcFileInfo, renameEvent, this::buildRenameFileDiff);
+      } else {
+        // if src is in backup directory and dest isn't,
+        // then simply delete all files under src on remote cluster
+        fileDiffs = Collections.singletonList(getDeleteFileDiff(srcFileInfo.getPath()));
+      }
+    } else {
+      // if dest is in backup directory and src isn't,
+      // then simply copy files under dest to remote cluster
+      fileDiffs = visitFileRecursively(srcFileInfo, renameEvent, this::buildCreateFileDiff);
+    }
+
+    if (fileDiffs.isEmpty()) {
+      log.error(
+          "Inconsistency in metastore and HDFS namespace, file not found: {}",
+          renameEvent.getSrcPath());
+      return Collections.emptyList();
+    }
+    // set first diff as base rename operation
+    fileDiffs.get(0).setParameter(BASE_OPERATION, "");
+    return fileDiffs;
+  }
+
+  public Optional<FileDiff> onFileDelete(String path)
+      throws MetaStoreException {
+    if (!inBackup(path)) {
+      return Optional.empty();
+    }
+
+    FileDiff deleteFileDiff = getDeleteFileDiff(path);
+    return Optional.of(deleteFileDiff);
+  }
+
+  private FileDiff toCreateDiff(FileInfo file, String path) {
+    return file.isDir()
+        ? toCreateDirectoryDiff(path)
+        : toCreateFileDiff(file, path);
+  }
+
+  private FileDiff toCreateDirectoryDiff(String path) {
+    return fileDiffBuilder(path)
+        .diffType(FileDiffType.MKDIR)
+        .build();
+  }
+
+  private FileDiff toAppendDiff(String path, long currentLength, long newLength) {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(CopyFileAction.OFFSET_INDEX, String.valueOf(currentLength));
+    parameters.put(CopyFileAction.LENGTH, String.valueOf(newLength - currentLength));
+
+    return fileDiffBuilder(path)
+        .diffType(FileDiffType.APPEND)
+        .parameters(parameters)
+        .build();
+  }
+
+  private FileDiff toCreateFileDiff(FileInfo file, String path) {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(CopyFileAction.OFFSET_INDEX, "0");
+    parameters.put(CopyFileAction.LENGTH, String.valueOf(file.getLength()));
+
+    return fileDiffBuilder(path)
+        .diffType(FileDiffType.APPEND)
+        .parameters(parameters)
+        .build();
+  }
+
+  private FileDiff buildRenameFileDiff(FileInfo fileInfo, Event.RenameEvent renameEvent) {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(
+        SyncAction.DEST,
+        fileInfo.getPath().replaceFirst(
+            renameEvent.getSrcPath(),
+            renameEvent.getDstPath())
+    );
+    return fileDiffBuilder(fileInfo.getPath())
+        .diffType(FileDiffType.RENAME)
+        .parameters(parameters)
+        .build();
+  }
+
+  private FileDiff getDeleteFileDiff(String path) {
+    return fileDiffBuilder(path)
+        .diffType(FileDiffType.DELETE)
+        .build();
+  }
+
+  private FileDiff buildCreateFileDiff(FileInfo fileInfo, Event.RenameEvent renameEvent) {
+    String newPath = fileInfo.getPath()
+        .replaceFirst(renameEvent.getSrcPath(), renameEvent.getDstPath());
+    return toCreateDiff(fileInfo, newPath);
+  }
+
+  private <C, T> List<T> visitFileRecursively(
+      FileInfo srcFileInfo, C context,
+      BiFunction<FileInfo, C, T> diffProducer)
+      throws MetaStoreException {
+    List<T> results = new ArrayList<>();
+    results.add(diffProducer.apply(srcFileInfo, context));
+
+    if (srcFileInfo.isDir()) {
+      metaStore.getFilesByPrefixInOrder(addPathSeparator(srcFileInfo.getPath()))
+          .stream()
+          .map(fileInfo -> diffProducer.apply(fileInfo, context))
+          .forEach(results::add);
+    }
+
+    return results;
+  }
+
+  private FileDiff.Builder fileDiffBuilder(String src) {
+    return FileDiff.builder()
+        .src(src)
+        .state(FileDiffState.PENDING)
+        .createTime(currentTimeMsSupplier.get())
+        .parameters(new HashMap<>());
+  }
+
+  private boolean inBackup(String src) throws MetaStoreException {
+    return metaStore.srcInBackup(src);
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyEventApplier.java
@@ -24,15 +24,12 @@ import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.io.WritableUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.smartdata.action.SyncAction;
 import org.smartdata.conf.SmartConf;
 import org.smartdata.hdfs.CompatibilityHelperLoader;
 import org.smartdata.hdfs.HadoopUtil;
-import org.smartdata.hdfs.action.CopyFileAction;
 import org.smartdata.metastore.MetaStore;
 import org.smartdata.metastore.MetaStoreException;
 import org.smartdata.model.FileDiff;
-import org.smartdata.model.FileDiffType;
 import org.smartdata.model.FileInfo;
 import org.smartdata.model.FileInfoDiff;
 import org.smartdata.model.PathChecker;
@@ -40,15 +37,10 @@ import org.smartdata.model.PathChecker;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-
-import static org.smartdata.action.SyncAction.BASE_OPERATION;
-import static org.smartdata.utils.PathUtil.addPathSeparator;
+import java.util.Optional;
 
 /**
  * This is a very preliminary and buggy applier, can further enhance by referring to
@@ -59,26 +51,26 @@ public class InotifyEventApplier {
       LoggerFactory.getLogger(InotifyEventApplier.class);
 
   private static final String ROOT_DIRECTORY = "/";
+  private static final String EC_POLICY_XATTR = "hdfs.erasurecoding.policy";
+
+  private static final byte DEFAULT_STORAGE_POLICY_ID = 7;
+  private static final byte DEFAULT_EC_POLICY_ID = 0;
 
   private final MetaStore metaStore;
   private final PathChecker pathChecker;
   private final DFSClient client;
-
-  private NamespaceFetcher namespaceFetcher;
-
-  public InotifyEventApplier(MetaStore metaStore, DFSClient client) {
-    this(new SmartConf(), metaStore, client);
-  }
-
-  public InotifyEventApplier(SmartConf conf, MetaStore metaStore, DFSClient client, NamespaceFetcher namespaceFetcher) {
-    this(conf, metaStore, client);
-    this.namespaceFetcher = namespaceFetcher;
-  }
+  private final FileDiffGenerator fileDiffGenerator;
 
   public InotifyEventApplier(SmartConf conf, MetaStore metaStore, DFSClient client) {
+    this(conf, metaStore, client, new FileDiffGenerator(metaStore, System::currentTimeMillis));
+  }
+
+  public InotifyEventApplier(SmartConf conf, MetaStore metaStore,
+      DFSClient client, FileDiffGenerator fileDiffGenerator) {
     this.metaStore = metaStore;
     this.client = client;
     this.pathChecker = new PathChecker(conf);
+    this.fileDiffGenerator = fileDiffGenerator;
   }
 
   public void apply(List<Event> events) throws IOException, InterruptedException {
@@ -88,169 +80,134 @@ public class InotifyEventApplier {
   }
 
   public void apply(Event[] events) throws IOException, InterruptedException {
-    this.apply(Arrays.asList(events));
+    apply(Arrays.asList(events));
   }
 
-  private void apply(Event event) throws IOException, InterruptedException {
-    String path;
-    String srcPath, dstPath;
-    LOG.debug("Handle event {}", event);
+  private void apply(Event event) throws IOException {
+    LOG.debug("Handle INotify event: {}", event);
 
     // we already filtered events in the fetch tasks, so we can skip
     // event's path check here
     switch (event.getEventType()) {
       case CREATE:
-        path = ((Event.CreateEvent) event).getPath();
-        LOG.trace("event type: {}, path: {}", event.getEventType().name(), path);
         applyCreate((Event.CreateEvent) event);
         break;
       case CLOSE:
-        path = ((Event.CloseEvent) event).getPath();
-        LOG.trace("event type: {}, path: {}", event.getEventType().name(), path);
         applyClose((Event.CloseEvent) event);
         break;
       case RENAME:
-        srcPath = ((Event.RenameEvent) event).getSrcPath();
-        dstPath = ((Event.RenameEvent) event).getDstPath();
-        LOG.trace("event type: {}, src path: {}, dest path: {}",
-            event.getEventType().name(), srcPath, dstPath);
         applyRename((Event.RenameEvent) event);
         break;
       case METADATA:
         // The property dfs.namenode.accesstime.precision in HDFS's configuration controls
         // the precision of access time. Its default value is 1h. To avoid missing a
         // MetadataUpdateEvent for updating access time, a smaller value should be set.
-        path = ((Event.MetadataUpdateEvent) event).getPath();
-        LOG.trace("event type: {}, path: {}", event.getEventType().name(), path);
         applyMetadataUpdate((Event.MetadataUpdateEvent) event);
         break;
-      case APPEND:
-        path = ((Event.AppendEvent) event).getPath();
-        LOG.trace("event type: {}, path: {}", event.getEventType().name(), path);
-        // do nothing
-        break;
       case UNLINK:
-        path = ((Event.UnlinkEvent) event).getPath();
-        LOG.trace("event type: {}, path: {}", event.getEventType().name(), path);
         applyUnlink((Event.UnlinkEvent) event);
+      case APPEND:
+        break;
     }
   }
 
-  //Todo: times and ec policy id, etc.
-  // TODO we need to create FileInfo from create event, not from HDFS client,
-  // because it can be either deleted or renamed at the moment
-  // of fetching info from HDFS
-  private void applyCreate(Event.CreateEvent createEvent) throws IOException, MetaStoreException {
-    FileInfo fileInfo = getFileInfo(createEvent.getPath());
-    if (fileInfo == null) {
-      LOG.warn("Skipping create event for file {}", createEvent.getPath());
-      return;
-    }
+  private void applyCreate(Event.CreateEvent createEvent) throws IOException {
+    FileInfo fileInfo = fileBuilderWithPolicies(createEvent.getPath())
+        .setPath(createEvent.getPath())
+        .setIsDir(createEvent.getiNodeType() == Event.CreateEvent.INodeType.DIRECTORY)
+        .setBlockReplication((short) createEvent.getReplication())
+        .setBlockSize(createEvent.getDefaultBlockSize())
+        .setModificationTime(createEvent.getCtime())
+        .setAccessTime(createEvent.getCtime())
+        .setPermission(createEvent.getPerms().toShort())
+        .setOwner(createEvent.getOwnerName())
+        .setGroup(createEvent.getGroupName())
+        .build();
 
-    applyCreateFileDiff(fileInfo);
+    fileDiffGenerator.onFileCreate(fileInfo)
+        .ifPresent(this::insertFileDiffUnchecked);
+
     metaStore.deleteFileByPath(fileInfo.getPath(), false);
     metaStore.deleteFileState(fileInfo.getPath());
-    metaStore.insertFile(fileInfo);
+    metaStore.insertFile(fileInfo, true);
   }
 
-  private void applyRenameIgnoredFile(Event.RenameEvent renameEvent) throws IOException, MetaStoreException {
+  private Optional<HdfsFileStatus> getHdfsFileStatus(String path) throws IOException {
+    return Optional.ofNullable(client.getFileInfo(path));
+  }
+
+  private void insertFileDiffUnchecked(FileDiff fileDiff) {
+    try {
+      metaStore.insertFileDiff(fileDiff);
+    } catch (MetaStoreException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  // TODO store ignored files to metastore as well
+  // to take info from metastore instead of fetching fileInfo from hdfs
+  private void applyRenameIgnoredFile(Event.RenameEvent renameEvent) throws IOException {
     FileInfo fileInfo = getFileInfo(renameEvent.getDstPath());
     if (fileInfo == null) {
+      LOG.warn("Error getting info about file moved from ignored directory {}",
+          renameEvent.getDstPath());
       return;
     }
 
-    applyCreateFileDiff(fileInfo);
+    fileDiffGenerator.onFileCreate(fileInfo)
+        .ifPresent(this::insertFileDiffUnchecked);
+
     metaStore.deleteFileByPath(fileInfo.getPath(), false);
-    metaStore.insertFile(fileInfo);
+    metaStore.insertFile(fileInfo, true);
     metaStore.renameFile(renameEvent.getSrcPath(), renameEvent.getDstPath(), fileInfo.isDir());
   }
 
   private FileInfo getFileInfo(String path) throws IOException {
-    HdfsFileStatus fileStatus = client.getFileInfo(path);
-    if (fileStatus == null) {
-      LOG.debug("Can not get HdfsFileStatus for file " + path);
-      return null;
-    }
-
-    return HadoopUtil.convertFileStatus(fileStatus, path);
-  }
-
-  private void applyCreateFileDiff(FileInfo fileInfo) throws MetaStoreException {
-    if (inBackup(fileInfo.getPath())) {
-      if (fileInfo.isDir()) {
-        FileDiff fileDiff = new FileDiff(FileDiffType.MKDIR);
-        fileDiff.setSrc(fileInfo.getPath());
-        metaStore.insertFileDiff(fileDiff);
-        return;
-      }
-      FileDiff fileDiff = new FileDiff(FileDiffType.APPEND);
-      fileDiff.setSrc(fileInfo.getPath());
-      fileDiff.getParameters().put("-offset", String.valueOf(0));
-      // Note that "-length 0" means create an empty file
-      fileDiff.getParameters()
-          .put("-length", String.valueOf(fileInfo.getLength()));
-      // TODO add support in CopyFileAction or split into two file diffs
-      //add modification_time and access_time to filediff
-      fileDiff.getParameters().put("-mtime", "" + fileInfo.getModificationTime());
-      // fileDiff.getParameters().put("-atime", "" + fileInfo.getAccessTime());
-      //add owner to filediff
-      fileDiff.getParameters().put("-owner", "" + fileInfo.getOwner());
-      fileDiff.getParameters().put("-group", "" + fileInfo.getGroup());
-      //add Permission to filediff
-      fileDiff.getParameters().put("-permission", "" + fileInfo.getPermission());
-      //add replication count to file diff
-      fileDiff.getParameters().put("-replication", "" + fileInfo.getBlockReplication());
-      metaStore.insertFileDiff(fileDiff);
-    }
-  }
-
-  private boolean inBackup(String src) throws MetaStoreException {
-    return metaStore.srcInBackup(src);
+    return getHdfsFileStatus(path)
+        .map(status -> HadoopUtil.convertFileStatus(status, path))
+        .orElseGet(() -> {
+          LOG.warn("Error getting file status for file {}", path);
+          return null;
+        });
   }
 
   //Todo: should update mtime? atime?
   private void applyClose(Event.CloseEvent closeEvent) throws MetaStoreException {
-    FileDiff fileDiff = new FileDiff(FileDiffType.APPEND);
-    fileDiff.setSrc(closeEvent.getPath());
-    long newLen = closeEvent.getFileSize();
-    long currLen;
-    // TODO make sure offset is correct
-    if (inBackup(closeEvent.getPath())) {
-      FileInfo fileInfo = metaStore.getFile(closeEvent.getPath());
-      if (fileInfo == null) {
-        // TODO add metadata
-        currLen = 0;
-      } else {
-        currLen = fileInfo.getLength();
-      }
-      if (currLen != newLen) {
-        fileDiff.getParameters().put("-offset", String.valueOf(currLen));
-        fileDiff.getParameters()
-            .put("-length", String.valueOf(newLen - currLen));
-        metaStore.insertFileDiff(fileDiff);
-      }
-    }
+    fileDiffGenerator.onFileClose(closeEvent)
+        .ifPresent(this::insertFileDiffUnchecked);
+
     FileInfoDiff fileInfoDiff = new FileInfoDiff()
         .setLength(closeEvent.getFileSize())
         .setModificationTime(closeEvent.getTimestamp());
     metaStore.updateFileByPath(closeEvent.getPath(), fileInfoDiff);
   }
 
-  private void applyRename(Event.RenameEvent renameEvent)
-      throws IOException, InterruptedException {
+  private void applyRename(Event.RenameEvent renameEvent) throws IOException {
     String src = renameEvent.getSrcPath();
     String dest = renameEvent.getDstPath();
 
+    // if the src is ignored, create new file with dest path
     if (pathChecker.isIgnored(src)) {
       applyRenameIgnoredFile(renameEvent);
       return;
     }
 
-    HdfsFileStatus destHdfsStatus = client.getFileInfo(dest);
-    FileInfo info = metaStore.getFile(src);
+    // if the dest is ignored, delete src info from file table
+    if (pathChecker.isIgnored(dest)) {
+      deleteFile(src);
+      return;
+    }
 
-    // For backup data to use.
-    generateFileDiff(renameEvent);
+    FileInfo srcFile = metaStore.getFile(src);
+    if (srcFile == null) {
+      LOG.error(
+          "Inconsistency in metastore and HDFS namespace, file not found: {}",
+          renameEvent.getSrcPath());
+      return;
+    }
+
+    List<FileDiff> fileDiffs = fileDiffGenerator.onFileRename(renameEvent, srcFile);
+    metaStore.insertFileDiffs(fileDiffs);
 
     // The dest path which the src is renamed to should be checked in file table
     // to avoid duplicated record for one same path.
@@ -258,198 +215,39 @@ public class InotifyEventApplier {
     if (destInfo != null) {
       metaStore.deleteFileByPath(dest, false);
     }
-    // src is not in file table because it is not fetched or other reason
-    if (info == null) {
-      // TODO get rid of repeating namespace fetching
-      // by achieving full consistency of metastore fs namespace
-      // by saving all files including ignored ones
-      if (destHdfsStatus != null) {
-        namespaceFetcher.startFetch(dest);
-        while (!namespaceFetcher.fetchFinished()) {
-          LOG.info("Fetching the files under " + dest);
-          Thread.sleep(100);
-        }
-        namespaceFetcher.stop();
-      }
-      return;
-    }
 
-    // if the dest is ignored, delete src info from file table
-    // TODO: tackle with file_state and small_state
-    if (pathChecker.isIgnored(dest)) {
-      // fuzzy matching is used to delete content under the dir
-      metaStore.deleteFileByPath(src, true);
-      return;
-    }
-
-    metaStore.renameFile(src, dest, info.isDir());
+    metaStore.renameFile(src, dest, srcFile.isDir());
+    maybeSetPolicies(srcFile, dest);
   }
 
-  private void generateFileDiff(Event.RenameEvent renameEvent) throws MetaStoreException {
-    boolean srcInBackup = inBackup(renameEvent.getSrcPath());
-    boolean destInBackup = inBackup(renameEvent.getDstPath());
+  private void applyMetadataUpdate(
+      Event.MetadataUpdateEvent metadataUpdateEvent) throws MetaStoreException {
+    fileDiffGenerator.onMetadataUpdate(metadataUpdateEvent)
+        .ifPresent(this::insertFileDiffUnchecked);
 
-    if (!srcInBackup && !destInBackup) {
-      return;
-    }
-
-    FileInfo srcFileInfo = metaStore.getFile(renameEvent.getSrcPath());
-    if (srcFileInfo == null) {
-      LOG.warn(
-          "Inconsistency in metastore and HDFS namespace, file not found: {}",
-          renameEvent.getSrcPath());
-      return;
-    }
-
-    List<FileDiff> fileDiffs;
-    if (srcInBackup) {
-      if (destInBackup) {
-        // if both src and dest are in backup directory,
-        // then generate rename diffs for all content under src
-        fileDiffs = visitFileRecursively(srcFileInfo, renameEvent, this::buildRenameFileDiff);
-      } else {
-        // if src is in backup directory and dest isn't,
-        // then simply delete all files under src on remote cluster
-        fileDiffs = Collections.singletonList(getDeleteFileDiff(srcFileInfo.getPath()));
-      }
-    } else {
-      // if dest is in backup directory and src isn't,
-      // then simply copy files under dest to remote cluster
-      fileDiffs = visitFileRecursively(srcFileInfo, renameEvent, this::buildCreateFileDiff);
-    }
-
-    if (fileDiffs.isEmpty()) {
-      LOG.warn(
-          "Inconsistency in metastore and HDFS namespace, file not found: {}",
-          renameEvent.getSrcPath());
-      return;
-    }
-    // set first diff as base rename operation
-    fileDiffs.get(0).setParameter(BASE_OPERATION, "");
-    metaStore.insertFileDiffs(fileDiffs);
-  }
-
-  private <C, T> List<T> visitFileRecursively(
-      FileInfo srcFileInfo, C context,
-      BiFunction<FileInfo, C, T> diffProducer)
-      throws MetaStoreException {
-    List<T> results = new ArrayList<>();
-    results.add(diffProducer.apply(srcFileInfo, context));
-
-    if (srcFileInfo.isDir()) {
-      metaStore.getFilesByPrefixInOrder(addPathSeparator(srcFileInfo.getPath()))
-          .stream()
-          .map(fileInfo -> diffProducer.apply(fileInfo, context))
-          .forEach(results::add);
-    }
-
-    return results;
-  }
-
-  private FileDiff buildRenameFileDiff(FileInfo fileInfo, Event.RenameEvent renameEvent) {
-    FileDiff fileDiff = new FileDiff(FileDiffType.RENAME);
-    fileDiff.setSrc(fileInfo.getPath());
-    fileDiff.getParameters().put(
-        SyncAction.DEST,
-        fileInfo.getPath().replaceFirst(
-            renameEvent.getSrcPath(),
-            renameEvent.getDstPath()));
-    return fileDiff;
-  }
-
-  private FileDiff buildCreateFileDiff(FileInfo fileInfo, Event.RenameEvent renameEvent) {
-    if (fileInfo.isDir()) {
-      FileDiff fileDiff = new FileDiff(FileDiffType.MKDIR);
-      fileDiff.setSrc(fileInfo.getPath());
-      return fileDiff;
-    }
-
-    FileDiff fileDiff = new FileDiff(FileDiffType.APPEND);
-    fileDiff.setSrc(fileInfo.getPath()
-        .replaceFirst(renameEvent.getSrcPath(), renameEvent.getDstPath()));
-    fileDiff.getParameters().put(
-        CopyFileAction.OFFSET_INDEX, String.valueOf(0));
-    fileDiff.getParameters()
-        .put(CopyFileAction.LENGTH, String.valueOf(fileInfo.getLength()));
-    return fileDiff;
-  }
-
-  private void applyMetadataUpdate(Event.MetadataUpdateEvent metadataUpdateEvent) throws MetaStoreException {
-
-    FileDiff fileDiff = null;
-    if (inBackup(metadataUpdateEvent.getPath())) {
-      fileDiff = new FileDiff(FileDiffType.METADATA);
-      fileDiff.setSrc(metadataUpdateEvent.getPath());
-    }
     FileInfoDiff fileInfoUpdate = new FileInfoDiff();
     switch (metadataUpdateEvent.getMetadataType()) {
       case TIMES:
         if (metadataUpdateEvent.getMtime() > 0) {
-          if (fileDiff != null) {
-            fileDiff.getParameters().put("-mtime", String.valueOf(metadataUpdateEvent.getMtime()));
-            // fileDiff.getParameters().put("-access_time", "" + metadataUpdateEvent.getAtime());
-            metaStore.insertFileDiff(fileDiff);
-          }
           fileInfoUpdate.setModificationTime(metadataUpdateEvent.getMtime());
         }
         if (metadataUpdateEvent.getAtime() > 0) {
-          // if (fileDiff != null) {
-          //   fileDiff.getParameters().put("-access_time", "" + metadataUpdateEvent.getAtime());
-          //   metaStore.insertFileDiff(fileDiff);
-          // }
           fileInfoUpdate.setAccessTime(metadataUpdateEvent.getAtime());
         }
         break;
       case OWNER:
-        if (fileDiff != null) {
-          fileDiff.getParameters().put("-owner", metadataUpdateEvent.getOwnerName());
-          metaStore.insertFileDiff(fileDiff);
-        }
         fileInfoUpdate.setOwner(metadataUpdateEvent.getOwnerName())
             .setGroup(metadataUpdateEvent.getGroupName());
         break;
       case PERMS:
-        if (fileDiff != null) {
-          fileDiff.getParameters().put("-permission", "" + metadataUpdateEvent.getPerms().toShort());
-          metaStore.insertFileDiff(fileDiff);
-        }
         fileInfoUpdate.setPermission(metadataUpdateEvent.getPerms().toShort());
         break;
       case REPLICATION:
-        if (fileDiff != null) {
-          fileDiff.getParameters().put("-replication", "" + metadataUpdateEvent.getReplication());
-          metaStore.insertFileDiff(fileDiff);
-        }
         fileInfoUpdate.setBlockReplication((short) metadataUpdateEvent.getReplication());
         break;
       case XATTRS:
-        final String EC_POLICY = "hdfs.erasurecoding.policy";
-        //Todo
-        if (LOG.isDebugEnabled()) {
-          String message = metadataUpdateEvent.getxAttrs()
-              .stream()
-              .map(XAttr::toString)
-              .collect(Collectors.joining("\n"));
-          LOG.debug(message);
-        }
-        // The following code should be executed merely on HDFS3.x.
-        for (XAttr xAttr : metadataUpdateEvent.getxAttrs()) {
-          if (xAttr.getName().equals(EC_POLICY)) {
-            try {
-              String ecPolicyName = WritableUtils.readString(
-                  new DataInputStream(new ByteArrayInputStream(xAttr.getValue())));
-              byte ecPolicyId = CompatibilityHelperLoader.getHelper().
-                  getErasureCodingPolicyByName(client, ecPolicyName);
-              if (ecPolicyId == (byte) -1) {
-                LOG.error("Unrecognized EC policy for updating!");
-              }
-              fileInfoUpdate.setErasureCodingPolicy(ecPolicyId);
-              break;
-            } catch (IOException ex) {
-              LOG.error("Error occurred for updating ecPolicy!", ex);
-            }
-          }
-        }
+        getErasureCodingPolicyId(metadataUpdateEvent.getxAttrs())
+            .ifPresent(fileInfoUpdate::setErasureCodingPolicy);
         break;
       case ACLS:
         return;
@@ -458,35 +256,108 @@ public class InotifyEventApplier {
   }
 
   private void applyUnlink(Event.UnlinkEvent unlinkEvent) throws MetaStoreException {
+    deleteFile(unlinkEvent.getPath());
+  }
+
+  private void deleteFile(String path) throws MetaStoreException {
+    fileDiffGenerator.onFileDelete(path)
+        .ifPresent(this::insertFileDiffUnchecked);
+
     // delete root, i.e., /
-    if (ROOT_DIRECTORY.equals(unlinkEvent.getPath())) {
+    if (ROOT_DIRECTORY.equals(path)) {
       LOG.warn("Deleting root directory!!!");
-      insertDeleteDiff(ROOT_DIRECTORY);
       metaStore.unlinkRootDirectory();
       return;
     }
 
-    String path = unlinkEvent.getPath();
     // file has no "/" appended in the metaStore
     FileInfo fileInfo = metaStore.getFile(path.endsWith("/") ?
         path.substring(0, path.length() - 1) : path);
 
     if (fileInfo != null) {
-      insertDeleteDiff(unlinkEvent.getPath());
-      metaStore.unlinkFile(unlinkEvent.getPath(), fileInfo.isDir());
+      metaStore.unlinkFile(path, fileInfo.isDir());
     }
   }
 
-  private void insertDeleteDiff(String path) throws MetaStoreException {
-    if (inBackup(path)) {
-      FileDiff deleteFileDiff = getDeleteFileDiff(path);
-      metaStore.insertFileDiff(deleteFileDiff);
+  private Optional<Byte> getErasureCodingPolicyId(List<XAttr> xAttrs) {
+    for (XAttr xAttr : xAttrs) {
+      if (!EC_POLICY_XATTR.equals(xAttr.getName())) {
+        continue;
+      }
+
+      try {
+        String ecPolicyName = WritableUtils.readString(
+            new DataInputStream(new ByteArrayInputStream(xAttr.getValue())));
+        byte ecPolicyId = CompatibilityHelperLoader.getHelper().
+            getErasureCodingPolicyByName(client, ecPolicyName);
+        if (ecPolicyId == (byte) -1) {
+          LOG.error("Unrecognized EC policy for updating: {}", ecPolicyId);
+        }
+        return Optional.of(ecPolicyId);
+      } catch (IOException ex) {
+        LOG.error("Error occurred for updating ecPolicy!", ex);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+
+  /** @see InotifyEventApplier#fileBuilderWithPolicies */
+  private void maybeSetPolicies(FileInfo oldFile, String newPath) throws IOException {
+    if (oldFile.getErasureCodingPolicy() != DEFAULT_EC_POLICY_ID
+        || oldFile.getStoragePolicy() != DEFAULT_STORAGE_POLICY_ID) {
+      // we don't need to update anything in case if policies were
+      // already applied during create event handling
+      return;
+    }
+
+    Optional<HdfsFileStatus> fileStatus = getHdfsFileStatus(newPath);
+    if (!fileStatus.isPresent()) {
+      LOG.warn("Error getting status for {} after rename", newPath);
+      return;
+    }
+
+    FileInfoDiff fileInfoDiff = new FileInfoDiff()
+        .setStoragePolicy(fileStatus.get().getStoragePolicy())
+        .setErasureCodingPolicy(CompatibilityHelperLoader.getHelper()
+            .getErasureCodingPolicy(fileStatus.get()));
+    metaStore.updateFileByPath(newPath, fileInfoDiff);
+  }
+
+  /**
+   * Try to enrich FileInfo builder with EC and storage policies
+   * information from HDFS. In case if no information is found in HDFS for
+   * specified file, fallback to default policies.
+   *
+   * HDFS client will return null information about file in 2 cases:
+   * it was either deleted or renamed. In first case, there will be no issue,
+   * if we use fallback policies, because SSM will eventually remove file from its
+   * namespace copy, when the delete event arrive.
+   * In case of rename we will try to fetch policies info from HDFS again
+   * for the new name in the {@link InotifyEventApplier#maybeSetPolicies}.
+   * In case of failure in this method too, it only means, that file was deleted after rename.
+   */
+  private FileInfo.Builder fileBuilderWithPolicies(String path) {
+    try {
+      return getHdfsFileStatus(path)
+          .map(status -> FileInfo.builder()
+              .setStoragePolicy(status.getStoragePolicy())
+              .setErasureCodingPolicy(
+                  CompatibilityHelperLoader.getHelper().getErasureCodingPolicy(status)))
+          .orElseGet(() -> {
+            LOG.warn("Can't enrich info about new file: {} not found", path);
+            return defaultFileBuilder();
+          });
+    } catch (IOException e) {
+      LOG.warn("Can't enrich info about new file: {}", path, e);
+      return defaultFileBuilder();
     }
   }
 
-  private FileDiff getDeleteFileDiff(String path) {
-    FileDiff fileDiff = new FileDiff(FileDiffType.DELETE);
-    fileDiff.setSrc(path);
-    return fileDiff;
+  private FileInfo.Builder defaultFileBuilder() {
+    return FileInfo.builder()
+        .setStoragePolicy(DEFAULT_STORAGE_POLICY_ID)
+        .setErasureCodingPolicy(DEFAULT_EC_POLICY_ID);
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyFetchAndApplyTask.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/InotifyFetchAndApplyTask.java
@@ -29,7 +29,7 @@ import org.smartdata.metastore.MetaStore;
 import org.smartdata.model.SystemInfo;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class InotifyFetchAndApplyTask implements Runnable {
@@ -42,8 +42,7 @@ public class InotifyFetchAndApplyTask implements Runnable {
   private final INotifyEventFilter eventFilter;
 
   public InotifyFetchAndApplyTask(DFSClient client, MetaStore metaStore,
-                                  InotifyEventApplier applier, long startId, SmartConf conf)
-      throws IOException {
+      InotifyEventApplier applier, long startId, SmartConf conf) throws IOException {
     this.applier = applier;
     this.metaStore = metaStore;
     this.lastId = new AtomicLong(startId);
@@ -53,7 +52,7 @@ public class InotifyFetchAndApplyTask implements Runnable {
 
   @Override
   public void run() {
-    LOG.trace("InotifyFetchAndApplyTask run at " +  new Date());
+    LOG.debug("InotifyFetchAndApplyTask run at {}", LocalDateTime.now());
     try {
       EventBatch eventBatch = inotifyEventInputStream.poll();
       while (eventBatch != null) {
@@ -71,9 +70,5 @@ public class InotifyFetchAndApplyTask implements Runnable {
     } catch (Throwable t) {
       LOG.error("Inotify Apply Events error", t);
     }
-  }
-
-  public long getLastId() {
-    return this.lastId.get();
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/metric/fetcher/NamespaceFetcher.java
@@ -138,27 +138,6 @@ public class NamespaceFetcher {
     IngestionTask.init(dir);
   }
 
-  /*
-  startFetch(dir) is used to restart fetcher to fetch one specific dir.
-  In rename event, when src is not in file table because it is not fetched or other reason,
-  dest should be fetched by using startFetch(dest).
-  */
-  public void startFetch(String dir) {
-    init(dir);
-    this.fetchTaskFutures = new ScheduledFuture[ingestionTasks.length];
-    for (int i = 0; i < ingestionTasks.length; i++) {
-      fetchTaskFutures[i] = this.scheduledExecutorService.scheduleAtFixedRate(
-          ingestionTasks[i], 0, fetchInterval, TimeUnit.MILLISECONDS);
-    }
-
-    this.consumerFutures = new ScheduledFuture[consumers.length];
-    for (int i = 0; i < consumers.length; i++) {
-      consumerFutures[i] = this.scheduledExecutorService.scheduleAtFixedRate(
-          consumers[i], 0, fetchInterval, TimeUnit.MILLISECONDS);
-    }
-    LOG.info("Start fetch the given dir.");
-  }
-
   public boolean fetchFinished() {
     return IngestionTask.finished();
   }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestCachedListFetcher.java
@@ -140,7 +140,7 @@ public class TestCachedListFetcher extends TestDaoBase {
       // System.out.println(cacheAction.isCached(path));
     }
     metaStore.insertFiles(fileInfos
-        .toArray(new FileInfo[fileInfos.size()]));
+        .toArray(new FileInfo[fileInfos.size()]), false);
     List<FileInfo> ret = metaStore.getFile();
     Assert.assertTrue(ret.size() == fids.length);
     cachedListFetcher.start();

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestFileDiffGenerator.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestFileDiffGenerator.java
@@ -1,0 +1,483 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.metric.fetcher;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.inotify.Event;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.smartdata.hdfs.action.CopyFileAction;
+import org.smartdata.metastore.MetaStoreException;
+import org.smartdata.metastore.TestDaoBase;
+import org.smartdata.model.BackUpInfo;
+import org.smartdata.model.FileDiff;
+import org.smartdata.model.FileDiffState;
+import org.smartdata.model.FileDiffType;
+import org.smartdata.model.FileInfo;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.apache.hadoop.hdfs.inotify.Event.MetadataUpdateEvent.MetadataType.OWNER;
+import static org.apache.hadoop.hdfs.inotify.Event.MetadataUpdateEvent.MetadataType.PERMS;
+import static org.apache.hadoop.hdfs.inotify.Event.MetadataUpdateEvent.MetadataType.REPLICATION;
+import static org.apache.hadoop.hdfs.inotify.Event.MetadataUpdateEvent.MetadataType.TIMES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.smartdata.action.SyncAction.BASE_OPERATION;
+import static org.smartdata.action.SyncAction.DEST;
+import static org.smartdata.hdfs.action.MetaDataAction.BLOCK_REPLICATION;
+import static org.smartdata.hdfs.action.MetaDataAction.GROUP_NAME;
+import static org.smartdata.hdfs.action.MetaDataAction.MTIME;
+import static org.smartdata.hdfs.action.MetaDataAction.OWNER_NAME;
+import static org.smartdata.hdfs.action.MetaDataAction.PERMISSION;
+
+public class TestFileDiffGenerator extends TestDaoBase {
+
+  private FileDiffGenerator fileDiffGenerator;
+
+  @Before
+  public void init() throws Exception {
+    fileDiffGenerator = new FileDiffGenerator(metaStore, () -> 0L);
+
+    BackUpInfo backUpInfo = new BackUpInfo(-1, "/backup/src", "/dest", 1000L);
+    metaStore.insertBackUpInfo(backUpInfo);
+  }
+
+  @Test
+  public void testCreateFile() throws Exception {
+    FileInfo file = FileInfo.builder()
+        .setPath("/backup/src/file")
+        .setLength(42)
+        .build();
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileCreate(file);
+
+    Map<String, String> expectedParameters = ImmutableMap.of(
+        CopyFileAction.OFFSET_INDEX, "0",
+        CopyFileAction.LENGTH, "42"
+    );
+
+    FileDiff expectedFileDiff = fileDiffBuilder("/backup/src/file")
+        .diffType(FileDiffType.APPEND)
+        .parameters(expectedParameters)
+        .build();
+
+    assertTrue(fileDiff.isPresent());
+    assertEquals(expectedFileDiff, fileDiff.get());
+  }
+
+  @Test
+  public void testCreateDirectory() throws Exception {
+    FileInfo file = FileInfo.builder()
+        .setPath("/backup/src/1/dir")
+        .setIsDir(true)
+        .build();
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileCreate(file);
+    FileDiff expectedFileDiff = fileDiffBuilder("/backup/src/1/dir")
+        .diffType(FileDiffType.MKDIR)
+        .build();
+
+    assertTrue(fileDiff.isPresent());
+    assertEquals(expectedFileDiff, fileDiff.get());
+  }
+
+  @Test
+  public void testSkipCreateEventIfNotInBackupDir() throws Exception {
+    FileInfo file = FileInfo.builder()
+        .setPath("/another/src/1")
+        .build();
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileCreate(file);
+    assertFalse(fileDiff.isPresent());
+  }
+
+  @Test
+  public void testCloseNewFile() throws Exception {
+    Event.CloseEvent closeEvent =
+        new Event.CloseEvent("/backup/src/file", 100, 1L);
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileClose(closeEvent);
+
+    Map<String, String> expectedParameters = ImmutableMap.of(
+        CopyFileAction.OFFSET_INDEX, "0",
+        CopyFileAction.LENGTH, "100"
+    );
+    FileDiff expectedFileDiff = fileDiffBuilder("/backup/src/file")
+        .diffType(FileDiffType.APPEND)
+        .parameters(expectedParameters)
+        .build();
+
+    assertTrue(fileDiff.isPresent());
+    assertEquals(expectedFileDiff, fileDiff.get());
+  }
+
+  @Test
+  public void testCloseExistingFile() throws Exception {
+    Event.CloseEvent closeEvent =
+        new Event.CloseEvent("/backup/src/file", 100, 1L);
+
+    FileInfo fileInfo = FileInfo.builder()
+        .setPath("/backup/src/file")
+        .setLength(20)
+        .build();
+    metaStore.insertFile(fileInfo, true);
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileClose(closeEvent);
+
+    Map<String, String> expectedParameters = ImmutableMap.of(
+        CopyFileAction.OFFSET_INDEX, "20",
+        CopyFileAction.LENGTH, "80"
+    );
+    FileDiff expectedFileDiff = fileDiffBuilder("/backup/src/file")
+        .diffType(FileDiffType.APPEND)
+        .parameters(expectedParameters)
+        .build();
+
+    assertTrue(fileDiff.isPresent());
+    assertEquals(expectedFileDiff, fileDiff.get());
+  }
+
+  @Test
+  public void testSkipCloseEventIfEqualFileLength() throws Exception {
+    Event.CloseEvent closeEvent =
+        new Event.CloseEvent("/backup/src/file", 20, 1L);
+
+    FileInfo fileInfo = FileInfo.builder()
+        .setPath("/backup/src/file")
+        .setLength(20)
+        .build();
+    metaStore.insertFile(fileInfo, true);
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileClose(closeEvent);
+    assertFalse(fileDiff.isPresent());
+  }
+
+  @Test
+  public void testSkipCloseEventIfNotInBackupDir() throws Exception {
+    Event.CloseEvent closeEvent =
+        new Event.CloseEvent("/another/src/file", 20, 1L);
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileClose(closeEvent);
+    assertFalse(fileDiff.isPresent());
+  }
+
+  @Test
+  public void testDeleteFile() throws Exception {
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileDelete("/backup/src/file");
+
+    FileDiff expectedFileDiff = fileDiffBuilder("/backup/src/file")
+        .diffType(FileDiffType.DELETE)
+        .build();
+
+    assertTrue(fileDiff.isPresent());
+    assertEquals(expectedFileDiff, fileDiff.get());
+  }
+
+  @Test
+  public void testSkipDeleteEventIfNotInBackupDir() throws Exception {
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onFileDelete("/dir/file");
+    assertFalse(fileDiff.isPresent());
+  }
+
+  @Test
+  public void testChangeFileTimes() throws Exception {
+    Event.MetadataUpdateEvent metadataUpdateEvent = updateMetadataEvent(TIMES);
+
+    Map<String, String> expectedParameters = ImmutableMap.of(
+        MTIME, "1"
+    );
+
+    testChangeFileMetadata(metadataUpdateEvent, expectedParameters);
+  }
+
+  @Test
+  public void testChangeFileReplication() throws Exception {
+    Event.MetadataUpdateEvent metadataUpdateEvent = updateMetadataEvent(REPLICATION);
+
+    Map<String, String> expectedParameters = ImmutableMap.of(
+        BLOCK_REPLICATION, "42"
+    );
+
+    testChangeFileMetadata(metadataUpdateEvent, expectedParameters);
+  }
+
+  @Test
+  public void testChangeFileOwnerGroup() throws Exception {
+    Event.MetadataUpdateEvent metadataUpdateEvent = updateMetadataEvent(OWNER);
+
+    Map<String, String> expectedParameters = ImmutableMap.of(
+        OWNER_NAME, "newOwner",
+        GROUP_NAME, "newGroup"
+    );
+
+    testChangeFileMetadata(metadataUpdateEvent, expectedParameters);
+  }
+
+  @Test
+  public void testChangeFilePermissions() throws Exception {
+    Event.MetadataUpdateEvent metadataUpdateEvent = updateMetadataEvent(PERMS);
+
+    Map<String, String> expectedParameters = ImmutableMap.of(
+        PERMISSION, "777"
+    );
+
+    testChangeFileMetadata(metadataUpdateEvent, expectedParameters);
+  }
+
+  @Test
+  public void testSkipUpdateMetadataEventIfNotInBackupDir() throws Exception {
+    Event.MetadataUpdateEvent event = new Event.MetadataUpdateEvent.Builder()
+        .metadataType(OWNER)
+        .path("/test")
+        .build();
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onMetadataUpdate(event);
+    assertFalse(fileDiff.isPresent());
+  }
+
+  @Test
+  public void testRenameDir() throws Exception {
+    createFilesForRename();
+
+    Event.RenameEvent renameEvent = new Event.RenameEvent.Builder()
+        .srcPath("/backup/src/dir")
+        .dstPath("/backup/src/second_dir")
+        .build();
+
+    List<FileDiff> fileDiffs = fileDiffGenerator.onFileRename(
+        renameEvent, metaStore.getFile(renameEvent.getSrcPath()));
+
+    List<FileDiff> expectedFileDiffs = Arrays.asList(
+        fileDiffBuilder("/backup/src/dir")
+            .diffType(FileDiffType.RENAME)
+            .parameters(ImmutableMap.of(
+                DEST, "/backup/src/second_dir",
+                BASE_OPERATION, ""
+            ))
+            .build(),
+        fileDiffBuilder("/backup/src/dir/1")
+            .diffType(FileDiffType.RENAME)
+            .parameters(ImmutableMap.of(DEST, "/backup/src/second_dir/1"))
+            .build(),
+        fileDiffBuilder("/backup/src/dir/2")
+            .diffType(FileDiffType.RENAME)
+            .parameters(ImmutableMap.of(DEST, "/backup/src/second_dir/2"))
+            .build()
+    );
+
+    assertEquals(expectedFileDiffs, fileDiffs);
+  }
+
+  @Test
+  public void testRenameFile() throws Exception {
+    createFilesForRename();
+
+    Event.RenameEvent renameEvent = new Event.RenameEvent.Builder()
+        .srcPath("/backup/src/3")
+        .dstPath("/backup/src/4")
+        .build();
+
+    List<FileDiff> fileDiffs = fileDiffGenerator.onFileRename(
+        renameEvent, metaStore.getFile(renameEvent.getSrcPath()));
+
+    List<FileDiff> expectedFileDiffs = Collections.singletonList(
+        fileDiffBuilder("/backup/src/3")
+            .diffType(FileDiffType.RENAME)
+            .parameters(ImmutableMap.of(
+                DEST, "/backup/src/4",
+                BASE_OPERATION, ""
+            ))
+            .build()
+    );
+
+    assertEquals(expectedFileDiffs, fileDiffs);
+  }
+
+  @Test
+  public void testRenameFileDestNotInBackup() throws Exception {
+    createFilesForRename();
+
+    Event.RenameEvent renameEvent = new Event.RenameEvent.Builder()
+        .srcPath("/backup/src/dir")
+        .dstPath("/somewhere")
+        .build();
+
+    List<FileDiff> fileDiffs = fileDiffGenerator.onFileRename(
+        renameEvent, metaStore.getFile(renameEvent.getSrcPath()));
+
+    List<FileDiff> expectedFileDiffs = Collections.singletonList(
+        fileDiffBuilder("/backup/src/dir")
+            .diffType(FileDiffType.DELETE)
+            .parameters(ImmutableMap.of(BASE_OPERATION, ""))
+            .build()
+    );
+
+    assertEquals(expectedFileDiffs, fileDiffs);
+  }
+
+  @Test
+  public void testRenameSrcDirNotInBackup() throws Exception {
+    createFilesForRename();
+
+    Event.RenameEvent renameEvent = new Event.RenameEvent.Builder()
+        .srcPath("/another_dir/dir")
+        .dstPath("/backup/src/renamed")
+        .build();
+
+    List<FileDiff> fileDiffs = fileDiffGenerator.onFileRename(
+        renameEvent, metaStore.getFile(renameEvent.getSrcPath()));
+
+    Map<String, String> appendParameters = ImmutableMap.of(
+        CopyFileAction.OFFSET_INDEX, "0",
+        CopyFileAction.LENGTH, "128"
+    );
+
+    List<FileDiff> expectedFileDiffs = Arrays.asList(
+        fileDiffBuilder("/backup/src/renamed")
+            .diffType(FileDiffType.MKDIR)
+            .parameters(ImmutableMap.of(BASE_OPERATION, ""))
+            .build(),
+        fileDiffBuilder("/backup/src/renamed/4")
+            .diffType(FileDiffType.APPEND)
+            .parameters(appendParameters)
+            .build(),
+        fileDiffBuilder("/backup/src/renamed/5")
+            .diffType(FileDiffType.APPEND)
+            .parameters(appendParameters)
+            .build()
+    );
+
+    assertEquals(expectedFileDiffs, fileDiffs);
+  }
+
+  @Test
+  public void testRenameSrcFileNotInBackup() throws Exception {
+    createFilesForRename();
+
+    Event.RenameEvent renameEvent = new Event.RenameEvent.Builder()
+        .srcPath("/another_dir/file")
+        .dstPath("/backup/src/file")
+        .build();
+
+    List<FileDiff> fileDiffs = fileDiffGenerator.onFileRename(
+        renameEvent, metaStore.getFile(renameEvent.getSrcPath()));
+
+    List<FileDiff> expectedFileDiffs = Collections.singletonList(
+        fileDiffBuilder("/backup/src/file")
+            .diffType(FileDiffType.APPEND)
+            .parameters(ImmutableMap.of(
+                BASE_OPERATION, "",
+                CopyFileAction.OFFSET_INDEX, "0",
+                CopyFileAction.LENGTH, "128"
+            ))
+            .build()
+    );
+
+    assertEquals(expectedFileDiffs, fileDiffs);
+  }
+
+
+  @Test
+  public void testSkipRenameEventIfNotInBackupDir() throws Exception {
+    Event.RenameEvent renameEvent = new Event.RenameEvent.Builder()
+        .srcPath("/another_dir/file")
+        .dstPath("/another_dir/another_file")
+        .build();
+
+    List<FileDiff> fileDiffs = fileDiffGenerator.onFileRename(
+        renameEvent, metaStore.getFile(renameEvent.getSrcPath()));
+    assertTrue(fileDiffs.isEmpty());
+  }
+
+  private void createFilesForRename() {
+    Stream.of(
+        "/backup",
+        "/backup/src",
+        "/backup/src/dir",
+        "/another_dir",
+        "/another_dir/dir"
+    ).forEach(path -> createFile(path, true));
+
+    Stream.of(
+        "/backup/src/dir/1",
+        "/backup/src/dir/2",
+        "/backup/src/3",
+        "/another_dir/dir/4",
+        "/another_dir/dir/5",
+        "/another_dir/file"
+    ).forEach(path -> createFile(path, false));
+  }
+
+  private void createFile(String path, boolean isDir) {
+    FileInfo fileInfo = FileInfo.builder()
+        .setPath(path)
+        .setIsDir(isDir)
+        .setLength(128)
+        .build();
+    try {
+      metaStore.insertFile(fileInfo, true);
+    } catch (MetaStoreException e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  private void testChangeFileMetadata(
+      Event.MetadataUpdateEvent event, Map<String, String> expectedParameters) throws MetaStoreException {
+    FileDiff expectedFileDiff = fileDiffBuilder("/backup/src/2/file")
+        .diffType(FileDiffType.METADATA)
+        .parameters(expectedParameters)
+        .build();
+
+    Optional<FileDiff> fileDiff = fileDiffGenerator.onMetadataUpdate(event);
+
+    assertTrue(fileDiff.isPresent());
+    assertEquals(expectedFileDiff, fileDiff.get());
+  }
+
+  private Event.MetadataUpdateEvent updateMetadataEvent(
+      Event.MetadataUpdateEvent.MetadataType metadataType) {
+    return new Event.MetadataUpdateEvent.Builder()
+        .metadataType(metadataType)
+        .path("/backup/src/2/file")
+        .ownerName("newOwner")
+        .groupName("newGroup")
+        .mtime(1)
+        .atime(2)
+        .replication(42)
+        .perms(new FsPermission(777))
+        .build();
+  }
+
+  private FileDiff.Builder fileDiffBuilder(String src) {
+    return FileDiff.builder()
+        .src(src)
+        .state(FileDiffState.PENDING)
+        .createTime(0L)
+        .parameters(new HashMap<>());
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestInotifyFetcher.java
@@ -56,7 +56,7 @@ public class TestInotifyFetcher extends TestDaoBase {
     private final List<Event> events = new ArrayList<>();
 
     public EventApplierForTest(MetaStore metaStore, DFSClient client) {
-      super(metaStore, client);
+      super(new SmartConf(), metaStore, client);
     }
 
     @Override

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestNamespaceFetcher.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/metric/fetcher/TestNamespaceFetcher.java
@@ -74,7 +74,7 @@ public class TestNamespaceFetcher {
           }
           return null;
         }
-      }).when(adapter).insertFiles(any(FileInfo[].class));
+      }).when(adapter).insertFiles(any(FileInfo[].class), anyBoolean());
 
       SmartConf nonNullConfig = Optional.ofNullable(conf)
           .orElseGet(SmartConf::new);
@@ -94,28 +94,6 @@ public class TestNamespaceFetcher {
       NamespaceFetcher fetcher = init(cluster, null);
       fetcher.startFetch();
       Set<String> expected = Sets.newHashSet("/", "/user", "/user/user1", "/user/user2", "/tmp");
-      while (!fetcher.fetchFinished()) {
-        Thread.sleep(100);
-      }
-      Assert.assertEquals(expected, pathesInDB);
-      fetcher.stop();
-    } finally {
-      cluster.shutdown();
-    }
-  }
-
-  @Test
-  public void testFetchingFromGivenDir() throws IOException, InterruptedException,
-      MetaStoreException {
-    pathesInDB.clear();
-    final Configuration conf = new SmartConf();
-    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
-        .numDataNodes(2).build();
-    String fetchDir = "/user";
-    try {
-      NamespaceFetcher fetcher = init(cluster, null);
-      fetcher.startFetch(fetchDir);
-      Set<String> expected = Sets.newHashSet("/user", "/user/user1", "/user/user2");
       while (!fetcher.fetchFinished()) {
         Thread.sleep(100);
       }

--- a/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/MetaStore.java
@@ -218,20 +218,20 @@ public class MetaStore implements CopyMetaService,
   /**
    * Store a single file info into database.
    */
-  public void insertFile(FileInfo file)
+  public void insertFile(FileInfo file, boolean generateId)
       throws MetaStoreException {
     updateCache();
-    fileInfoDao.insert(file);
+    fileInfoDao.insert(file, generateId);
   }
 
 
   /**
    * Store files info into database.
    */
-  public void insertFiles(FileInfo[] files)
+  public void insertFiles(FileInfo[] files, boolean generateIds)
       throws MetaStoreException {
     updateCache();
-    fileInfoDao.insert(files);
+    fileInfoDao.insert(files, generateIds);
   }
 
   public void updateFileByPath(String path, FileInfoDiff fileUpdate) {

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/FileInfoDao.java
@@ -43,9 +43,9 @@ public interface FileInfoDao {
   Map<String, Long> getPathFids(Collection<String> paths)
       throws SQLException;
 
-  void insert(FileInfo fileInfo);
+  void insert(FileInfo fileInfo, boolean generateId);
 
-  void insert(FileInfo[] fileInfos);
+  void insert(FileInfo[] fileInfos, boolean generateIds);
 
   int update(String path, int storagePolicy);
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/impl/DefaultFileInfoDao.java
@@ -24,11 +24,13 @@ import org.smartdata.model.FileInfoDiff;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
 import javax.sql.DataSource;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -101,13 +103,21 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
   }
 
   @Override
-  public void insert(FileInfo fileInfo) {
-    insert(fileInfo, this::toMap);
+  public void insert(FileInfo fileInfo, boolean generateId) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    if (generateId) {
+      simpleJdbcInsert.usingGeneratedKeyColumns("fid");
+    }
+    simpleJdbcInsert.execute(toMap(fileInfo));
   }
 
   @Override
-  public void insert(FileInfo[] fileInfos) {
-    insert(fileInfos, this::toMap);
+  public void insert(FileInfo[] fileInfos, boolean generateId) {
+    SimpleJdbcInsert simpleJdbcInsert = simpleJdbcInsert();
+    if (generateId) {
+      simpleJdbcInsert.usingGeneratedKeyColumns("fid");
+    }
+    insert(simpleJdbcInsert, Arrays.asList(fileInfos), this::toMap);
   }
 
   @Override
@@ -128,7 +138,7 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
   }
 
   @Override
-  public void deleteByPath(String path,  boolean recursive) {
+  public void deleteByPath(String path, boolean recursive) {
     String sql = "DELETE FROM file WHERE path = ?";
     jdbcTemplate.update(sql, path);
     if (recursive) {
@@ -171,6 +181,7 @@ public class DefaultFileInfoDao extends AbstractDao implements FileInfoDao {
         .put("owner_group", fileInfo.getGroup());
     parameters.put("permission", fileInfo.getPermission());
     parameters.put("ec_policy_id", fileInfo.getErasureCodingPolicy());
+    parameters.put("sid", fileInfo.getStoragePolicy());
     return parameters;
   }
 

--- a/smart-metastore/src/main/java/org/smartdata/metastore/ingestion/FileStatusIngester.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/ingestion/FileStatusIngester.java
@@ -45,12 +45,12 @@ public class FileStatusIngester implements Runnable {
       if (batch != null) {
         FileInfo[] statuses = batch.getFileInfos();
         if (statuses.length == batch.actualSize()) {
-          this.dbAdapter.insertFiles(batch.getFileInfos());
+          this.dbAdapter.insertFiles(batch.getFileInfos(), true);
           IngestionTask.numPersisted.addAndGet(statuses.length);
         } else {
           FileInfo[] actual = new FileInfo[batch.actualSize()];
           System.arraycopy(statuses, 0, actual, 0, batch.actualSize());
-          this.dbAdapter.insertFiles(actual);
+          this.dbAdapter.insertFiles(actual, true);
           IngestionTask.numPersisted.addAndGet(actual.length);
         }
 

--- a/smart-metastore/src/main/resources/db/changelog/changelog-6.make-fileId-autoincrement.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-6.make-fileId-autoincrement.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="2024.11.19_001" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="file"/>
+        </preConditions>
+        <addAutoIncrement
+                tableName="file"
+                columnName="fid"
+                columnDataType="BIGINT"/>
+    </changeSet>
+
+    <changeSet id="2024.11.19_002" author="tmanasyan" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="file"/>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/set_file_id_sequence_start_value.sql"/>
+    </changeSet>
+</databaseChangeLog>

--- a/smart-metastore/src/main/resources/db/changelog/changelog-root.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-root.xml
@@ -13,4 +13,5 @@
     <include file="db/changelog/changelog-3.create-user-activities-table.xml"/>
     <include file="/db/changelog/changelog-4.add-action-search-fields.xml"/>
     <include file="/db/changelog/changelog-5.add-partitioning.xml"/>
+    <include file="/db/changelog/changelog-6.make-fileId-autoincrement.xml"/>
 </databaseChangeLog>

--- a/smart-metastore/src/main/resources/db/changelog/sql/set_file_id_sequence_start_value.sql
+++ b/smart-metastore/src/main/resources/db/changelog/sql/set_file_id_sequence_start_value.sql
@@ -1,0 +1,3 @@
+SELECT setval(pg_get_serial_sequence('file', 'fid'),
+              COALESCE(MAX(fid), 0) + 1, false)
+FROM file;

--- a/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/TestMetaStore.java
@@ -173,7 +173,7 @@ public class TestMetaStore extends TestDaoBase {
             group,
             storagePolicy,
             erasureCodingPolicy);
-    metaStore.insertFile(fileInfo);
+    metaStore.insertFile(fileInfo, false);
     FileInfo dbFileInfo = metaStore.getFile(56);
     Assert.assertEquals(fileInfo, dbFileInfo);
     dbFileInfo = metaStore.getFile("/tmp/des");
@@ -331,7 +331,7 @@ public class TestMetaStore extends TestDaoBase {
             storagePolicy,
             erasureCodingPolicy)
     };
-    metaStore.insertFiles(files);
+    metaStore.insertFiles(files, false);
     FileInfo dbFileInfo = metaStore.getFile("/tmp/testFile");
     Assert.assertEquals(files[0], dbFileInfo);
   }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileInfoDao.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/TestFileInfoDao.java
@@ -23,9 +23,7 @@ import org.junit.Test;
 import org.smartdata.metastore.TestDaoBase;
 import org.smartdata.model.FileInfo;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class TestFileInfoDao extends TestDaoBase {
   private FileInfoDao fileInfoDao;
@@ -36,7 +34,7 @@ public class TestFileInfoDao extends TestDaoBase {
   }
 
   @Test
-  public void testInsetGetDeleteFiles() throws Exception {
+  public void testInsetGetDeleteFiles() {
     String path = "/testFile";
     long length = 123L;
     boolean isDir = false;
@@ -47,33 +45,39 @@ public class TestFileInfoDao extends TestDaoBase {
     short permission = 1;
     String owner = "root";
     String group = "admin";
-    long fileId = 312321L;
+    long fileId = 1L;
     byte storagePolicy = 0;
     byte erasureCodingPolicy = 0;
     FileInfo fileInfo = new FileInfo(path, fileId, length, isDir, blockReplication, blockSize,
         modTime, accessTime, permission, owner, group, storagePolicy, erasureCodingPolicy);
-    fileInfoDao.insert(fileInfo);
+    fileInfoDao.insert(fileInfo, true);
+
     FileInfo file1 = fileInfoDao.getByPath("/testFile");
-    Assert.assertTrue(fileInfo.equals(file1));
+    Assert.assertEquals(fileInfo, file1);
+
     FileInfo file2 = fileInfoDao.getById(fileId);
-    Assert.assertTrue(fileInfo.equals(file2));
+    Assert.assertEquals(fileInfo, file2);
+
     FileInfo fileInfo1 = new FileInfo(path, fileId + 1, length, isDir, blockReplication, blockSize,
         modTime, accessTime, permission, owner, group, storagePolicy, erasureCodingPolicy);
-    fileInfoDao.insert(fileInfo1);
+    fileInfoDao.insert(fileInfo1, true);
     List<FileInfo> fileInfos = fileInfoDao.getFilesByPrefix("/testaaFile");
-    Assert.assertTrue(fileInfos.size() == 0);
+    Assert.assertEquals(0, fileInfos.size());
+
     fileInfos = fileInfoDao.getFilesByPrefix("/testFile");
-    Assert.assertTrue(fileInfos.size() == 2);
+    Assert.assertEquals(2, fileInfos.size());
+
     fileInfoDao.deleteById(fileId);
     fileInfos = fileInfoDao.getAll();
-    Assert.assertTrue(fileInfos.size() == 1);
+    Assert.assertEquals(1, fileInfos.size());
+
     fileInfoDao.deleteAll();
     fileInfos = fileInfoDao.getAll();
-    Assert.assertTrue(fileInfos.size() == 0);
+    Assert.assertTrue(fileInfos.isEmpty());
   }
 
   @Test
-  public void testInsertUpdateFiles() throws Exception {
+  public void testInsertUpdateFiles() {
     String path = "/testFile";
     long length = 123L;
     boolean isDir = false;
@@ -84,19 +88,17 @@ public class TestFileInfoDao extends TestDaoBase {
     short permission = 1;
     String owner = "root";
     String group = "admin";
-    long fileId = 312321L;
+    long fileId = 1L;
     byte storagePolicy = 0;
     byte erasureCodingPolicy = 0;
-    Map<Integer, String> mapOwnerIdName = new HashMap<>();
-    mapOwnerIdName.put(1, "root");
-    Map<Integer, String> mapGroupIdName = new HashMap<>();
-    mapGroupIdName.put(1, "admin");
+
     FileInfo fileInfo = new FileInfo(path, fileId, length, isDir, blockReplication, blockSize,
         modTime, accessTime, permission, owner, group, storagePolicy, erasureCodingPolicy);
-    fileInfoDao.insert(fileInfo);
+    fileInfoDao.insert(fileInfo, true);
     fileInfoDao.update(path, 10);
     FileInfo file = fileInfoDao.getById(fileId);
     fileInfo.setStoragePolicy((byte) 10);
-    Assert.assertTrue(file.equals(fileInfo));
+
+    Assert.assertEquals(file, fileInfo);
   }
 }

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/accesscount/TestAccessEventAggregator.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/accesscount/TestAccessEventAggregator.java
@@ -61,7 +61,7 @@ public class TestAccessEventAggregator extends TestDaoBase {
     aggregator =
         new DbAccessEventAggregator(metaStore.fileInfoDao(),
             dbTableManager, new Failover<AccessCountContext>(){});
-    metaStore.fileInfoDao().insert(testFileInfos());
+    metaStore.fileInfoDao().insert(testFileInfos(), false);
   }
 
   @Test

--- a/smart-metastore/src/test/java/org/smartdata/metastore/dao/accesscount/TestFileAccessManager.java
+++ b/smart-metastore/src/test/java/org/smartdata/metastore/dao/accesscount/TestFileAccessManager.java
@@ -156,6 +156,6 @@ public class TestFileAccessManager extends
             .build())
         .toArray(FileInfo[]::new);
 
-    metaStore.insertFiles(fileInfos);
+    metaStore.insertFiles(fileInfos, false);
   }
 }

--- a/smart-server/src/test/java/org/smartdata/server/engine/rule/TestRuleManager.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/rule/TestRuleManager.java
@@ -300,7 +300,7 @@ public class TestRuleManager extends TestDaoBase {
     FileInfo[] files = {new FileInfo("/tmp/testfile", fid, length, false, (short) 3,
         1024, now, now, (short) 1, null, null, (byte) 3, (byte) 0)};
 
-    metaStore.insertFiles(files);
+    metaStore.insertFiles(files, false);
     long rid = ruleManager.submitRule(rule, RuleState.ACTIVE);
 
     long start = System.currentTimeMillis();


### PR DESCRIPTION
- Made the `fid` field of the `file` table auto-incremented logical file id, decouple it from HDFS INode id
- Now information from `CreateEvent` is used to add information about file to Metastore for fixing SSM namespace consistency issues
- Removed the namespace fetcher triggering in case if the rename source cannot be found