### PR TITLE
[ADH-4929] Support debugging in docker stand

### DIFF
--- a/bin/start-ssm.sh
+++ b/bin/start-ssm.sh
@@ -54,8 +54,9 @@ while [ $# != 0 ]; do
           shift
           ;;
         *)
+          shift
+          ;;
       esac
-      shift
       ;;
     "--help" | "-h")
       echo "--help -h Show this usage information"

--- a/supports/tools/docker/README.md
+++ b/supports/tools/docker/README.md
@@ -34,6 +34,8 @@ cd ./supports/tools/docker
 * SSM Server container
 * SSM metastore as postgres container
 * Kerberos KDC container
+* Samba LDAP server
+* Prometheus server
 
 Command to build docker images in multihost cluster mode (from project root dir)
 
@@ -57,6 +59,16 @@ Use one of the following credentials to log in to the Web UI
 | krb_user2@DEMO | krb_pass2     | kerberos |
 | july           | kitty_cat     | ldap     |
 | ben            | bens_password | ldap     |
+
+### SSM Master debug
+
+To enable debugging support for the SSM Master add the `--debugMaster` argument, when executing the `start-demo.sh` script. 
+Debugger then can be attached to the `localhost:8008`.
+
+### SSM Agent debug
+
+To enable debugging support for the SSM Agent add the `--debugAgent` argument, when executing the `start-demo.sh` script.
+Debugger then can be attached to the `localhost:8009`.
 
 ### Testing SPNEGO auth
 
@@ -82,156 +94,3 @@ kinit krb_user1
 ```shell
 curl --negotiate http://ssm-server.demo:8081/api/v2/audit/events
 ```
-
-# Run/Test SSM with Docker
-
-Docker can greately reduce boring time for installing and maintaining software on servers and developer machines. This
-document presents this basic workflow of Run/test ssm with
-docker. [Docker Quick Start](https://docs.docker.com/get-started/)
-
-## Necessary Components
-
-### MetaStore(Postgresql) on Docker
-
-#### Launch a postgresql container
-
-Pull latest postgresql official image from docker store. You can use `postgres:tag` to specify the Postgresql version (
-`tag`) you want.
-
-```
-docker pull postgres
-```
-
-Launch a postgres container with a given {passowrd} on 5432, and create a test database/schema named `{database_name}`.
-
-```bash
-docker run -p 5432:5432 --name {container_name} -e POSTGRES_PASSWORD={password} -e POSTGRES_DB={database_name} -d postgres:latest
-```
-
-**Parameters:**
-
-- `container_name` name of container
-- `password` root password of user root for login and access.
-- `database_name` Create a new database/schema with given name.
-
-### HDFS on Docker
-
-**Note that this part is not suggested on OSX (mac), becasue the containers' newtork is limited on OSX.**
-
-Pull a well-known third-party hadoop image from docker store. You can use `hadoop-docker:tag` to specify the Hadoop
-version (`tag`) you want.
-
-#### Set a HDFS Container
-
-```bash
-docker pull sequenceiq/hadoop-docker
-```
-
-Launch a Hadoop container with a exposed namenode.rpcserver.
-
-```bash
-docker run -it --add-host=moby:127.0.0.1 --ulimit memlock=2024000000:2024000000 -p 9000:9000 --name=hadoop sequenceiq/hadoop-docker /etc/bootstrap.sh -bash
-```
-
-Note that we try to launch a interactive docker container. Use the following command to check HDFS status. We also set
-`memlock=2024000000` for cache size.
-
-```
-cd $HADOOP_PREFIX
-bin/hdfs dfs -ls /
-```
-
-#### Configure HDFS with multiple storage types and cache
-
-Edit `$HADOOP_PREFIX/etc/hadoop/hdfs-site.xml` and add the property below. This will turn off premission check to avoid
-`Access denied for user ***. Superuser privilege is required`.
-
-```
-<property>
-    <name>dfs.permissions.enabled</name>
-    <value>false</value>
-</property>
-```
-
-Create `/tmp/hadoop-root/dfs/data1~3` for different storage types. Delete all content in `/tmp/hadoop-root/dfs/data` and
-`/tmp/hadoop-root/dfs/name`, then use `bin/hdfs namenode -format` to format HDFS.
-
-Add the following properties to `$HADOOP_PREFIX/etc/hadoop/hdfs-site.xml`.
-
-```
-<property>
-	<name>dfs.datanode.max.locked.memory</name>
-	<value>2024000000</value>
-</property>
-<property>
-	<name>dfs.datanode.data.dir</name>
-	<value>[DISK]/tmp/hadoop-root/dfs/data,[SSD]/tmp/hadoop-root/dfs/data1,[RAM_DISK]/tmp/hadoop-root/dfs/data2,[ARCHIVE]/tmp/hadoop-root/dfs/data3</value>
-</property>
-<property>
-	<name>dfs.blocksize</name>
-	<value>1048576</value>
-	</property>
-<property>
-	<name>dfs.permissions.enabled</name>
-	<value>false</value>
-</property>
-```
-
-Restart HDFS.
-
-```
-$HADOOP_PREFIX/sbin/stop-dfs.sh
-$HADOOP_PREFIX/sbin/start-dfs.sh
-```
-
-Use `bin/hdfs dfsadmin -report` to check status.
-
-## SSM Configuration
-
-### MetaStore
-
-#### Configure MetaStore for SSM
-
-Assuming you are in SSM root directory, modify `conf/druid.xml` to enable SSM to connect with postgres.
-
-```
-	<entry key="url">jdbc:postgresql://localhost/{database_name}</entry>
-	<entry key="username">root</entry>
-	<entry key="password">{root_password}</entry>
-```
-
-Wait for at least 10 seconds. Then, use `bin/start-smart.sh -format` to format (re-init) the database. Also, you can use
-this command to clear all data in database in tests.
-
-#### Stop/Remove Postgres container
-
-You can use the `docker stop {contrainer_name}` to stop postgres container. Then, this postgres service cannot be
-accessed, until you start it again with `docker start {contrainer_name}`. Note that, `stop/start` will not remove any
-data from your postgres container.
-
-Use `docker rm {container_name}` to remove postgres container, if this container is not necessary. If you don't remember
-the specific name of container, you can use `docker ps -a` to look for it.
-
-### HDFS
-
-### Configure HDFS for SSM
-
-Configure `namenode.rpcserver` in `smart-site.xml`.
-
-```xml
-
-<configuration>
-    <property>
-        <name>smart.dfs.namenode.rpcserver</name>
-        <value>hdfs://localhost:9000</value>
-        <description>Namenode rpcserver</description>
-    </property>
-</configuration>
-```
-
-## More Information
-
-1. [Docker](https://www.docker.com/)
-2. [Docker doc](https://docs.docker.com/)
-3. [Postgres on Docker](https://store.docker.com/images/postgres)
-4. [Docker CN mirror](https://www.docker-cn.com/registry-mirror) 

--- a/supports/tools/docker/multihost/Dockerfile-hadoop-base
+++ b/supports/tools/docker/multihost/Dockerfile-hadoop-base
@@ -38,14 +38,10 @@ RUN mkdir /opt/ssm/bin
 RUN mkdir /opt/ssm/lib
 RUN mkdir /opt/ssm/conf
 
-# Copy custom hadoop config files to $HADOOP_CONF_DIR
-COPY ./supports/tools/docker/multihost/conf/* $HADOOP_CONF_DIR/
-
 # Copy ssm jars to $HADOOP_HOME/share/hadoop/common/lib
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/smart-*.jar $HADOOP_HOME/share/hadoop/common/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/*.jar $SSM_HOME/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/bin/* $SSM_HOME/bin/
-COPY ./supports/tools/docker/multihost/conf/* $SSM_HOME/conf/
 
 RUN chmod a+x $SSM_HOME/bin/install.sh
 RUN chmod a+x $SSM_HOME/bin/start-ssm.sh

--- a/supports/tools/docker/multihost/common.sh
+++ b/supports/tools/docker/multihost/common.sh
@@ -40,6 +40,13 @@ function addProperty() {
   sed -i "/<\/configuration>/ s/.*/${escapedEntry}\n&/" $path
 }
 
+function moveHadoopConfFiles() {
+  local srcDirectory=$1
+  local target=$2
+
+  cp ${srcDirectory}/*.xml ${target}
+}
+
 function configure() {
     local path=$1
     local module=$2

--- a/supports/tools/docker/multihost/datanode/hadoop-datanode-entrypoint.sh
+++ b/supports/tools/docker/multihost/datanode/hadoop-datanode-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. ./common.sh
+
 cp /etc/ssm/shared/id_rsa /root/.ssh/id_rsa
 cp /etc/ssm/shared/id_rsa.pub /root/.ssh/id_rsa.pub
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
@@ -14,6 +16,8 @@ if [ ! -d $datadir ]; then
 fi
 
 chmod +r /etc/secrets/*.keytab
+
+moveHadoopConfFiles /etc/conf ${HADOOP_CONF_DIR}
 
 $HADOOP_HOME/bin/hdfs --config $HADOOP_CONF_DIR datanode
 

--- a/supports/tools/docker/multihost/docker-compose.yaml
+++ b/supports/tools/docker/multihost/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - hadoop-namenode:/hadoop/dfs/name
       - secrets:/etc/secrets
       - ./kerberos/krb5.conf:/etc/krb5.conf
+      - ./conf:/etc/conf
     ports:
       - "9870:9870"
       - "8020:8020"
@@ -39,6 +40,8 @@ services:
       - hadoop-datanode-archive-data:/hadoop/dfs/archive-data
       - secrets:/etc/secrets
       - ./kerberos/krb5.conf:/etc/krb5.conf
+      - ./conf:/etc/conf
+      - ./conf:/opt/ssm/conf
     ports:
       - "9864:9864"
       - "7048:7048"
@@ -68,6 +71,7 @@ services:
       - ssm-shared:/tmp/shared
       - secrets:/etc/secrets
       - ./kerberos/krb5.conf:/etc/krb5.conf
+      - ./conf:/opt/ssm/conf
     ports:
       - "7042:7042"
       - "8081:8081"
@@ -110,6 +114,11 @@ services:
     hostname: kdc-server.demo
     volumes:
       - secrets:/tmp/secrets
+      - ./kerberos/krb5.conf:/etc/krb5.conf
+      - ./kerberos/kdc.conf:/etc/krb5kdc/kdc.conf
+      - ./kerberos/kdc.conf:/var/kerberos/krb5kdc/kdc.conf
+      - ./kerberos/kadm5.acl:/etc/krb5kdc/kadm5.acl
+      - ./kerberos/kdc-init.sh:/tmp/kdc-init.sh
     ports:
       - "749:749"
       - "88:88/udp"

--- a/supports/tools/docker/multihost/docker-compose.yaml
+++ b/supports/tools/docker/multihost/docker-compose.yaml
@@ -50,6 +50,10 @@ services:
       - "18081:8081"
       # JMX port
       - "3334:3334"
+      # agent debug port
+      - "8009:8008"
+    environment:
+      - SSM_DEBUG_OPT
     env_file:
       - hadoop.env
     healthcheck:
@@ -77,6 +81,10 @@ services:
       - "8081:8081"
       # JMX port
       - "3333:3333"
+      # ssm debug port
+      - "8008:8008"
+    environment:
+      - SSM_DEBUG_OPT
     healthcheck:
       test: curl http://ssm-server.demo:8081 || exit 1
       interval: 30s

--- a/supports/tools/docker/multihost/kerberos/Dockerfile-kdc
+++ b/supports/tools/docker/multihost/kerberos/Dockerfile-kdc
@@ -9,10 +9,4 @@ ENV MASTER_PASSWORD ${MASTER_PASSWORD:-masterpassword}
 ENV KADMIN_PRINCIPAL ${KADMIN_PRINCIPAL:-kadmin/admin}
 ENV KADMIN_PASSWORD ${KADMIN_PASSWORD:-adminpassword}
 
-COPY ./supports/tools/docker/multihost/kerberos/krb5.conf /etc/krb5.conf
-COPY ./supports/tools/docker/multihost/kerberos/kdc.conf /etc/krb5kdc/kdc.conf
-COPY ./supports/tools/docker/multihost/kerberos/kdc.conf /var/kerberos/krb5kdc/kdc.conf
-COPY ./supports/tools/docker/multihost/kerberos/kadm5.acl /etc/krb5kdc/kadm5.acl
-COPY ./supports/tools/docker/multihost/kerberos/kdc-init.sh /tmp/
-
 CMD bash /tmp/kdc-init.sh

--- a/supports/tools/docker/multihost/namenode/hadoop-namenode-entrypoint.sh
+++ b/supports/tools/docker/multihost/namenode/hadoop-namenode-entrypoint.sh
@@ -17,6 +17,8 @@ if [ -z "$CLUSTER_NAME" ]; then
   exit 2
 fi
 
+moveHadoopConfFiles /etc/conf ${HADOOP_CONF_DIR}
+
 # HDFS
 addProperty "$HADOOP_CONF_DIR"/hdfs-site.xml dfs.namenode.rpc-bind-host 0.0.0.0
 addProperty "$HADOOP_CONF_DIR"/hdfs-site.xml dfs.namenode.servicerpc-bind-host 0.0.0.0

--- a/supports/tools/docker/multihost/ssm/Dockerfile-ssm-server
+++ b/supports/tools/docker/multihost/ssm/Dockerfile-ssm-server
@@ -23,7 +23,6 @@ RUN mkdir /opt/ssm/conf
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/smart-*.jar $HADOOP_HOME/share/hadoop/common/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/*.jar $SSM_HOME/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/bin/* $SSM_HOME/bin/
-COPY ./supports/tools/docker/multihost/conf/* $SSM_HOME/conf/
 
 ADD ./supports/tools/docker/multihost/ssm/ssm-server-entrypoint.sh /ssm-server-entrypoint.sh
 ADD ./supports/tools/docker/multihost/common.sh /common.sh

--- a/supports/tools/docker/multihost/ssm/ssm-server-entrypoint.sh
+++ b/supports/tools/docker/multihost/ssm/ssm-server-entrypoint.sh
@@ -17,7 +17,7 @@ echo "---------------------------"
 echo "Starting SSM server and agents"
 echo "---------------------------"
 
-source bin/start-ssm.sh --config ${SSM_HOME}/conf/ &
+source bin/start-ssm.sh ${SSM_DEBUG_OPT} --config ${SSM_HOME}/conf/ &
 wait_for_it $(hostname -f):8081
 wait_for_it hadoop-datanode.demo:7048
 

--- a/supports/tools/docker/start-demo.sh
+++ b/supports/tools/docker/start-demo.sh
@@ -9,12 +9,20 @@ while [ $# -gt 0 ]; do
     --hadoop=*)
       HADOOP_PROFILE="${1#*=}"
       ;;
+    --debugMaster)
+      SSM_DEBUG_OPT+="--debug master "
+      ;;
+    --debugAgent)
+      SSM_DEBUG_OPT+="--debug agent "
+      ;;
     *)
       echo "=========================================================="
-      echo " Error: Invalid argument. Should be in the form --key=arg."
+      echo " Error: Invalid argument. Should be in the form --key=arg or --key."
       echo " Supported arguments:"
       echo "    --cluster: multihost (default) | singlehost"
       echo "    --hadoop: 3.3 (default)"
+      echo "    --debugMaster"
+      echo "    --debugAgent"
       echo "=========================================================="
       exit 1
   esac
@@ -47,4 +55,4 @@ case $CLUSTER_TYPE in
   ;;
 esac
 
-env HADOOP_VERSION=$HADOOP_VERSION docker compose -f ${COMPOSE_FILE_PATH} up -d
+env HADOOP_VERSION=$HADOOP_VERSION SSM_DEBUG_OPT="$SSM_DEBUG_OPT" docker compose -f ${COMPOSE_FILE_PATH} up -d


### PR DESCRIPTION
- Added option to `start-demo.sh` for debugging enabling in the docker stand
- Refactored Dockerfiles and entry point scripts to support config files reloading without image rebuild