### PR TITLE
[ADH-5728] Add shading of SSM HDFS client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,8 @@
     <maven-replacer-plugin.version>1.5.3</maven-replacer-plugin.version>
     <hadoop-thirdparty-shaded.prefix>org.apache.hadoop.thirdparty</hadoop-thirdparty-shaded.prefix>
     <hadoop-thirdparty-shaded.protobuf.prefix>${hadoop-thirdparty-shaded.prefix}.protobuf</hadoop-thirdparty-shaded.protobuf.prefix>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <shaded.dependencies.prefix>org.smartdata.shaded</shaded.dependencies.prefix>
   </properties>
 
   <profiles>

--- a/smart-dist/src/assemblies/component.xml
+++ b/smart-dist/src/assemblies/component.xml
@@ -17,6 +17,13 @@
             <directory>${basedir}/../conf</directory>
             <outputDirectory>/conf</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}/../smart-hadoop-support/target</directory>
+            <includes>
+                <include>smart-hadoop-client-shaded-${project.version}.jar</include>
+            </includes>
+            <outputDirectory>/clients</outputDirectory>
+        </fileSet>
     </fileSets>
     <dependencySets>
         <dependencySet>

--- a/smart-hadoop-support/smart-hadoop-client-3/pom.xml
+++ b/smart-hadoop-support/smart-hadoop-client-3/pom.xml
@@ -38,7 +38,6 @@
             <groupId>org.smartdata</groupId>
             <artifactId>smart-common</artifactId>
             <version>2.2.0-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -60,13 +59,11 @@
             <groupId>org.smartdata</groupId>
             <artifactId>smart-inputstream</artifactId>
             <version>2.2.0-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.smartdata</groupId>
             <artifactId>smart-hadoop-3</artifactId>
             <version>2.2.0-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.smartdata</groupId>
@@ -142,6 +139,61 @@
                         </goals>
                         <configuration>
                             <outputDirectory>target/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <finalName>smart-hadoop-client-shaded-${project.version}</finalName>
+                            <outputDirectory>../target</outputDirectory>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.smartdata</include>
+                                    <include>org.apache.commons</include>
+                                    <include>com.google.guava</include>
+                                    <include>com.google.thirdparty</include>
+                                    <include>com.fasterxml</include>
+                                    <include>commons-*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${shaded.dependencies.prefix}.org.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>${shaded.dependencies.prefix}.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>${shaded.dependencies.prefix}.com.fasterxml</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/supports/tools/docker/multihost/Dockerfile-hadoop-base
+++ b/supports/tools/docker/multihost/Dockerfile-hadoop-base
@@ -38,8 +38,8 @@ RUN mkdir /opt/ssm/bin
 RUN mkdir /opt/ssm/lib
 RUN mkdir /opt/ssm/conf
 
-# Copy ssm jars to $HADOOP_HOME/share/hadoop/common/lib
-COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/smart-*.jar $HADOOP_HOME/share/hadoop/common/lib/
+# Copy ssm client jar to $HADOOP_HOME/share/hadoop/common/lib
+COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/clients/smart-hadoop-client-shaded-${SSM_APP_VERSION}.jar $HADOOP_HOME/share/hadoop/common/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/*.jar $SSM_HOME/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/bin/* $SSM_HOME/bin/
 

--- a/supports/tools/docker/multihost/docker-compose.yaml
+++ b/supports/tools/docker/multihost/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
       - ssm-server
 
   ssm-server:
-    image: cloud-hub.adsw.io/library/ssm-server:2.0.0-SNAPSHOT
+    image: cloud-hub.adsw.io/library/ssm-server:${SSM_VERSION:-2.2.0-SNAPSHOT}
     hostname: ssm-server.demo
     restart: unless-stopped
     container_name: ssm-server

--- a/supports/tools/docker/multihost/ssm/Dockerfile-ssm-server
+++ b/supports/tools/docker/multihost/ssm/Dockerfile-ssm-server
@@ -19,8 +19,8 @@ RUN mkdir /opt/ssm/bin
 RUN mkdir /opt/ssm/lib
 RUN mkdir /opt/ssm/conf
 
-# Copy ssm jars to $HADOOP_HOME/share/hadoop/common/lib
-COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/smart-*.jar $HADOOP_HOME/share/hadoop/common/lib/
+# Copy ssm client jar to $HADOOP_HOME/share/hadoop/common/lib
+COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/clients/smart-hadoop-client-shaded-${SSM_APP_VERSION}.jar $HADOOP_HOME/share/hadoop/common/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/*.jar $SSM_HOME/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/bin/* $SSM_HOME/bin/
 

--- a/supports/tools/docker/singlehost/Dockerfile
+++ b/supports/tools/docker/singlehost/Dockerfile
@@ -55,8 +55,8 @@ ENV SSM_HOME=/opt/ssm
 # Copy custom hadoop config files to $HADOOP_CONF_DIR
 COPY ./supports/tools/docker/singlehost/conf/* $HADOOP_CONF_DIR/
 
-# Copy ssm jars to $HADOOP_HOME/share/hadoop/common/lib
-COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/smart-*.jar $HADOOP_HOME/share/hadoop/common/lib/
+# Copy ssm client jar to $HADOOP_HOME/share/hadoop/common/lib
+COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/clients/smart-hadoop-client-shaded-${SSM_APP_VERSION}.jar $HADOOP_HOME/share/hadoop/common/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/lib/*.jar $SSM_HOME/lib/
 COPY ./smart-dist/target/smart-data-${SSM_APP_VERSION}/bin/* $SSM_HOME/bin/
 COPY ./supports/tools/docker/singlehost/conf/* $SSM_HOME/conf/

--- a/supports/tools/docker/start-demo.sh
+++ b/supports/tools/docker/start-demo.sh
@@ -55,4 +55,7 @@ case $CLUSTER_TYPE in
   ;;
 esac
 
-env HADOOP_VERSION=$HADOOP_VERSION SSM_DEBUG_OPT="$SSM_DEBUG_OPT" docker compose -f ${COMPOSE_FILE_PATH} up -d
+SSM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive -f "../../../pom.xml" exec:exec)
+SSM_VERSION=$(echo "${SSM_VERSION}" | head -1)
+
+env HADOOP_VERSION=$HADOOP_VERSION SSM_DEBUG_OPT="$SSM_DEBUG_OPT" SSM_VERSION="$SSM_VERSION" docker compose -f ${COMPOSE_FILE_PATH} up -d


### PR DESCRIPTION
- Added shaded jar construction and common libraries relocation (Apache Commons, Guava, Jackson) to the `smart-hadoop-client-3` module build pipeline
- Adapted distribution archive construction to also include shaded client jar
- Updated SSM demo docker images to copy only shaded  Smart HDFS client jar to the Hadoop classpath