### PR TITLE
[ADH-7076] Support HMS objects filtering at the configuration level

### DIFF
--- a/smart-common/src/main/java/org/smartdata/model/PathChecker.java
+++ b/smart-common/src/main/java/org/smartdata/model/PathChecker.java
@@ -29,9 +29,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.StringJoiner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.smartdata.conf.SmartConfKeys.SMART_IGNORED_PATH_TEMPLATES_KEY;
 import static org.smartdata.conf.SmartConfKeys.SMART_IGNORE_DIRS_KEY;
@@ -41,7 +38,7 @@ import static org.smartdata.conf.SmartConfKeys.SMART_INTERNAL_PATH_TEMPLATES_KEY
 public class PathChecker {
   private static final String IGNORED_PATH_TEMPLATES_DELIMITER = ",";
 
-  private final ThreadLocal<Matcher> patternMatcherThreadLocal;
+  private final RegexFilterSupport filterSupport;
   private final List<String> coverDirs;
 
   public PathChecker(Configuration configuration) {
@@ -49,19 +46,12 @@ public class PathChecker {
   }
 
   public PathChecker(List<String> ignoredPathPatterns, List<String> coverDirs) {
-    StringJoiner patternBuilder = new StringJoiner("|", "(", ")");
-    ignoredPathPatterns.forEach(patternBuilder::add);
-
-    Pattern pattern = Pattern.compile(patternBuilder.toString());
-    this.patternMatcherThreadLocal =
-        ThreadLocal.withInitial(() -> pattern.matcher(""));
+    this.filterSupport = new RegexFilterSupport(ignoredPathPatterns);
     this.coverDirs = coverDirs;
   }
 
   public boolean isIgnored(String absolutePath) {
-    return patternMatcherThreadLocal.get()
-        .reset(absolutePath)
-        .find();
+    return filterSupport.matches(absolutePath);
   }
 
   public boolean isCovered(String absolutePath) {

--- a/smart-common/src/main/java/org/smartdata/model/RegexFilterSupport.java
+++ b/smart-common/src/main/java/org/smartdata/model/RegexFilterSupport.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.model;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.Collection;
+import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFilterSupport {
+  static final String DEFAULT_PATTERN = ".*";
+
+  private final ThreadLocal<Matcher> patternMatcherThreadLocal;
+
+  public RegexFilterSupport(Collection<String> patterns) {
+    Pattern pattern = Pattern.compile(buildPattern(patterns));
+    this.patternMatcherThreadLocal =
+        ThreadLocal.withInitial(() -> pattern.matcher(""));
+  }
+
+  public boolean matches(String value) {
+    return value != null
+        && patternMatcherThreadLocal.get()
+        .reset(value)
+        .find();
+  }
+
+  static String buildPattern(Collection<String> patterns) {
+    if (CollectionUtils.isEmpty(patterns)) {
+      return DEFAULT_PATTERN;
+    }
+
+    StringJoiner patternBuilder = new StringJoiner("|", "(", ")");
+    patterns.forEach(patternBuilder::add);
+    return patternBuilder.toString();
+  }
+}

--- a/smart-common/src/test/java/org/smartdata/model/RegexFilterSupportTest.java
+++ b/smart-common/src/test/java/org/smartdata/model/RegexFilterSupportTest.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartdata.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.smartdata.model.RegexFilterSupport.DEFAULT_PATTERN;
+
+@RunWith(Parameterized.class)
+public class RegexFilterSupportTest {
+  @Parameterized.Parameter
+  public List<String> patterns;
+
+  @Parameterized.Parameter(1)
+  public String expectedResult;
+
+  @Parameterized.Parameters(
+      name = "patterns = {0}, expectedResult = {1}")
+  public static Object[] parameters() {
+    return new Object[][]{
+        {Collections.emptyList(), DEFAULT_PATTERN},
+        {Collections.singletonList("first"), "(first)"},
+        {Arrays.asList("first", ".*second", ".*third.*"), "(first|.*second|.*third.*)"}
+    };
+  }
+
+  @Test
+  public void testBuildPattern() {
+    String pattern = RegexFilterSupport.buildPattern(patterns);
+    Assert.assertEquals(expectedResult, pattern);
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/HiveMetastoreFetcherService.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/HiveMetastoreFetcherService.java
@@ -32,6 +32,9 @@ import org.smartdata.hive.fetch.HmsEventSource;
 import org.smartdata.hive.fetch.HmsEventStream;
 import org.smartdata.hive.fetch.HmsInFlightEventSource;
 import org.smartdata.hive.fetch.composite.CompositeHmsEventSource;
+import org.smartdata.hive.fetch.enrich.HmsEventNameSetter;
+import org.smartdata.hive.fetch.filter.CompositeHmsEventFilter;
+import org.smartdata.hive.fetch.filter.HmsEventFilter;
 import org.smartdata.hive.handler.AsyncHmsEventStreamHandler;
 import org.smartdata.hive.handler.CompositeHmsEventHandler;
 import org.smartdata.hive.handler.DbHmsEventHandler;
@@ -47,6 +50,7 @@ import org.smartdata.retry.RetrySupport;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -148,10 +152,12 @@ public class HiveMetastoreFetcherService extends AbstractService {
   private HmsEventSource buildEventSource(
       Supplier<IMetaStoreClient> metaStoreClientSupplier,
       HiveNotificationEventFactory eventFactory) {
+    HmsEventFilter eventFilter = CompositeHmsEventFilter.fromConf(hiveSmartConf);
+
     return new CompositeHmsEventSource(
         metaStoreClientSupplier,
-        buildSnapshotEventSource(metaStoreClientSupplier, eventFactory),
-        buildInFlightEventSource(metaStoreClientSupplier),
+        buildSnapshotEventSource(metaStoreClientSupplier, eventFilter, eventFactory),
+        buildInFlightEventSource(metaStoreClientSupplier, eventFilter),
         scheduledExecutorService,
         hiveSmartConf.getFetchBatchSize()
     );
@@ -159,12 +165,14 @@ public class HiveMetastoreFetcherService extends AbstractService {
 
   private HmsSnapshotEventSource buildSnapshotEventSource(
       Supplier<IMetaStoreClient> metaStoreClientSupplier,
+      HmsEventFilter eventFilter,
       HiveNotificationEventFactory eventFactory) {
     ExecutorService executorService = Executors.newFixedThreadPool(
         hiveSmartConf.getSnapshotFetcherThreadsCount());
     return new HmsSnapshotEventSource(
         metaStoreClientSupplier,
         executorService,
+        eventFilter,
         eventFactory,
         hiveSmartConf
     );
@@ -186,14 +194,19 @@ public class HiveMetastoreFetcherService extends AbstractService {
   }
 
   private HmsInFlightEventSource buildInFlightEventSource(
-      Supplier<IMetaStoreClient> metaStoreClientSupplier) {
-    return new HmsInFlightEventSource(
-        metaStoreClientSupplier,
-        scheduledExecutorService,
-        hiveSmartConf.getFetchPeriodMs(),
-        hiveSmartConf.getFetchBatchSize(),
-        null
-    );
+      Supplier<IMetaStoreClient> metaStoreClientSupplier,
+      HmsEventFilter eventFilter) {
+    HmsEventNameSetter eventNameSetter =
+        new HmsEventNameSetter(GzipJSONMessageEncoder.getInstance());
+
+    return HmsInFlightEventSource.builder()
+        .metaStoreClientSupplier(metaStoreClientSupplier)
+        .executor(scheduledExecutorService)
+        .eventFilter(eventFilter)
+        .fetchPeriodMs(hiveSmartConf.getFetchPeriodMs())
+        .eventBatchSize(hiveSmartConf.getFetchBatchSize())
+        .eventEnrichers(Collections.singletonList(eventNameSetter))
+        .build();
   }
 
   private RetrySupport buildHandlerRetrySupport() {

--- a/smart-hive-support/src/main/java/org/smartdata/hive/HiveSmartConf.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/HiveSmartConf.java
@@ -20,6 +20,9 @@ package org.smartdata.hive;
 import org.apache.hadoop.conf.Configuration;
 import org.smartdata.retry.RetryStrategy;
 
+import java.util.Collection;
+import java.util.List;
+
 public class HiveSmartConf extends Configuration {
   private static final String HIVE_CONFIG_FILE = "hive-site.xml";
 
@@ -57,6 +60,9 @@ public class HiveSmartConf extends Configuration {
       "smart.hive.sync.progress.flush.interval.ms";
   public static final long HMS_SYNC_PROGRESS_FLUSH_INTERVAL_MS_DEFAULT = 5000;
 
+  public static final String HMS_EVENT_IGNORE_PATTERNS = "smart.hive.event.ignore.patterns";
+  public static final String HMS_EVENT_INCLUDE_PATTERNS = "smart.hive.event.include.patterns";
+
   public HiveSmartConf(Configuration conf) {
     super(conf);
 
@@ -90,6 +96,14 @@ public class HiveSmartConf extends Configuration {
 
   public int getSnapshotFetcherThreadsCount() {
     return getInt(HMS_SNAPSHOT_THREADS_COUNT, HMS_SNAPSHOT_THREADS_COUNT_DEFAULT);
+  }
+
+  public Collection<String> getEventIgnoredPatterns() {
+    return getStringCollection(HMS_EVENT_IGNORE_PATTERNS);
+  }
+
+  public Collection<String> getEventIncludePatterns() {
+    return getStringCollection(HMS_EVENT_INCLUDE_PATTERNS);
   }
 
   private void loadSystemProperties() {

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/BaseHmsEventSource.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/BaseHmsEventSource.java
@@ -18,11 +18,76 @@
 
 package org.smartdata.hive.fetch;
 
+import lombok.Getter;
+import org.smartdata.hive.fetch.enrich.HmsEventEnricher;
+import org.smartdata.hive.fetch.filter.HmsEventFilter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class BaseHmsEventSource implements HmsEventSource {
-  private final AtomicBoolean isClosed = new AtomicBoolean(false);
+  protected final HmsEventFilter eventFilter;
+  protected final List<HmsEventEnricher> eventEnrichers;
+
+  @Getter
+  protected final BlockingQueue<HmsEventStreamRecord> outputQueue;
+  @Getter
+  protected final BlockingQueue<HmsEventStreamRecord> ignoredEventsQueue;
+
+  private final AtomicBoolean isClosed;
+
+  protected BaseHmsEventSource(HmsEventFilter eventFilter,
+      int eventBatchSize, HmsEventEnricher... eventEnrichers) {
+    this(eventFilter, eventBatchSize, Arrays.asList(eventEnrichers));
+  }
+
+  protected BaseHmsEventSource(HmsEventFilter eventFilter,
+      int eventBatchSize, List<HmsEventEnricher> eventEnrichers) {
+    this.outputQueue = new ArrayBlockingQueue<>(eventBatchSize);
+    this.ignoredEventsQueue = new ArrayBlockingQueue<>(eventBatchSize);
+    this.isClosed = new AtomicBoolean(false);
+    this.eventFilter = eventFilter;
+    this.eventEnrichers = eventEnrichers;
+  }
+
+  protected void sendEvent(HmsEventStreamRecord record) throws InterruptedException {
+    if (record instanceof HiveNotificationEvent) {
+      sendEvent((HiveNotificationEvent) record);
+    } else {
+      outputQueue.put(record);
+    }
+  }
+
+  protected void sendEvent(HiveNotificationEvent event) throws InterruptedException {
+    HiveNotificationEvent enrichedEvent = enrichEvent(event);
+    if (eventFilter.test(enrichedEvent)) {
+      outputQueue.put(enrichedEvent);
+    } else {
+      sendIgnoredEvent(enrichedEvent);
+    }
+  }
+
+  protected void sendEof() {
+    outputQueue.add(HmsEventStreamRecord.endOfStreamRecord());
+    ignoredEventsQueue.add(HmsEventStreamRecord.endOfStreamRecord());
+  }
+
+  protected void sendIgnoredEvent(HmsEventStreamRecord record) throws InterruptedException {
+    ignoredEventsQueue.put(record);
+  }
+
+  protected void sendEofIfNotClosed() {
+    if (!isClosed.get()) {
+      sendEof();
+    }
+  }
+
+  protected HmsEventStream outputStream() {
+    return new HmsEventStream(outputQueue, ignoredEventsQueue);
+  }
 
   @Override
   public void close() {
@@ -33,13 +98,14 @@ public abstract class BaseHmsEventSource implements HmsEventSource {
 
   protected abstract void closeAction();
 
-  protected void closeQueue(BlockingQueue<HmsEventStreamRecord> outputQueue) {
-    if (!isClosed.get()) {
-      outputQueue.add(HmsEventStreamRecord.endOfStreamRecord());
-    }
-  }
-
   protected boolean isClosed() {
     return isClosed.get();
+  }
+
+  private HiveNotificationEvent enrichEvent(HiveNotificationEvent event) {
+    return eventEnrichers.stream()
+        .reduce(event,
+            (currentEvent, enricher) -> enricher.enrich(currentEvent),
+            (left, right) -> right);
   }
 }

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/HmsInFlightEventSource.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/HmsInFlightEventSource.java
@@ -23,10 +23,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
+import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
+import org.smartdata.hive.fetch.enrich.HmsEventEnricher;
+import org.smartdata.hive.fetch.enrich.HmsEventNameSetter;
+import org.smartdata.hive.fetch.filter.HmsEventFilter;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,10 +51,6 @@ public class HmsInFlightEventSource extends BaseHmsEventSource {
   @Getter(PROTECTED)
   private final Long endEventId;
 
-  @Getter(AccessLevel.PACKAGE)
-  private final BlockingQueue<HmsEventStreamRecord> outputQueue;
-  @Getter(AccessLevel.PACKAGE)
-  private final BlockingQueue<HmsEventStreamRecord> ignoredEventsQueue;
   private final AtomicBoolean pollStarted;
   private final AtomicBoolean pollFinished;
 
@@ -65,16 +64,17 @@ public class HmsInFlightEventSource extends BaseHmsEventSource {
   public HmsInFlightEventSource(
       Supplier<IMetaStoreClient> metaStoreClientSupplier,
       ScheduledExecutorService executor,
+      HmsEventFilter eventFilter,
       long fetchPeriodMs,
       int eventBatchSize,
-      Long endEventId
+      Long endEventId,
+      List<HmsEventEnricher> eventEnrichers
   ) {
+    super(eventFilter, eventBatchSize, eventEnrichers);
     this.metaStoreClientSupplier = metaStoreClientSupplier;
     this.executor = executor;
     this.fetchPeriodMs = fetchPeriodMs;
     this.eventBatchSize = eventBatchSize;
-    this.outputQueue = new ArrayBlockingQueue<>(eventBatchSize);
-    this.ignoredEventsQueue = new ArrayBlockingQueue<>(eventBatchSize);
     this.pollStarted = new AtomicBoolean(false);
     this.pollFinished = new AtomicBoolean(false);
     this.endEventId = endEventId;
@@ -94,7 +94,7 @@ public class HmsInFlightEventSource extends BaseHmsEventSource {
       executor.scheduleAtFixedRate(this::pollRecordsBatch,
           0L, fetchPeriodMs, TimeUnit.MILLISECONDS);
     }
-    return new HmsEventStream(outputQueue, ignoredEventsQueue);
+    return outputStream();
   }
 
   void pollRecordsBatch() {
@@ -122,8 +122,7 @@ public class HmsInFlightEventSource extends BaseHmsEventSource {
 
   @Override
   protected void closeAction() {
-    outputQueue.add(HmsEventStreamRecord.endOfStreamRecord());
-    ignoredEventsQueue.add(HmsEventStreamRecord.endOfStreamRecord());
+    sendEof();
   }
 
   private void pollRecordsBatchAction(IMetaStoreClient metaStoreClient) {
@@ -180,7 +179,7 @@ public class HmsInFlightEventSource extends BaseHmsEventSource {
         .eventType(eventOperation.getOperation().toString())
         .build();
 
-    outputQueue.put(ssmEvent);
+    sendEvent(ssmEvent);
   }
 
   private void handleIgnoredEvent(NotificationEvent event) throws InterruptedException {
@@ -189,6 +188,6 @@ public class HmsInFlightEventSource extends BaseHmsEventSource {
         .eventType(event.getEventType())
         .build();
 
-    ignoredEventsQueue.put(ignoredEvent);
+    sendIgnoredEvent(ignoredEvent);
   }
 }

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/composite/CompositeHmsEventSource.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/composite/CompositeHmsEventSource.java
@@ -18,8 +18,6 @@
 
 package org.smartdata.hive.fetch.composite;
 
-import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.smartdata.hive.fetch.BaseHmsEventSource;
@@ -27,11 +25,10 @@ import org.smartdata.hive.fetch.HmsEventSource;
 import org.smartdata.hive.fetch.HmsEventStream;
 import org.smartdata.hive.fetch.HmsEventStreamRecord;
 import org.smartdata.hive.fetch.HmsInFlightEventSource;
+import org.smartdata.hive.fetch.filter.HmsEventFilter;
 import org.smartdata.hive.snapshot.HmsSnapshotEventSource;
 
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,10 +47,6 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
   private final HmsInFlightEventSource eventFetcher;
   private final ExecutorService executor;
 
-  @Getter(AccessLevel.PACKAGE)
-  private final BlockingQueue<HmsEventStreamRecord> outputQueue;
-  @Getter(AccessLevel.PACKAGE)
-  private final BlockingQueue<HmsEventStreamRecord> unhandledOutputQueue;
   private final AtomicBoolean pollStarted;
 
   @lombok.Builder(builderClassName = "Builder")
@@ -64,12 +57,11 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
       ExecutorService executor,
       int eventBatchSize
   ) {
+    super(HmsEventFilter.noOp(), eventBatchSize);
     this.metaStoreClientSupplier = metaStoreClientSupplier;
     this.snapshotFetcher = snapshotFetcher;
     this.eventFetcher = eventFetcher;
     this.executor = executor;
-    this.outputQueue = new ArrayBlockingQueue<>(eventBatchSize);
-    this.unhandledOutputQueue = new ArrayBlockingQueue<>(eventBatchSize);
     this.pollStarted = new AtomicBoolean(false);
   }
 
@@ -79,7 +71,7 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
       log.info("Start composite hive metastore event fetcher");
       executor.submit(this::multiPhaseFetch);
     }
-    return new HmsEventStream(outputQueue, unhandledOutputQueue);
+    return outputStream();
   }
 
   @Override
@@ -88,7 +80,7 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
       log.info("Start simple hive metastore event fetcher");
       executor.submit(() -> fetchMetastoreEventsDirectly(fromEventId));
     }
-    return new HmsEventStream(outputQueue, unhandledOutputQueue);
+    return outputStream();
   }
 
   @Override
@@ -97,21 +89,20 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
       executor.shutdown();
     }
 
-    outputQueue.add(HmsEventStreamRecord.endOfStreamRecord());
-    unhandledOutputQueue.add(HmsEventStreamRecord.endOfStreamRecord());
+    sendEof();
   }
 
   void fetchMetastoreEventsDirectly(long fromEventId) {
     try {
-      outputQueue.put(newStateRecord(EVENTS_STARTED));
+      stateTransition(EVENTS_STARTED);
 
       log.info("Start fetching Hive events using event fetcher from id {}", fromEventId);
-      pollRecords(eventFetcher, fromEventId, true);
+      pollRecords(eventFetcher, fromEventId);
     } catch (Exception retryException) {
       log.error("Exiting HiveMetastoreEventFetcher due to error", retryException);
       close();
     } finally {
-      sendEof();
+      sendEofIfNotClosed();
     }
   }
 
@@ -119,10 +110,10 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
     try (IMetaStoreClient metaStoreClient = metaStoreClientSupplier.get()) {
       // 1. Snapshot phase
       log.info("Start fetching Hive entities using snapshot fetcher");
-      outputQueue.put(newStateRecord(SNAPSHOT_STARTED));
+      stateTransition(SNAPSHOT_STARTED);
 
       long eventIdBeforeSnapshot = metaStoreClient.getCurrentNotificationEventId().getEventId();
-      pollRecords(snapshotFetcher, eventIdBeforeSnapshot, false);
+      pollRecords(snapshotFetcher, eventIdBeforeSnapshot);
       long eventIdAfterSnapshot = metaStoreClient.getCurrentNotificationEventId().getEventId();
 
       log.info("Hive entities initial fetch successfully finished");
@@ -137,32 +128,34 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
       // 3. Hive metastore events phase
       log.info("Start fetching Hive entity diffs using event fetcher from id {}", eventIdAfterSnapshot);
 
-      outputQueue.put(newStateRecord(EVENTS_STARTED));
-      pollRecords(eventFetcher, eventIdAfterSnapshot, true);
+      stateTransition(EVENTS_STARTED);
+      pollRecords(eventFetcher, eventIdAfterSnapshot);
     } catch (Exception retryException) {
       log.error("Exiting HiveMetastoreEventFetcher due to error", retryException);
       close();
     } finally {
-      sendEof();
+      sendEofIfNotClosed();
     }
   }
 
   private void resolveUnhandledEvents(long eventIdBeforeSnapshot,
       long eventIdAfterSnapshot) throws Exception {
-    outputQueue.put(newStateRecord(INTERMEDIATE_EVENTS_STARTED));
+    stateTransition(INTERMEDIATE_EVENTS_STARTED);
 
     HmsInFlightEventSource unhandledEventsFetcher = eventFetcher.toFiniteFetcher(eventIdAfterSnapshot);
-    pollRecords(unhandledEventsFetcher, eventIdBeforeSnapshot, true);
+    pollRecords(unhandledEventsFetcher, eventIdBeforeSnapshot);
+  }
+
+  private void stateTransition(HiveDiffSourceState newState) throws InterruptedException {
+    outputQueue.put(newStateRecord(newState));
   }
 
   private void pollRecords(
       HmsEventSource fetcher,
-      long fromEventId,
-      boolean forwardUnprocessedRecords) {
+      long fromEventId) {
     HmsEventStream sourceStream = fetcher.eventStreamFrom(fromEventId);
-    Future<?> ignoredEventsFuture = forwardUnprocessedRecords
-        ? executor.submit(() -> handleUnprocessedEvents(sourceStream.getIgnoredEvents()))
-        : CompletableFuture.completedFuture(null);
+    Future<?> ignoredEventsFuture = executor.submit(
+        () -> handleUnprocessedEvents(sourceStream.getIgnoredEvents()));
 
     try {
       forwardEvents(sourceStream.getEvents(), outputQueue);
@@ -177,15 +170,11 @@ public class CompositeHmsEventSource extends BaseHmsEventSource {
 
   private void handleUnprocessedEvents(BlockingQueue<HmsEventStreamRecord> ignoredEvents) {
     try {
-      forwardEvents(ignoredEvents, unhandledOutputQueue);
+      forwardEvents(ignoredEvents, ignoredEventsQueue);
     } catch (InterruptedException e) {
+      ignoredEventsQueue.add(HmsEventStreamRecord.endOfStreamRecord());
       log.debug("Interrupting unprocessed events handler", e);
     }
-  }
-
-  private void sendEof() {
-    closeQueue(outputQueue);
-    closeQueue(unhandledOutputQueue);
   }
 
   private void forwardEvents(

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsEventEnricher.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsEventEnricher.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.enrich;
+
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+
+public interface HmsEventEnricher {
+  HiveNotificationEvent enrich(HiveNotificationEvent event);
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsEventNameSetter.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsEventNameSetter.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.enrich;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.metastore.messaging.CreateFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
+import org.smartdata.hive.fetch.HiveEntity;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+import org.smartdata.hive.fetch.HiveOperation;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.smartdata.hive.fetch.HiveNotificationEvent.fullResourceName;
+import static org.smartdata.hive.fetch.HiveOperation.CREATE;
+import static org.smartdata.hive.fetch.HiveOperation.DROP;
+import static org.smartdata.hive.snapshot.HiveNotificationEventFactory.fullName;
+
+@Slf4j
+@RequiredArgsConstructor
+public class HmsEventNameSetter implements HmsEventEnricher {
+  private final MessageEncoder messageEncoder;
+
+  @Override
+  public HiveNotificationEvent enrich(HiveNotificationEvent event) {
+    String newName = extractFullName(event);
+    return Objects.equals(newName, event.getFullName())
+        ? event
+        : event.toBuilder()
+        .fullName(newName)
+        .build();
+  }
+
+  private String extractFullName(HiveNotificationEvent event) {
+    return Optional.ofNullable(event.getEntityType())
+        .map(type -> EnumUtils.getEnum(HiveEntity.class, type))
+        .filter(HiveEntity.FUNCTION::equals)
+        .flatMap(ignore -> extractFunctionName(event))
+        .orElseGet(event::getFullName);
+  }
+
+  private Optional<String> extractFunctionName(HiveNotificationEvent event) {
+    return Optional.ofNullable(event.getEventType())
+        .map(type -> EnumUtils.getEnum(HiveOperation.class, type))
+        .map(operation -> extractFunctionName(event, operation));
+  }
+
+  private String extractFunctionName(HiveNotificationEvent event, HiveOperation operation) {
+    if (StringUtils.isBlank(event.getMessage())) {
+      return event.getFullName();
+    }
+
+    try {
+      if (operation == CREATE) {
+        CreateFunctionMessage msg = messageEncoder.getDeserializer()
+            .getCreateFunctionMessage(event.getMessage());
+        return fullName(msg.getFunctionObj());
+      }
+
+      if (operation == DROP) {
+        DropFunctionMessage msg = messageEncoder.getDeserializer()
+            .getDropFunctionMessage(event.getMessage());
+        return fullResourceName(msg.getDB(), msg.getFunctionName());
+      }
+    } catch (Exception e) {
+      log.error("Failed to parse event message {}", event, e);
+    }
+
+    return event.getFullName();
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/CompositeHmsEventFilter.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/CompositeHmsEventFilter.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.smartdata.hive.HiveSmartConf;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CompositeHmsEventFilter implements HmsEventFilter {
+  @Getter(AccessLevel.PACKAGE)
+  private final List<HmsEventFilter> delegates;
+
+  @Override
+  public boolean test(HiveNotificationEvent event) {
+    return delegates.stream()
+        .allMatch(delegate -> delegate.test(event));
+  }
+
+  public static HmsEventFilter fromConf(HiveSmartConf config) {
+    List<HmsEventFilter> delegates = new ArrayList<>();
+
+    HmsEventNameIncludeFilter.fromConf(config)
+        .ifPresent(delegates::add);
+    HmsEventNameIgnoreFilter.fromConf(config)
+        .ifPresent(delegates::add);
+
+    if (delegates.isEmpty()) {
+      return HmsEventFilter.noOp();
+    }
+
+    if (delegates.size() == 1) {
+      return delegates.get(0);
+    }
+
+    return new CompositeHmsEventFilter(delegates);
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/HmsEventFilter.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/HmsEventFilter.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+
+public interface HmsEventFilter {
+  HmsEventFilter NO_OP_FILTER = ignore -> true;
+
+  boolean test(HiveNotificationEvent event);
+
+  static HmsEventFilter noOp() {
+    return NO_OP_FILTER;
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/HmsEventNameIgnoreFilter.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/HmsEventNameIgnoreFilter.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.smartdata.hive.HiveSmartConf;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+import org.smartdata.model.RegexFilterSupport;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+public class HmsEventNameIgnoreFilter implements HmsEventFilter {
+  private final RegexFilterSupport filterSupport;
+
+  public HmsEventNameIgnoreFilter(String... ignorePatterns) {
+    this(Arrays.asList(ignorePatterns));
+  }
+
+  public HmsEventNameIgnoreFilter(Collection<String> ignorePatterns) {
+    this.filterSupport = new RegexFilterSupport(ignorePatterns);
+  }
+
+  @Override
+  public boolean test(HiveNotificationEvent event) {
+    return !filterSupport.matches(event.getFullName());
+  }
+
+  public static Optional<HmsEventFilter> fromConf(HiveSmartConf config) {
+    return Optional.ofNullable(config.getEventIgnoredPatterns())
+        .filter(CollectionUtils::isNotEmpty)
+        .map(HmsEventNameIgnoreFilter::new);
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/HmsEventNameIncludeFilter.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/filter/HmsEventNameIncludeFilter.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.smartdata.hive.HiveSmartConf;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+import org.smartdata.model.RegexFilterSupport;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public class HmsEventNameIncludeFilter implements HmsEventFilter {
+  private final RegexFilterSupport filterSupport;
+
+  public HmsEventNameIncludeFilter(Collection<String> ignorePatterns) {
+    this.filterSupport = new RegexFilterSupport(ignorePatterns);
+  }
+
+  @Override
+  public boolean test(HiveNotificationEvent event) {
+    return filterSupport.matches(event.getFullName());
+  }
+
+  public static Optional<HmsEventFilter> fromConf(HiveSmartConf config) {
+    return Optional.ofNullable(config.getEventIncludePatterns())
+        .filter(CollectionUtils::isNotEmpty)
+        .map(HmsEventNameIncludeFilter::new);
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/handler/CompositeHmsEventHandler.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/handler/CompositeHmsEventHandler.java
@@ -100,16 +100,16 @@ public class CompositeHmsEventHandler implements HmsEventHandler {
     }
   }
 
-  @RequiredArgsConstructor
   class SnapshotRecordsHandler implements RecordsHandler {
-    private TransactionStatus transactionStatus;
+    private final TransactionStatus transactionStatus;
+
+    public SnapshotRecordsHandler() {
+      this.transactionStatus = transactionManager.getTransaction(
+          new DefaultTransactionDefinition());
+    }
 
     @Override
     public void handle(HmsEventStreamRecord record) throws Exception {
-      if (transactionStatus == null) {
-        transactionStatus = transactionManager.getTransaction(
-            new DefaultTransactionDefinition());
-      }
       delegate.handle(record);
     }
 

--- a/smart-hive-support/src/main/java/org/smartdata/hive/snapshot/HmsSnapshotEventSource.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/snapshot/HmsSnapshotEventSource.java
@@ -18,7 +18,6 @@
 
 package org.smartdata.hive.snapshot;
 
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -33,12 +32,11 @@ import org.smartdata.hive.fetch.BaseHmsEventSource;
 import org.smartdata.hive.fetch.HiveNotificationEvent;
 import org.smartdata.hive.fetch.HmsEventStream;
 import org.smartdata.hive.fetch.HmsEventStreamRecord;
+import org.smartdata.hive.fetch.filter.HmsEventFilter;
 import org.smartdata.utils.ThrowingFunction;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -55,24 +53,22 @@ public class HmsSnapshotEventSource extends BaseHmsEventSource {
 
   private final Supplier<IMetaStoreClient> metaStoreClientProvider;
   private final ExecutorService executor;
+  private final HiveNotificationEventFactory eventFactory;
   private final String defaultCatalog;
 
-  @Getter
-  private final BlockingQueue<HmsEventStreamRecord> outputQueue;
   private final AtomicBoolean pollStarted;
-
-  private final HiveNotificationEventFactory eventFactory;
 
   @lombok.Builder(builderClassName = "Builder")
   public HmsSnapshotEventSource(
       Supplier<IMetaStoreClient> metaStoreClientProvider,
       ExecutorService executor,
+      HmsEventFilter eventFilter,
       HiveNotificationEventFactory eventFactory,
       HiveSmartConf hiveSmartConf
   ) {
+    super(eventFilter, hiveSmartConf.getFetchBatchSize());
     this.metaStoreClientProvider = metaStoreClientProvider;
     this.executor = executor;
-    this.outputQueue = new ArrayBlockingQueue<>(hiveSmartConf.getFetchBatchSize());
     this.eventFactory = eventFactory;
     this.pollStarted = new AtomicBoolean(false);
     this.defaultCatalog = MetaStoreUtils.getDefaultCatalog(hiveSmartConf);
@@ -88,12 +84,12 @@ public class HmsSnapshotEventSource extends BaseHmsEventSource {
     if (pollStarted.compareAndSet(false, true)) {
       pollRecordsBatchAsync(eventId);
     }
-    return HmsEventStream.withoutIgnoredEvents(outputQueue);
+    return outputStream();
   }
 
   @Override
   protected void closeAction() {
-    outputQueue.add(HmsEventStreamRecord.endOfStreamRecord());
+    sendEof();
     executor.shutdown();
   }
 
@@ -256,7 +252,7 @@ public class HmsSnapshotEventSource extends BaseHmsEventSource {
   private void send(HmsEventStreamRecord record) {
     try {
       throwIfClosed();
-      outputQueue.put(record);
+      sendEvent(record);
     } catch (InterruptedException e) {
       throw new RuntimeException("Thread interrupted during event send", e);
     }

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/HmsInFlightEventSourceTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/HmsInFlightEventSourceTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.smartdata.hive.EntityInfo;
+import org.smartdata.hive.fetch.filter.HmsEventNameIgnoreFilter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,6 +67,7 @@ import static org.smartdata.hive.fetch.HiveEntity.FUNCTION;
 import static org.smartdata.hive.fetch.HiveEntity.PARTITION;
 import static org.smartdata.hive.fetch.HiveEntity.TABLE;
 import static org.smartdata.hive.fetch.HiveOperation.CREATE;
+import static org.smartdata.hive.fetch.HiveOperation.DROP;
 
 public class HmsInFlightEventSourceTest {
 
@@ -84,6 +86,8 @@ public class HmsInFlightEventSourceTest {
         // we don't use executor in tests
         .fetchPeriodMs(-1)
         .eventBatchSize(10000)
+        .eventFilter(new HmsEventNameIgnoreFilter("ignore.*"))
+        .eventEnrichers(Collections.emptyList())
         .build();
 
     eventsHolder = new MetastoreEventsHolder();
@@ -107,15 +111,19 @@ public class HmsInFlightEventSourceTest {
         ssmIgnoredEvent(newEvent(8, "default.db.table77", COMMIT_TXN)),
         ssmIgnoredEvent(newEvent(9, "default.db", COMMIT_COMPACTION)),
         ssmIgnoredEvent(newEvent(12, "default.db.table78", "unknown_event_type")),
-        ssmIgnoredEvent(newEvent(15, "default.db.table78", UPDATE_PARTITION_COLUMN_STAT_BATCH)),
-        ssmIgnoredEvent(newEvent(18, "catalog1", DROP_CATALOG)),
-        ssmIgnoredEvent(newEvent(19, "default.db_schema", DROP_SCHEMA_VERSION)),
-        ssmIgnoredEvent(newEvent(20, "default.db_conn", CREATE_DATACONNECTOR))
+        ssmEvent(newCreateDbEvent(15, "default.ignored_db", "/ignored_db"), new EventOperation(DATABASE, CREATE)),
+        ssmIgnoredEvent(newEvent(16, "default.db.table78", UPDATE_PARTITION_COLUMN_STAT_BATCH)),
+        ssmEvent(newCreateDbEvent(17, "default.ignoreddb2", "/ignoreddb2"), new EventOperation(DATABASE, DROP)),
+        ssmEvent(newCreateTableEvent(20, "default.ignored_db.tb1", TableType.MANAGED_TABLE,
+            "/db/ignored_db/tb1"), new EventOperation(TABLE, CREATE)),
+        ssmIgnoredEvent(newEvent(21, "catalog1", DROP_CATALOG)),
+        ssmIgnoredEvent(newEvent(22, "default.db_schema", DROP_SCHEMA_VERSION)),
+        ssmIgnoredEvent(newEvent(23, "default.db_conn", CREATE_DATACONNECTOR))
     );
     assertEquals(expectedIgnoredRecords, new ArrayList<>(eventFetcher.getIgnoredEventsQueue()));
 
     assertEquals(Collections.singletonList(0L), eventsHolder.requestedOffsetIds);
-    assertEquals(20L, eventFetcher.getLastHandledEventId());
+    assertEquals(23L, eventFetcher.getLastHandledEventId());
   }
 
   private List<HmsEventStreamRecord> getFetchedEvents() {
@@ -166,9 +174,9 @@ public class HmsInFlightEventSourceTest {
                 new EntityInfo("default.db.table3", "/db/table3"),
                 new EntityInfo("default.db.table3", "/other/location2")),
             new EventOperation(TABLE, HiveOperation.ALTER)),
-        ssmEvent(newEvent(16, "default.db.partitioned_table", ALTER_PARTITION),
+        ssmEvent(newEvent(18, "default.db.partitioned_table", ALTER_PARTITION),
             new EventOperation(PARTITION, HiveOperation.ALTER)),
-        ssmEvent(newEvent(17, "default.db2", CREATE_FUNCTION),
+        ssmEvent(newEvent(19, "default.db2", CREATE_FUNCTION),
             new EventOperation(FUNCTION, CREATE))
     );
   }
@@ -201,9 +209,13 @@ public class HmsInFlightEventSourceTest {
             TableType.EXTERNAL_TABLE,
             new EntityInfo("default.db.table3", "/db/table3"),
             new EntityInfo("default.db.table3", "/other/location2")),
+        newCreateDbEvent(idSeq.getAndIncrement(), "default.ignored_db", "/ignored_db"),
         newEvent(idSeq.getAndIncrement(), "default.db.table78", UPDATE_PARTITION_COLUMN_STAT_BATCH),
+        newDropDbEvent(idSeq.getAndIncrement(), "default.ignoreddb2", "/ignoreddb2"),
         newEvent(idSeq.getAndIncrement(), "default.db.partitioned_table", ALTER_PARTITION),
         newEvent(idSeq.getAndIncrement(), "default.db2", CREATE_FUNCTION),
+        newCreateTableEvent(idSeq.getAndIncrement(), "default.ignored_db.tb1", TableType.MANAGED_TABLE,
+            "/db/ignored_db/tb1"),
         newEvent(idSeq.getAndIncrement(), "catalog1", DROP_CATALOG),
         newEvent(idSeq.getAndIncrement(), "default.db_schema", DROP_SCHEMA_VERSION),
         newEvent(idSeq.getAndIncrement(), "default.db_conn", CREATE_DATACONNECTOR)

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/composite/CompositeHmsEventSourceTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/composite/CompositeHmsEventSourceTest.java
@@ -23,12 +23,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
+import org.apache.hadoop.hive.metastore.messaging.json.gzip.GzipJSONMessageEncoder;
 import org.junit.Test;
 import org.smartdata.conf.SmartConf;
 import org.smartdata.hive.HiveSmartConf;
 import org.smartdata.hive.fetch.HmsEventStream;
 import org.smartdata.hive.fetch.HmsEventStreamRecord;
 import org.smartdata.hive.fetch.HmsInFlightEventSource;
+import org.smartdata.hive.fetch.filter.HmsEventFilter;
 import org.smartdata.hive.snapshot.HmsSnapshotEventSource;
 
 import java.util.ArrayList;
@@ -209,7 +211,7 @@ public class CompositeHmsEventSourceTest {
 
     public MockSnapshotFetcher(List<HmsEventStreamRecord> records) {
       super(null, Executors.newSingleThreadExecutor(),
-          null, new HiveSmartConf(new SmartConf()));
+          HmsEventFilter.noOp(), null, new HiveSmartConf(new SmartConf()));
       this.records = new ArrayBlockingQueue<>(records.size() + 1);
       this.records.addAll(records);
       this.records.add(HmsEventStreamRecord.endOfStreamRecord());
@@ -241,7 +243,7 @@ public class CompositeHmsEventSourceTest {
     private MockEventFetcher(
         BlockingQueue<HmsEventStreamRecord> records,
         Long endEventId) {
-      super(null, null, 0, 1, endEventId);
+      super(null, null, HmsEventFilter.noOp(), 0, 1, endEventId, Collections.emptyList());
       this.records = records;
     }
 

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/enrich/HmsEventNameSetterTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/enrich/HmsEventNameSetterTest.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.enrich;
+
+import org.apache.hadoop.hive.metastore.messaging.CreateDatabaseMessage;
+import org.apache.hadoop.hive.metastore.messaging.CreateFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.DropFunctionMessage;
+import org.apache.hadoop.hive.metastore.messaging.EventMessage;
+import org.apache.hadoop.hive.metastore.messaging.MessageBuilder;
+import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
+import org.apache.hadoop.hive.metastore.messaging.json.JSONMessageEncoder;
+import org.junit.Before;
+import org.junit.Test;
+import org.smartdata.hive.fetch.HiveEntity;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+import org.smartdata.hive.fetch.HiveOperation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.smartdata.hive.HiveEntityFactory.buildDb;
+import static org.smartdata.hive.HiveEntityFactory.buildFunction;
+
+public class HmsEventNameSetterTest {
+
+  private HmsEventNameSetter eventNameSetter;
+  private MessageEncoder messageEncoder;
+
+  @Before
+  public void setUp() {
+    this.messageEncoder = JSONMessageEncoder.getInstance();
+    this.eventNameSetter = new HmsEventNameSetter(messageEncoder);
+  }
+
+  @Test
+  public void testUpdateNameInCreateFunctionEvent() {
+    CreateFunctionMessage message = MessageBuilder.getInstance()
+        .buildCreateFunctionMessage(buildFunction("hive.db.function1"));
+    testUpdateNameInFunctionEvent(message, HiveOperation.CREATE, "db.function1");
+  }
+
+  @Test
+  public void testUpdateNameInDropFunctionEvent() {
+    DropFunctionMessage message = MessageBuilder.getInstance()
+        .buildDropFunctionMessage(buildFunction("hive.db.function2"));
+    testUpdateNameInFunctionEvent(message, HiveOperation.DROP, "db.function2");
+  }
+
+  @Test
+  public void testReturnOldNameByDefault() {
+    CreateDatabaseMessage message = MessageBuilder.getInstance()
+        .buildCreateDatabaseMessage(buildDb("hive.db", "/loc"));
+
+    String serializedMessage = messageEncoder.getSerializer().serialize(message);
+
+    HiveNotificationEvent functionEvent = HiveNotificationEvent
+        .builder()
+        .fullName("db")
+        .entityType(HiveEntity.DATABASE.name())
+        .eventType(HiveOperation.CREATE.name())
+        .message(serializedMessage)
+        .messageFormat(messageEncoder.getMessageFormat())
+        .build();
+    HiveNotificationEvent enrichedEvent = eventNameSetter.enrich(functionEvent);
+    assertEquals("db", enrichedEvent.getFullName());
+  }
+
+  @Test
+  public void testReturnOldNameForEmptyEvent() {
+    HiveNotificationEvent functionEvent = HiveNotificationEvent.builder().build();
+    HiveNotificationEvent enrichedEvent = eventNameSetter.enrich(functionEvent);
+    assertNull(enrichedEvent.getFullName());
+  }
+
+  private void testUpdateNameInFunctionEvent(EventMessage message, HiveOperation operation, String expectedName) {
+    String serializedMessage = messageEncoder.getSerializer().serialize(message);
+
+    HiveNotificationEvent functionEvent = HiveNotificationEvent
+        .builder()
+        .fullName("db")
+        .entityType(HiveEntity.FUNCTION.name())
+        .eventType(operation.name())
+        .message(serializedMessage)
+        .messageFormat(messageEncoder.getMessageFormat())
+        .build();
+    HiveNotificationEvent enrichedEvent = eventNameSetter.enrich(functionEvent);
+    assertEquals(expectedName, enrichedEvent.getFullName());
+  }
+}

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/CompositeHmsEventNameFilterTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/CompositeHmsEventNameFilterTest.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.smartdata.hive.HiveSmartConf;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.smartdata.hive.HiveSmartConf.HMS_EVENT_IGNORE_PATTERNS;
+import static org.smartdata.hive.HiveSmartConf.HMS_EVENT_INCLUDE_PATTERNS;
+import static org.smartdata.hive.fetch.filter.HmsEventFilter.NO_OP_FILTER;
+
+@RunWith(Parameterized.class)
+public class CompositeHmsEventNameFilterTest {
+  @Parameterized.Parameter
+  public String inputString;
+  @Parameterized.Parameter(1)
+  public boolean expectedResult;
+
+  @Parameterized.Parameters(
+      name = "inputString = {0}, expectedResult = {1}")
+  public static Object[] parameters() {
+    return new Object[][]{
+        {"include", true},
+        {"include1", true},
+        {"3.include1", true},
+        {"include.ignore", false},
+        {"another", false},
+        {"another.ignore", false},
+        {"another.ignored", false},
+        {"another.include.", true},
+    };
+  }
+
+  @Test
+  public void testInputValue() {
+    HiveNotificationEvent event = HiveNotificationEvent.builder()
+        .fullName(inputString)
+        .build();
+    boolean actualResult = buildFilter().test(event);
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void testBuildFilterFromConf() {
+    Configuration configuration = new Configuration();
+    configuration.set(HMS_EVENT_IGNORE_PATTERNS, ".*ignore.*,db1.*");
+    configuration.set(HMS_EVENT_INCLUDE_PATTERNS, ".*include.*,db1.*");
+    HmsEventFilter filter = CompositeHmsEventFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertTrue(filter instanceof CompositeHmsEventFilter);
+    CompositeHmsEventFilter compositeFilter = (CompositeHmsEventFilter) filter;
+    assertEquals(2, compositeFilter.getDelegates().size());
+  }
+
+  @Test
+  public void testUnwrapIgnoreFilter() {
+    Configuration configuration = new Configuration();
+    configuration.set(HMS_EVENT_IGNORE_PATTERNS, ".*ignore.*,db1.*");
+    HmsEventFilter filter = CompositeHmsEventFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertTrue(filter instanceof HmsEventNameIgnoreFilter);
+  }
+
+  @Test
+  public void testUnwrapIncludeFilter() {
+    Configuration configuration = new Configuration();
+    configuration.set(HMS_EVENT_INCLUDE_PATTERNS, ".*include.*,db1.*");
+    HmsEventFilter filter = CompositeHmsEventFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertTrue(filter instanceof HmsEventNameIncludeFilter);
+  }
+
+  @Test
+  public void testNoOpFilterFromConfig() {
+    Configuration configuration = new Configuration();
+    HmsEventFilter filter = CompositeHmsEventFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertEquals(NO_OP_FILTER, filter);
+  }
+
+  protected HmsEventFilter buildFilter() {
+    List<HmsEventFilter> filters = Arrays.asList(
+        new NameContainsFilter("include"),
+        new NameNotContainsFilter("ignore")
+    );
+    return new CompositeHmsEventFilter(filters);
+  }
+
+  @RequiredArgsConstructor
+  private static class NameContainsFilter implements HmsEventFilter {
+
+    private final String value;
+
+    @Override
+    public boolean test(HiveNotificationEvent event) {
+      return event.getFullName().contains(value);
+    }
+  }
+
+  @RequiredArgsConstructor
+  private static class NameNotContainsFilter implements HmsEventFilter {
+
+    private final String value;
+
+    @Override
+    public boolean test(HiveNotificationEvent event) {
+      return !event.getFullName().contains(value);
+    }
+  }
+}

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/HmsEventNameFilterBaseTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/HmsEventNameFilterBaseTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import lombok.RequiredArgsConstructor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public abstract class HmsEventNameFilterBaseTest {
+  @Parameterized.Parameter
+  public List<String> patterns;
+  @Parameterized.Parameter(1)
+  public String inputString;
+  @Parameterized.Parameter(2)
+  public boolean expectedResult;
+
+  @Test
+  public void testInputValue() {
+    HmsEventFilter filter = buildFilter(patterns);
+    HiveNotificationEvent event = HiveNotificationEvent.builder()
+        .fullName(inputString)
+        .build();
+    boolean actualResult = filter.test(event);
+    assertEquals(expectedResult, actualResult);
+  }
+
+  protected abstract HmsEventFilter buildFilter(List<String> patterns);
+
+  @RequiredArgsConstructor
+  static class Parameters {
+    protected final List<String> patterns;
+    protected String inputString = "";
+    protected boolean expectedResult;
+
+    public static Parameters patterns(String... templates) {
+      return new Parameters(Arrays.asList(templates));
+    }
+
+    public Object[] shouldIgnore(String inputString) {
+      this.inputString = inputString;
+      this.expectedResult = false;
+      return asJunitParameters();
+    }
+
+    public Object[] shouldAccept(String inputString) {
+      this.inputString = inputString;
+      this.expectedResult = true;
+      return asJunitParameters();
+    }
+
+    protected Object[] asJunitParameters() {
+      return new Object[]{patterns, inputString, expectedResult};
+    }
+  }
+}

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/HmsEventNameIgnoreFilterTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/HmsEventNameIgnoreFilterTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.smartdata.hive.HiveSmartConf;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.smartdata.hive.HiveSmartConf.HMS_EVENT_IGNORE_PATTERNS;
+import static org.smartdata.hive.fetch.filter.HmsEventNameFilterBaseTest.Parameters.patterns;
+
+public class HmsEventNameIgnoreFilterTest extends HmsEventNameFilterBaseTest {
+  @Parameterized.Parameters(
+      name = "patterns = {0}, inputString = {1}, expectedResult = {2}")
+  public static Object[] parameters() {
+    return new Object[][]{
+        patterns("ignore.*").shouldIgnore("ignore"),
+        patterns("ignore.*").shouldIgnore("ignore.tb1"),
+        patterns("ignore.*").shouldIgnore("ignored.tb1"),
+        patterns("ignore.*").shouldIgnore("ignore.ignore"),
+        patterns("ignore.*").shouldAccept("ignor"),
+        patterns("ignore.*").shouldAccept("ignor.tb"),
+        patterns("ignore.*").shouldAccept("another_db"),
+
+        patterns(".*ignore.*").shouldIgnore("db.ignore"),
+        patterns(".*ignore.*").shouldIgnore("db.ignored"),
+        patterns(".*ignore.*").shouldIgnore("ignore"),
+        patterns(".*ignore.*").shouldIgnore("ignore.tb1"),
+        patterns(".*ignore.*").shouldIgnore("db.tb.ignored_partition"),
+        patterns(".*ignore.*").shouldAccept("ignor.tb"),
+        patterns(".*ignore.*").shouldAccept("another_db.ignor"),
+        patterns(".*ignore.*").shouldAccept("another_db"),
+        patterns(".*ignore.*").shouldAccept("another_db.ignor"),
+
+        patterns("db1.*tbl.*", ".*db2.*").shouldIgnore("db1.tbl1"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldIgnore("db2"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldIgnore("other.db2.t1"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldAccept("db3"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldAccept("db3.t1"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldAccept("db1"),
+    };
+  }
+
+  @Test
+  public void testBuildFilterFromConfig() {
+    Configuration configuration = new Configuration();
+    configuration.set(HMS_EVENT_IGNORE_PATTERNS, ".*ignore.*,db1.*");
+    Optional<HmsEventFilter> hmsEventFilter = HmsEventNameIgnoreFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertTrue(hmsEventFilter.isPresent());
+  }
+
+  @Test
+  public void testNoOpFilterFromConfig() {
+    Configuration configuration = new Configuration();
+    Optional<HmsEventFilter> hmsEventFilter = HmsEventNameIgnoreFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertFalse(hmsEventFilter.isPresent());
+  }
+
+  @Override
+  protected HmsEventFilter buildFilter(List<String> patterns) {
+    return new HmsEventNameIgnoreFilter(patterns);
+  }
+}

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/HmsEventNameIncludeFilterTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/filter/HmsEventNameIncludeFilterTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.filter;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.smartdata.hive.HiveSmartConf;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.smartdata.hive.HiveSmartConf.HMS_EVENT_INCLUDE_PATTERNS;
+import static org.smartdata.hive.fetch.filter.HmsEventNameFilterBaseTest.Parameters.patterns;
+
+public class HmsEventNameIncludeFilterTest extends HmsEventNameFilterBaseTest {
+  @Parameterized.Parameters(
+      name = "patterns = {0}, inputString = {1}, expectedResult = {2}")
+  public static Object[] parameters() {
+    return new Object[][]{
+        patterns("include.*").shouldAccept("include"),
+        patterns("include.*").shouldAccept("include.tb1"),
+        patterns("include.*").shouldAccept("included.tb1"),
+        patterns("include.*").shouldAccept("include.include"),
+        patterns("include.*").shouldIgnore("includ"),
+        patterns("include.*").shouldIgnore("includ.tb"),
+        patterns("include.*").shouldIgnore("another_db"),
+
+        patterns(".*include.*").shouldAccept("db.include"),
+        patterns(".*include.*").shouldAccept("db.included"),
+        patterns(".*include.*").shouldAccept("include"),
+        patterns(".*include.*").shouldAccept("include.tb1"),
+        patterns(".*include.*").shouldAccept("db.tb.included_partition"),
+        patterns(".*include.*").shouldIgnore("another_db.includ"),
+        patterns(".*include.*").shouldIgnore("ignor.tb"),
+        patterns(".*include.*").shouldIgnore("another_db"),
+        patterns(".*include.*").shouldIgnore("another_db.includ"),
+
+        patterns("db1.*tbl.*", ".*db2.*").shouldAccept("db1.tbl1"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldAccept("db2"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldAccept("other.db2.t1"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldIgnore("db3"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldIgnore("db3.t1"),
+        patterns("db1.*tbl.*", ".*db2.*").shouldIgnore("db1"),
+    };
+  }
+
+  @Test
+  public void testBuildFilterFromConfig() {
+    Configuration configuration = new Configuration();
+    configuration.set(HMS_EVENT_INCLUDE_PATTERNS, ".*ignore.*,db1.*");
+    Optional<HmsEventFilter> hmsEventFilter = HmsEventNameIncludeFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertTrue(hmsEventFilter.isPresent());
+  }
+
+  @Test
+  public void testNoOpFilterFromConfig() {
+    Configuration configuration = new Configuration();
+    Optional<HmsEventFilter> hmsEventFilter = HmsEventNameIncludeFilter.fromConf(
+        new HiveSmartConf(configuration));
+
+    assertFalse(hmsEventFilter.isPresent());
+  }
+
+
+  @Override
+  protected HmsEventFilter buildFilter(List<String> patterns) {
+    return new HmsEventNameIncludeFilter(patterns);
+  }
+}

--- a/smart-hive-support/src/test/java/org/smartdata/hive/snapshot/HmsSnapshotEventSourceTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/snapshot/HmsSnapshotEventSourceTest.java
@@ -38,6 +38,7 @@ import org.smartdata.hive.HiveSmartConf;
 import org.smartdata.hive.fetch.HiveEntity;
 import org.smartdata.hive.fetch.HiveNotificationEvent;
 import org.smartdata.hive.fetch.HiveOperation;
+import org.smartdata.hive.fetch.filter.HmsEventNameIgnoreFilter;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -83,15 +84,19 @@ public class HmsSnapshotEventSourceTest {
   private final static int FUNCTION_COUNT = 16;
   private final static int CONSTRAINT_PER_TABLE_COUNT = 6;
 
-  private final static int TOTAL_EVENTS_COUNT = DB_COUNT
-      // tables
-      + DB_COUNT * TABLE_PER_DB_COUNT
-      // partitions
-      + DB_COUNT * TABLE_PER_DB_COUNT * PARTITION_PER_TABLE_COUNT
-      // constraints
-      + DB_COUNT * TABLE_PER_DB_COUNT * CONSTRAINT_PER_TABLE_COUNT
-      // functions
-      + FUNCTION_COUNT;
+  private final static int TOTAL_EVENTS_PER_TABLE_COUNT =
+      1 + PARTITION_PER_TABLE_COUNT + CONSTRAINT_PER_TABLE_COUNT;
+
+  private final static int TOTAL_EVENTS_PER_DB_COUNT =
+      1 + TABLE_PER_DB_COUNT * TOTAL_EVENTS_PER_TABLE_COUNT;
+
+  private final static int TOTAL_EVENTS_COUNT =
+      DB_COUNT * TOTAL_EVENTS_PER_DB_COUNT + FUNCTION_COUNT;
+
+  private final static String IGNORED_ENTITIES_PATTERN = "ignore";
+  private final static int TOTAL_IGNORED_EVENTS_COUNT =
+      // 2 ignored dbs + 1 ignored function
+      2 * TOTAL_EVENTS_PER_DB_COUNT + 1;
 
   private MockMetastoreClient metaStoreClient;
   private ExecutorService executorService;
@@ -112,6 +117,7 @@ public class HmsSnapshotEventSourceTest {
         .metaStoreClientProvider(() -> metaStoreClient.delegate)
         .executor(executorService)
         .eventFactory(new HiveNotificationEventFactory(GzipJSONMessageEncoder.getInstance()))
+        .eventFilter(new HmsEventNameIgnoreFilter("ignore.*"))
         .hiveSmartConf(conf)
         .build();
   }
@@ -135,15 +141,20 @@ public class HmsSnapshotEventSourceTest {
 
     assertEquals(TOTAL_EVENTS_COUNT, actualEvents.size());
     assertEquals(metaStoreClient.getExpectedEvents(), actualEvents);
+    assertEquals(TOTAL_IGNORED_EVENTS_COUNT, snapshotEventSource.getIgnoredEventsQueue().size());
   }
 
   private Map<String, DbInfo> buildDbs() {
-    return IntStream.range(0, DB_COUNT)
+    Map<String, DbInfo> dbs = IntStream.range(0, DB_COUNT)
         .mapToObj(i -> buildDbInfo("db_" + i))
         .collect(Collectors.toMap(
             db -> db.getDelegate().getName(),
             db -> db
         ));
+
+    dbs.put("ignored_db", buildDbInfo("ignored_db"));
+    dbs.put("ignoreddb2", buildDbInfo("ignoreddb2"));
+    return dbs;
   }
 
   private DbInfo buildDbInfo(String dbName) {
@@ -202,9 +213,12 @@ public class HmsSnapshotEventSourceTest {
   }
 
   private List<Function> buildFunctions() {
-    return IntStream.range(0, FUNCTION_COUNT)
+    List<Function> functions = IntStream.range(0, FUNCTION_COUNT)
         .mapToObj(i -> buildFunction("hive.db.function_" + i))
         .collect(Collectors.toList());
+
+    functions.add(buildFunction("hive.ignored_db.function_1"));
+    return functions;
   }
 
   @Data
@@ -285,6 +299,7 @@ public class HmsSnapshotEventSourceTest {
 
     private Set<EventInfo> functionExpectedEvents() {
       return functions.stream()
+          .filter(function -> !fullName(function).contains(IGNORED_ENTITIES_PATTERN))
           .map(function -> EventInfo.of(HiveEntity.FUNCTION, fullName(function)))
           .collect(Collectors.toSet());
     }
@@ -292,6 +307,7 @@ public class HmsSnapshotEventSourceTest {
     private Set<EventInfo> dbsExpectedEvents() {
       return dbs.values()
           .stream()
+          .filter(db -> !db.delegate.getName().contains(IGNORED_ENTITIES_PATTERN))
           .flatMap(db -> dbExpectedEvents(db).stream())
           .collect(Collectors.toSet());
     }
@@ -299,6 +315,7 @@ public class HmsSnapshotEventSourceTest {
     private Set<EventInfo> dbExpectedEvents(DbInfo dbInfo) {
       Set<EventInfo> events = dbInfo.getTables().values()
           .stream()
+          .filter(table -> !fullName(table.delegate).contains(IGNORED_ENTITIES_PATTERN))
           .flatMap(table -> tableExpectedEvents(table).stream())
           .collect(Collectors.toSet());
       events.add(EventInfo.of(HiveEntity.DATABASE, dbInfo.delegate.getName()));


### PR DESCRIPTION
- Added `smart.hive.event.ignore.patterns` option to define the Java regex patterns for event entity names that should be ignored by SSM. Default is an empty list of patterns, which means we accept all events.
- Added `smart.hive.event.include.patterns` option to define the Java regex patterns for event entity names that should be included by SSM. Default is an empty list of patterns, which means we accept all events. 