### PR TITLE
[ADH-6574] Filter the -ruleId arg from the arguments of DistCp call

### DIFF
--- a/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DistCpAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/main/java/org/smartdata/hdfs/action/DistCpAction.java
@@ -17,6 +17,7 @@
  */
 package org.smartdata.hdfs.action;
 
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.tools.DistCp;
@@ -28,8 +29,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.smartdata.model.CmdletDescriptor.RULE_ID;
 
 @ActionSignature(
     actionId = "distcp",
@@ -49,6 +53,12 @@ public class DistCpAction extends HdfsAction {
   private static final String SOURCE_PATHS_DELIMITER = ",";
   private static final String PRESERVE_DISTCP_OPTION_PREFIX = "-p";
 
+  private static final Set<String> SSM_ARGS = Sets.newHashSet(
+      FILE_PATH,
+      TARGET_ARG,
+      RULE_ID
+  );
+
   private String sourcePaths;
 
   private String targetPath;
@@ -63,8 +73,7 @@ public class DistCpAction extends HdfsAction {
     targetPath = args.get(TARGET_ARG);
 
     distCpArgs = new HashMap<>(args);
-    distCpArgs.remove(FILE_PATH);
-    distCpArgs.remove(TARGET_ARG);
+    SSM_ARGS.forEach(distCpArgs::remove);
 
     if (!containsPreserveOption(args)) {
       distCpArgs.put(PRESERVE_DISTCP_OPTION_DEFAULT, "");

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpAction.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpAction.java
@@ -17,20 +17,7 @@
  */
 package org.smartdata.hdfs.action;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.tools.DistCpOptions;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -38,12 +25,21 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.smartdata.hdfs.MiniClusterHarness;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.ACL;
 import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.CHECKSUMTYPE;
 import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.GROUP;
 import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.PERMISSION;
 import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.TIMES;
 import static org.apache.hadoop.tools.DistCpOptions.FileAttribute.USER;
+import static org.smartdata.model.CmdletDescriptor.RULE_ID;
 
 /**
  * Test for DistCpAction.
@@ -119,8 +115,8 @@ public class TestDistCpAction extends MiniClusterHarness {
 
     IllegalArgumentException exception = Assert.assertThrows(
         IllegalArgumentException.class, () -> createAction(args).buildDistCpOptions());
-    Assert.assertEquals(exception.getMessage(),
-        "Source paths not provided, please provide either -file either -f argument");
+    Assert.assertEquals("Source paths not provided, please provide either -file either -f argument",
+        exception.getMessage());
   }
 
   @Test
@@ -131,8 +127,8 @@ public class TestDistCpAction extends MiniClusterHarness {
 
     IllegalArgumentException exception = Assert.assertThrows(
         IllegalArgumentException.class, () -> createAction(args).buildDistCpOptions());
-    Assert.assertEquals(exception.getMessage(),
-        "Source paths not provided, please provide either -file either -f argument");
+    Assert.assertEquals("Source paths not provided, please provide either -file either -f argument",
+        exception.getMessage());
   }
 
   @Test
@@ -144,8 +140,9 @@ public class TestDistCpAction extends MiniClusterHarness {
 
     IllegalArgumentException exception = Assert.assertThrows(
         IllegalArgumentException.class, () -> createAction(args).buildDistCpOptions());
-    Assert.assertEquals(exception.getMessage(),
-        "-file and -f can't be used at the same time. Use only one of the options for specifying source paths.");
+    Assert.assertEquals(
+        "-file and -f can't be used at the same time. Use only one of the options for specifying source paths.",
+        exception.getMessage());
   }
 
   @Test
@@ -155,7 +152,7 @@ public class TestDistCpAction extends MiniClusterHarness {
 
     IllegalArgumentException exception = Assert.assertThrows(
         IllegalArgumentException.class, () -> createAction(args).buildDistCpOptions());
-    Assert.assertEquals(exception.getMessage(), "Required argument not present: -target");
+    Assert.assertEquals("Required argument not present: -target", exception.getMessage());
   }
 
   @Test
@@ -166,7 +163,7 @@ public class TestDistCpAction extends MiniClusterHarness {
 
     IllegalArgumentException exception = Assert.assertThrows(
         IllegalArgumentException.class, () -> createAction(args).buildDistCpOptions());
-    Assert.assertEquals(exception.getMessage(), "Required argument not present: -target");
+    Assert.assertEquals("Required argument not present: -target", exception.getMessage());
   }
 
   @Test
@@ -174,6 +171,7 @@ public class TestDistCpAction extends MiniClusterHarness {
     Map<String, String> args = new HashMap<>();
     args.put(DistCpAction.FILE_PATH, "/test/source/dir1");
     args.put(DistCpAction.TARGET_ARG, "hdfs://nn2/test/target/dir1");
+    args.put(RULE_ID, "183");
     args.put("-pcat", "");
     args.put("-m", "16");
     args.put("-strategy", "dynamic");
@@ -192,88 +190,5 @@ public class TestDistCpAction extends MiniClusterHarness {
     Assert.assertTrue(distCpOptions.shouldSyncFolder());
     Assert.assertEquals(EnumSet.of(CHECKSUMTYPE, ACL, TIMES),
         distCpOptions.getPreserveAttributes());
-  }
-
-  @Test
-  public void testIntraClusterCopy() throws Exception {
-    testCopyToCluster(dfs, dfs);
-  }
-
-  @Test
-  public void testCopyToAnotherCluster() throws Exception {
-    // MiniDFSCluster from hadoop 2.7 doesn't implement AutoCloseable
-    MiniDFSCluster anotherCluster = null;
-    try {
-      anotherCluster = createAnotherCluster();
-      anotherCluster.waitActive();
-      FileSystem anotherFs = anotherCluster.getFileSystem();
-      testCopyToCluster(dfs, anotherFs);
-    } finally {
-      if (anotherCluster != null) {
-        anotherCluster.shutdown();
-      }
-    }
-  }
-
-  @Test
-  public void testCopyFromAnotherCluster() throws Exception {
-    MiniDFSCluster anotherCluster = null;
-    try {
-      anotherCluster = createAnotherCluster();
-      anotherCluster.waitActive();
-      FileSystem anotherFs = anotherCluster.getFileSystem();
-      testCopyToCluster(anotherFs, dfs);
-    } finally {
-      if (anotherCluster != null) {
-        anotherCluster.shutdown();
-      }
-    }
-  }
-
-  // todo inherit from MultiClusterHarness
-  private void testCopyToCluster(FileSystem sourceFs, FileSystem targetFs) throws Exception {
-    Map<String, String> args = new HashMap<>();
-    String sourcePath = sourceFs.getUri() + "/test/source/dir1";
-    String targetPath = targetFs.getUri() + "/test/target/";
-
-    args.put(DistCpAction.FILE_PATH, sourcePath);
-    args.put(DistCpAction.TARGET_ARG, targetPath);
-    DistCpAction action = createAction(args);
-
-    writeToFile(sourceFs, new Path(sourcePath + "/testFile1"), "data-1");
-    writeToFile(sourceFs, new Path(sourcePath + "/testFile2"), "another file data");
-    writeToFile(sourceFs, new Path(sourcePath + "/inner/testFile3"), "inner data");
-
-    action.execute();
-
-    assertFileContent(targetFs, new Path(targetPath + "/dir1/testFile1"), "data-1");
-    assertFileContent(targetFs, new Path(targetPath + "/dir1/testFile2"), "another file data");
-    assertFileContent(targetFs, new Path(targetPath + "/dir1/inner/testFile3"), "inner data");
-  }
-
-  private MiniDFSCluster createAnotherCluster() throws Exception {
-    Configuration clusterConfig = new Configuration(smartContext.getConf());
-    clusterConfig.set("hdfs.minidfs.basedir", tmpFolder.newFolder().getAbsolutePath());
-    return createCluster(clusterConfig);
-  }
-
-  private void assertFileContent(
-      final FileSystem fileSystem, final Path path, final String expectedData) throws IOException {
-    Assert.assertTrue(fileSystem.exists(path));
-    Assert.assertEquals(expectedData, readFromFile(fileSystem, path));
-  }
-
-  private void writeToFile(
-      final FileSystem fileSystem, final Path path, final String data) throws IOException {
-    fileSystem.mkdirs(path.getParent());
-    try (final FSDataOutputStream outputStream = fileSystem.create(path)) {
-      outputStream.writeUTF(data);
-    }
-  }
-
-  private String readFromFile(final FileSystem fileSystem, final Path path) throws IOException {
-    try (final FSDataInputStream inputStream = fileSystem.open(path)) {
-      return inputStream.readUTF();
-    }
   }
 }

--- a/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpMultiCluster.java
+++ b/smart-hadoop-support/smart-hadoop/src/test/java/org/smartdata/hdfs/action/TestDistCpMultiCluster.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hdfs.action;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSTestUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartdata.hdfs.MultiClusterHarness;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.smartdata.model.CmdletDescriptor.RULE_ID;
+
+/**
+ * Test for DistCpAction.
+ */
+public class TestDistCpMultiCluster extends MultiClusterHarness {
+  @Test
+  public void testCopyToTargetCluster() throws Exception {
+    testCopyToCluster(dfs, anotherDfs);
+  }
+
+  @Test
+  public void testCopyFromTargetCluster() throws Exception {
+    testCopyToCluster(anotherDfs, dfs);
+  }
+
+  @Test
+  public void testCopyToTargetClusterAsRuleAction() throws Exception {
+    testCopyToCluster(dfs, anotherDfs, ImmutableMap.of(RULE_ID, "123"));
+  }
+
+  private void testCopyToCluster(FileSystem sourceFs, FileSystem targetFs) throws Exception {
+    testCopyToCluster(sourceFs, targetFs, new HashMap<>());
+  }
+
+  private void testCopyToCluster(
+      FileSystem sourceFs, FileSystem targetFs, Map<String, String> additionalArgs) throws Exception {
+    Map<String, String> args = new HashMap<>();
+    String sourcePath = sourceFs.getUri() + "/test/source/dir1";
+    String targetPath = targetFs.getUri() + "/test/target/";
+
+    args.put(DistCpAction.FILE_PATH, sourcePath);
+    args.put(DistCpAction.TARGET_ARG, targetPath);
+    args.putAll(additionalArgs);
+    DistCpAction action = createAction(args);
+
+    writeToFile(sourceFs, new Path(sourcePath + "/testFile1"), "data-1");
+    writeToFile(sourceFs, new Path(sourcePath + "/testFile2"), "another file data");
+    writeToFile(sourceFs, new Path(sourcePath + "/inner/testFile3"), "inner data");
+
+    action.execute();
+
+    assertFileContent(targetFs, new Path(targetPath + "/dir1/testFile1"), "data-1");
+    assertFileContent(targetFs, new Path(targetPath + "/dir1/testFile2"), "another file data");
+    assertFileContent(targetFs, new Path(targetPath + "/dir1/inner/testFile3"), "inner data");
+  }
+
+  private DistCpAction createAction(Map<String, String> args) {
+    DistCpAction distCpAction = new DistCpAction();
+    distCpAction.setLocalFileSystem(dfs);
+    distCpAction.setContext(smartContext);
+    distCpAction.init(args);
+    return distCpAction;
+  }
+
+  private void assertFileContent(
+      final FileSystem fileSystem, final Path path, final String expectedData) throws IOException {
+    Assert.assertTrue(fileSystem.exists(path));
+    Assert.assertEquals(expectedData, new String(
+        DFSTestUtil.readFileAsBytes(fileSystem, path),
+        StandardCharsets.UTF_8));
+  }
+
+  private void writeToFile(
+      final FileSystem fileSystem, final Path path, final String data) throws IOException {
+    fileSystem.mkdirs(path.getParent());
+    DFSTestUtil.writeFile(fileSystem, path, data);
+  }
+}


### PR DESCRIPTION
SSM injects an implicit `-ruleId` argument to an action if it was triggered by a rule. It causes failures during the construction of DistCp arguments. Now, the mentioned option is filtered before building the arguments for DistCp call.