### PR TITLE
[ADH-5330] Support full file re-copy instead of append for schemes not supporting appends

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <mockito.version>2.28.2</mockito.version>
-    <testcontainers.version>1.19.1</testcontainers.version>
+    <testcontainers.version>1.20.4</testcontainers.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <protobuf.version>3.7.1</protobuf.version>
     <dbunitVersion>2.5.3</dbunitVersion>

--- a/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
+++ b/smart-common/src/main/java/org/smartdata/utils/PathUtil.java
@@ -29,7 +29,7 @@ import static org.smartdata.utils.ConfigUtil.toRemoteClusterConfig;
 
 public class PathUtil {
   private static final String DIR_SEP = "/";
-  private static final String[] GLOBS = new String[] {
+  private static final String[] GLOBS = new String[]{
       "*", "?"
   };
 
@@ -100,14 +100,11 @@ public class PathUtil {
         .map(URI::getScheme);
   }
 
-  public static FileSystem getRemoteFileSystem(String path) throws IOException {
-    return getRemoteFileSystem(new Path(path));
-  }
-
   // todo we use default HDFS config, add mechanism to provide
   // hdfs config paths for remote clusters
-  public static FileSystem getRemoteFileSystem(Path path) throws IOException {
-    return path.getFileSystem(toRemoteClusterConfig(new Configuration()));
+  public static FileSystem getRemoteFileSystem(
+      Path path, Configuration configuration) throws IOException {
+    return path.getFileSystem(toRemoteClusterConfig(configuration));
   }
 
   public static String getRawPath(Path path) {

--- a/smart-frontend/app/yarn.lock
+++ b/smart-frontend/app/yarn.lock
@@ -4351,6 +4351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"antlr4@npm:4.13.2":
+  version: 4.13.2
+  resolution: "antlr4@npm:4.13.2"
+  checksum: 10c0/dfe7dcb24fe99ce103e1eac3ce30558a3df713cf5deeacd7e30686f5cca8206864e49b254af3bd5eff5904d31e5cd7902a7468c13dcb619da10caf3f703d03b4
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
@@ -8729,6 +8736,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"monaco-editor@npm:0.52.0":
+  version: 0.52.0
+  resolution: "monaco-editor@npm:0.52.0"
+  checksum: 10c0/962c75272568eb1556835f0097da2c7768bffe1116b252bb8b3aefd34f31e2dc46baa27e3911c0a6617bf556e6d6802e6e9f0f5548edd832c33872a8a0c146d3
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.0.0":
   version: 2.0.0
   resolution: "ms@npm:2.0.0"
@@ -10548,6 +10562,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:7.2.0"
     "@typescript-eslint/parser": "npm:7.2.0"
     "@vitejs/plugin-react": "npm:4.2.1"
+    antlr4: "npm:4.13.2"
     axios: "npm:1.7.2"
     classnames: "npm:2.5.1"
     date-fns: "npm:3.6.0"
@@ -10565,6 +10580,7 @@ __metadata:
     husky: "npm:9.0.11"
     js-base64: "npm:3.7.7"
     lint-staged: "npm:15.2.2"
+    monaco-editor: "npm:0.52.0"
     prettier: "npm:3.2.5"
     qs: "npm:6.12.1"
     react: "npm:18.2.0"

--- a/smart-hadoop-support/smart-hadoop-common/src/main/java/org/smartdata/hdfs/action/HdfsAction.java
+++ b/smart-hadoop-support/smart-hadoop-common/src/main/java/org/smartdata/hdfs/action/HdfsAction.java
@@ -32,7 +32,6 @@ import org.smartdata.conf.SmartConf;
 import org.smartdata.conf.SmartConfKeys;
 import org.smartdata.model.CmdletDescriptor;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -101,7 +100,7 @@ public abstract class HdfsAction extends SmartAction {
 
   protected FileSystem getFileSystemFor(Path path) throws IOException {
     return isAbsoluteRemotePath(path)
-        ? getRemoteFileSystem(path)
+        ? getRemoteFileSystem(path, getConf())
         : localFileSystem;
   }
 
@@ -112,7 +111,7 @@ public abstract class HdfsAction extends SmartAction {
   protected Optional<FileStatus> getFileStatus(FileSystem fileSystem, Path path) throws IOException {
     try {
       return Optional.of(fileSystem.getFileStatus(path));
-    } catch (FileNotFoundException e) {
+    } catch (IOException e) {
       return Optional.empty();
     }
   }

--- a/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MiniClusterHarness.java
+++ b/smart-hadoop-support/smart-hadoop-common/src/test/java/org/smartdata/hdfs/MiniClusterHarness.java
@@ -39,7 +39,8 @@ import static org.smartdata.conf.SmartConfKeys.SMART_SERVER_RPC_ADDRESS_KEY;
  * A MiniCluster for action test.
  */
 public abstract class MiniClusterHarness {
-  public static int DEFAULT_BLOCK_SIZE = 50;
+  public static final int DEFAULT_BLOCK_SIZE = 50;
+
   protected MiniDFSCluster cluster;
   protected DistributedFileSystem dfs;
   protected DFSClient dfsClient;
@@ -65,7 +66,7 @@ public abstract class MiniClusterHarness {
     smartContext = new SmartContext(conf);
   }
 
-  static void initConf(Configuration conf) {
+  protected void initConf(Configuration conf) {
     conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, DEFAULT_BLOCK_SIZE);
     conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, DEFAULT_BLOCK_SIZE);
     conf.setLong(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1L);

--- a/smart-hadoop-support/smart-hadoop/pom.xml
+++ b/smart-hadoop-support/smart-hadoop/pom.xml
@@ -214,6 +214,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>minio</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.smartdata</groupId>
             <artifactId>smart-metastore</artifactId>
             <version>2.0.0-SNAPSHOT</version>

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/HdfsActionWithRemoteClusterSupport.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/HdfsActionWithRemoteClusterSupport.java
@@ -32,7 +32,7 @@ public abstract class HdfsActionWithRemoteClusterSupport extends HdfsAction {
     Path targetPath = getTargetFile();
     if (isRemoteMode()) {
       preRemoteExecute();
-      execute(getRemoteFileSystem(targetPath));
+      execute(getRemoteFileSystem(targetPath, getConf()));
     } else {
       preLocalExecute();
       execute(localFileSystem);

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/ChecksumFileEqualityStrategy.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/file/equality/ChecksumFileEqualityStrategy.java
@@ -47,7 +47,7 @@ public class ChecksumFileEqualityStrategy implements FileEqualityStrategy {
 
   private FileSystem getFileSystem(Path path, Configuration conf) throws IOException {
     return isAbsoluteRemotePath(path)
-        ? getRemoteFileSystem(path)
+        ? getRemoteFileSystem(path, conf)
         : FileSystem.get(HadoopUtil.getNameNodeUri(conf), conf);
   }
 

--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/scheduler/CopyScheduler.java
@@ -249,6 +249,7 @@ public class CopyScheduler extends ActionSchedulerService {
         if (preserveAttributes != null) {
           action.getArgs().put(CopyFileAction.PRESERVE, preserveAttributes);
         }
+        action.getArgs().put(CopyFileAction.FORCE, "");
         if (rateLimiter != null) {
           String strLen = getLength(fileDiff);
           if (strLen != null) {

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/SmartMinIOContainer.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/SmartMinIOContainer.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs;
+
+import org.testcontainers.containers.MinIOContainer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SmartMinIOContainer extends MinIOContainer {
+  private static final int MINIO_UI_PORT = 9001;
+
+  private List<String> buckets;
+
+  public SmartMinIOContainer(String dockerImageName) {
+    super(dockerImageName);
+    this.buckets = new ArrayList<>();
+  }
+
+  public SmartMinIOContainer withBuckets(String... buckets) {
+    this.buckets = Arrays.asList(buckets);
+    return this;
+  }
+
+  @Override
+  public void configure() {
+    super.configure();
+
+    if (buckets.isEmpty()) {
+      return;
+    }
+
+    withCreateContainerCmdModifier(cmd -> {
+      cmd.withEntrypoint("sh");
+      cmd.withCmd("-c", createCmd());
+    });
+  }
+
+  @Override
+  public SmartMinIOContainer withPassword(String password) {
+    return (SmartMinIOContainer) super.withPassword(password);
+  }
+
+  @Override
+  public SmartMinIOContainer withUserName(String userName) {
+    return (SmartMinIOContainer) super.withUserName(userName);
+  }
+
+  private String createBucketDirs() {
+    return buckets.stream()
+        .map(bucket -> "/tmp/buckets/" + bucket)
+        .collect(Collectors.joining(" "));
+  }
+
+  private String createCmd() {
+    return "mkdir -p " + createBucketDirs()
+        + " && /usr/bin/docker-entrypoint.sh minio server "
+        + "--console-address :" + MINIO_UI_PORT
+        + " /tmp/buckets";
+  }
+}

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCompressionAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCompressionAction.java
@@ -21,11 +21,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.smartdata.hdfs.MiniClusterHarness;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
 import java.util.HashMap;
@@ -33,47 +31,36 @@ import java.util.Map;
 import java.util.Random;
 
 public class TestCompressionAction extends MiniClusterHarness {
-
-  @Override
-  @Before
-  public void init() throws Exception {
-    super.init();
-  }
+  private static final int BLOCK_SIZE = 1024 * 1024;
 
   @Override
   protected void initConf(Configuration conf) {
     super.initConf(conf);
-    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024);
-    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 1024 * 1024);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, BLOCK_SIZE);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, BLOCK_SIZE);
   }
 
-  protected void compression(String filePath, String bufferSize) throws IOException {
+  protected void compression(String filePath, String bufferSize) {
     CompressionAction compressionAction = new CompressionAction();
     compressionAction.setLocalFileSystem(dfs);
     compressionAction.setContext(smartContext);
     Map<String, String> args = new HashMap<>();
-    args.put(compressionAction.FILE_PATH, filePath);
-    args.put(compressionAction.BUF_SIZE, bufferSize);
+    args.put(CompressionAction.FILE_PATH, filePath);
+    args.put(CompressionAction.BUF_SIZE, bufferSize);
     // set a tmp dir for compression
     String COMPRESS_DIR = "/system/ssm/compress_tmp";
     String tempPath = COMPRESS_DIR + filePath + "_" + "aid" + compressionAction.getActionId()
         + "_" + System.currentTimeMillis();
-    args.put(compressionAction.COMPRESS_TMP, tempPath);
-//    args.put(CompressionAction.COMPRESS_IMPL, "Lz4");
-//    args.put(CompressionAction.COMPRESS_IMPL,"Bzip2");
-//    args.put(CompressionAction.COMPRESS_IMPL,"Zlib");
+    args.put(CompressionAction.COMPRESS_TMP, tempPath);
     compressionAction.init(args);
     compressionAction.run();
   }
 
   @Test
-  public void testInit() throws IOException {
+  public void testInit() {
     Map<String, String> args = new HashMap<>();
     args.put(CompressionAction.FILE_PATH, "/Test");
     args.put(CompressionAction.BUF_SIZE, "1024");
-//    args.put(CompressionAction.COMPRESS_IMPL, "Lz4");
-//    args.put(CompressionAction.COMPRESS_IMPL,"Bzip2");
-//    args.put(CompressionAction.COMPRESS_IMPL,"Zlib");
     CompressionAction compressionAction = new CompressionAction();
     compressionAction.setLocalFileSystem(dfs);
     compressionAction.setContext(smartContext);
@@ -84,16 +71,12 @@ public class TestCompressionAction extends MiniClusterHarness {
   public void testExecute() throws Exception {
     String filePath = "/testCompressFile/fadsfa/213";
     int bufferSize = 1024 * 128;
-//    String compressionImpl = "Lz4";
-//    String compressionImpl = "Bzip2";
-//    String compressionImpl = "Zlib";
     byte[] bytes = TestCompressionAction.BytesGenerator.get(bufferSize);
     short replication = 3;
-    long blockSize = DEFAULT_BLOCK_SIZE;
 
     // Create HDFS file
     OutputStream outputStream = dfsClient.create(filePath, true,
-      replication, blockSize);
+        replication, BLOCK_SIZE);
     outputStream.write(bytes);
     outputStream.close();
     dfsClient.setStoragePolicy(filePath, "COLD");
@@ -106,7 +89,7 @@ public class TestCompressionAction extends MiniClusterHarness {
     // Check HdfsFileStatus
     HdfsFileStatus fileStatus = dfsClient.getFileInfo(filePath);
     Assert.assertEquals(replication, fileStatus.getReplication());
-    Assert.assertEquals(blockSize, fileStatus.getBlockSize());
+    Assert.assertEquals(BLOCK_SIZE, fileStatus.getBlockSize());
 
     // 0 means unspecified.
     if (srcFileStatus.getStoragePolicy() != 0) {
@@ -117,16 +100,18 @@ public class TestCompressionAction extends MiniClusterHarness {
   }
 
   static final class BytesGenerator {
-    private static final byte[] CACHE = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4,
-      0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF };
-    private static final Random rnd = new Random(12345l);
+    private static final byte[] CACHE = new byte[]{0x0, 0x1, 0x2, 0x3, 0x4,
+        0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF};
+    private static final Random rnd = new Random(12345L);
+
     private BytesGenerator() {
     }
 
     public static byte[] get(int size) {
       byte[] array = (byte[]) Array.newInstance(byte.class, size);
-      for (int i = 0; i < size; i++)
+      for (int i = 0; i < size; i++) {
         array[i] = CACHE[rnd.nextInt(CACHE.length - 1)];
+      }
       return array;
     }
   }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCompressionAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestCompressionAction.java
@@ -17,6 +17,8 @@
  */
 package org.smartdata.hdfs.action;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,8 +37,14 @@ public class TestCompressionAction extends MiniClusterHarness {
   @Override
   @Before
   public void init() throws Exception {
-    DEFAULT_BLOCK_SIZE = 1024 * 1024;
     super.init();
+  }
+
+  @Override
+  protected void initConf(Configuration conf) {
+    super.initConf(conf);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 1024 * 1024);
   }
 
   protected void compression(String filePath, String bufferSize) throws IOException {

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestS3CopyFileAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestS3CopyFileAction.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.action;
+
+import com.google.common.collect.Sets;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.smartdata.hdfs.MiniClusterHarness;
+import org.smartdata.hdfs.SmartMinIOContainer;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test for CopyFileAction.
+ */
+public class TestS3CopyFileAction extends MiniClusterHarness {
+
+  private static final String FILE_TO_COPY_CONTENT = "1234567890";
+  private static final String FILE_TO_APPEND_CONTENT = "qwertyuiop";
+
+  private static final String MINIO_USER = "minioAdmin";
+  private static final String MINIO_PASSWORD = "minioPassword";
+  private static final String TEST_BUCKET = "bucket";
+
+  private FileSystem s3FileSystem;
+
+  @Rule
+  public SmartMinIOContainer minIOContainer =
+      new SmartMinIOContainer("minio/minio:RELEASE.2024-08-17T01-24-54Z")
+          .withBuckets(TEST_BUCKET)
+          .withUserName(MINIO_USER)
+          .withPassword(MINIO_PASSWORD);
+
+  @Before
+  public void initDestFs() throws Exception {
+    s3FileSystem = FileSystem.get(
+        URI.create("s3a://" + TEST_BUCKET),
+        smartContext.getConf());
+  }
+
+  @After
+  public void closeDestFs() throws Exception {
+    if (s3FileSystem != null) {
+      s3FileSystem.close();
+    }
+  }
+
+  @Override
+  protected void initConf(Configuration conf) {
+    super.initConf(conf);
+    conf.set("fs.s3a.impl", S3AFileSystem.class.getName());
+    conf.set("fs.s3a.endpoint", minIOContainer.getS3URL());
+    conf.set("fs.s3a.access.key", MINIO_USER);
+    conf.set("fs.s3a.secret.key", MINIO_PASSWORD);
+    conf.setBoolean("fs.s3a.path.style.access", true);
+    conf.setBoolean("fs.s3a.connection.ssl.enabled", false);
+  }
+
+  @Test
+  public void testCreateFile() throws Exception {
+    Path srcPath = new Path("/testCopy/file1");
+    Path destPath = new Path("s3a://bucket/file2");
+
+    DFSTestUtil.writeFile(dfs, srcPath, FILE_TO_COPY_CONTENT);
+
+    copyFile(srcPath, destPath, 0, 0);
+
+    assertFileContent(destPath, FILE_TO_COPY_CONTENT);
+  }
+
+  @Test
+  public void testAppendFile() throws Exception {
+    Path srcPath = new Path("/testCopy/testAppend");
+    Path destPath = new Path("s3a://bucket/fileAppended");
+
+    DFSTestUtil.writeFile(dfs, srcPath, FILE_TO_COPY_CONTENT + FILE_TO_APPEND_CONTENT);
+    DFSTestUtil.writeFile(s3FileSystem, destPath, FILE_TO_COPY_CONTENT);
+
+    copyFile(srcPath, destPath,
+        FILE_TO_APPEND_CONTENT.getBytes().length,
+        FILE_TO_COPY_CONTENT.getBytes().length);
+
+    assertFileContent(destPath, FILE_TO_COPY_CONTENT + FILE_TO_APPEND_CONTENT);
+  }
+
+  private void copyFile(Path src, Path dest, long length, long offset,
+      CopyPreservedAttributesAction.PreserveAttribute... preserveAttributes) {
+    CopyFileAction copyFileAction = new CopyFileAction();
+    copyFileAction.setLocalFileSystem(dfs);
+    copyFileAction.setContext(smartContext);
+
+    Map<String, String> args = new HashMap<>();
+    args.put(CopyFileAction.FILE_PATH, src.toUri().getPath());
+    args.put(CopyFileAction.DEST_PATH, dest.toString());
+    args.put(CopyFileAction.LENGTH, String.valueOf(length));
+    args.put(CopyFileAction.OFFSET_INDEX, String.valueOf(offset));
+    args.put(CopyFileAction.FORCE, "");
+
+    if (preserveAttributes.length != 0) {
+      String attributesOption = Sets.newHashSet(preserveAttributes)
+          .stream()
+          .map(Object::toString)
+          .collect(Collectors.joining(","));
+      args.put(CopyFileAction.PRESERVE, attributesOption);
+    }
+
+    copyFileAction.init(args);
+    copyFileAction.run();
+
+    if (!copyFileAction.getExpectedAfterRun()) {
+      throw new RuntimeException("Action failed", copyFileAction.getThrowable());
+    }
+  }
+
+  private void assertFileContent(Path filePath, String expectedContent) throws Exception {
+    Assert.assertTrue(s3FileSystem.exists(filePath));
+    String actualContent = DFSTestUtil.readFile(s3FileSystem, filePath);
+    Assert.assertEquals(expectedContent, actualContent);
+  }
+}

--- a/smart-server/src/test/java/org/smartdata/server/engine/cmdlet/TestCompressDecompress.java
+++ b/smart-server/src/test/java/org/smartdata/server/engine/cmdlet/TestCompressDecompress.java
@@ -17,11 +17,13 @@
  */
 package org.smartdata.server.engine.cmdlet;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.DFSClient;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSInputStream;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
@@ -61,7 +63,6 @@ public class TestCompressDecompress extends MiniSmartClusterHarness {
   @Override
   @Before
   public void init() throws Exception {
-    DEFAULT_BLOCK_SIZE = 1024 * 1024;
     super.init();
     this.codec = ZLibCompressorFactory.ZLIB_CODEC;
     smartDFSClient = new SmartDFSClient(ssm.getContext().getConf());
@@ -69,6 +70,13 @@ public class TestCompressDecompress extends MiniSmartClusterHarness {
     cmdletManager = ssm.getCmdletManager();
     cmdletInfoHandler = cmdletManager.getCmdletInfoHandler();
     actionInfoHandler = cmdletManager.getActionInfoHandler();
+  }
+
+  @Override
+  protected void initConf(Configuration conf) {
+    super.initConf(conf);
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, 1024 * 1024);
+    conf.setInt(DFSConfigKeys.DFS_BYTES_PER_CHECKSUM_KEY, 1024 * 1024);
   }
 
   @Test


### PR DESCRIPTION
Added the `-force` option for the `copy` action to support full file re-copy instead of append for schemes not supporting appends, like `s3a`