### PR TITLE
[ADH-5272] Support more actuator endpoints

### DIFF
--- a/smart-web-server/smart-agent-web-server/src/main/resources/application-agent.yaml
+++ b/smart-web-server/smart-agent-web-server/src/main/resources/application-agent.yaml
@@ -2,4 +2,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,prometheus
+        include: health,prometheus,heapdump,metrics,threaddump,env
+  health:
+    ldap:
+      enabled: false

--- a/smart-web-server/smart-master-web-server/src/main/resources/application-master.yaml
+++ b/smart-web-server/smart-master-web-server/src/main/resources/application-master.yaml
@@ -13,7 +13,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,prometheus
+        include: health,prometheus,heapdump,metrics,threaddump,env
+  health:
+    ldap:
+      enabled: false
 spring:
   web:
     resources:

--- a/smart-web-server/smart-web-server-base/src/main/java/org/smartdata/http/config/SecurityConfiguration.java
+++ b/smart-web-server/smart-web-server-base/src/main/java/org/smartdata/http/config/SecurityConfiguration.java
@@ -41,7 +41,8 @@ import static org.smartdata.http.config.ConfigKeys.WEB_SECURITY_ENABLED;
 public class SecurityConfiguration {
   private static final String SESSION_COOKIE_NAME = "SSM_SESSIONID";
   private static final String API_ENDPOINTS_PATTERN = "/api/**";
-  private static final String METRICS_ENDPOINT_PATTERN = "/actuator/prometheus/**";
+  private static final String ACTUATOR_ENDPOINTS_PATTERN = "/actuator/**";
+  private static final String HEALTH_ENDPOINT_PATTERN = "/actuator/health/**";
 
   @Bean
   @ConditionalOnProperty(name = WEB_SECURITY_ENABLED, havingValue = "true")
@@ -71,9 +72,9 @@ public class SecurityConfiguration {
       Set<SsmAuthHttpConfigurer> authHttpConfigurers) throws Exception {
     baseHttpSecurity(http)
         .authorizeRequests()
-        .antMatchers(API_ENDPOINTS_PATTERN, METRICS_ENDPOINT_PATTERN).authenticated()
+        .antMatchers(HEALTH_ENDPOINT_PATTERN).permitAll()
+        .antMatchers(API_ENDPOINTS_PATTERN, ACTUATOR_ENDPOINTS_PATTERN).authenticated()
         .and()
-        .anonymous().disable()
         .addFilterAfter(
             new SmartPrincipalInitializerFilter(principalManager),
             BasicAuthenticationFilter.class);


### PR DESCRIPTION
- Exposed [heapdump](https://docs.spring.io/spring-boot/docs/2.7.18/actuator-api/htmlsingle/#heapdump), [metrics](https://docs.spring.io/spring-boot/docs/2.7.18/actuator-api/htmlsingle/#metrics), [threaddump](https://docs.spring.io/spring-boot/docs/2.7.18/actuator-api/htmlsingle/#threaddump) and [env](https://docs.spring.io/spring-boot/docs/2.7.18/actuator-api/htmlsingle/#env) actuator secured endpoints on both master and agent
- Fixed issue with autoconfigured LDAP server healthcheck even if LDAP authentication is disabled