### PR TITLE
[ADH-7142] Fix HMS event applier retry mechanism

### DIFF
--- a/smart-hive-support/src/main/java/org/smartdata/hive/HiveMetastoreFetcherService.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/HiveMetastoreFetcherService.java
@@ -139,7 +139,6 @@ public class HiveMetastoreFetcherService extends AbstractService {
     DbHmsEventHandler delegate = new DbHmsEventHandler(hiveEventDao, retrySupport);
 
     return new CompositeHmsEventHandler(
-        retrySupport,
         transactionManager,
         new HmsIntermediateEventsResolver(hiveEventDao, eventFactory),
         delegate

--- a/smart-hive-support/src/main/java/org/smartdata/hive/handler/CompositeHmsEventHandler.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/handler/CompositeHmsEventHandler.java
@@ -23,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.smartdata.hive.fetch.HmsEventStreamRecord;
 import org.smartdata.hive.fetch.composite.HiveDiffSourceState;
 import org.smartdata.hive.fetch.composite.NewHiveSourceStateRecord;
-import org.smartdata.retry.RetrySupport;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -34,7 +33,6 @@ import static org.smartdata.hive.fetch.composite.HiveDiffSourceState.SNAPSHOT_ST
 
 @Slf4j
 public class CompositeHmsEventHandler implements HmsEventHandler {
-  private final RetrySupport retrySupport;
   private final PlatformTransactionManager transactionManager;
   private final HmsBufferingEventHandler intermediateEventsResolver;
   private final HmsEventHandler delegate;
@@ -43,11 +41,9 @@ public class CompositeHmsEventHandler implements HmsEventHandler {
 
   @lombok.Builder
   public CompositeHmsEventHandler(
-      RetrySupport retrySupport,
       PlatformTransactionManager transactionManager,
       HmsBufferingEventHandler intermediateEventsResolver,
       HmsEventHandler delegate) {
-    this.retrySupport = retrySupport;
     this.transactionManager = transactionManager;
     this.intermediateEventsResolver = intermediateEventsResolver;
     this.delegate = delegate;
@@ -57,7 +53,7 @@ public class CompositeHmsEventHandler implements HmsEventHandler {
   @Override
   public void handle(HmsEventStreamRecord record) throws Exception {
     try {
-      retrySupport.withRetries(() -> handleAction(record));
+      handleAction(record);
     } catch (Exception e) {
       recordsHandler.fail();
       throw e;

--- a/smart-hive-support/src/test/java/org/smartdata/hive/handler/CompositeHmsEventHandlerTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/handler/CompositeHmsEventHandlerTest.java
@@ -23,9 +23,6 @@ import lombok.Getter;
 import org.junit.Before;
 import org.junit.Test;
 import org.smartdata.hive.fetch.HmsEventStreamRecord;
-import org.smartdata.retry.PolicyBasedRetrySupport;
-import org.smartdata.retry.RetryException;
-import org.smartdata.retry.RetryPolicyFactory;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
@@ -64,8 +61,6 @@ public class CompositeHmsEventHandlerTest {
         .delegate(mockDiffCollectorDelegate)
         .intermediateEventsResolver(intermediateEventResolver)
         .transactionManager(transactionManager)
-        .retrySupport(new PolicyBasedRetrySupport(
-            RetryPolicyFactory.NO_RETRIES_POLICY, Thread::sleep))
         .build();
   }
 
@@ -181,7 +176,7 @@ public class CompositeHmsEventHandlerTest {
   }
 
   private void checkTxRollback(List<HmsEventStreamRecord> records) {
-    assertThrows(RetryException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       for (HmsEventStreamRecord record : records) {
         eventHandler.handle(record);
       }


### PR DESCRIPTION
Remove retry logic from `CompositeHmsEventHandler` to prevent infinite retry loops 