### PR TITLE
[ADH-7078] Add a new SKIP schedule result

### DIFF
--- a/build-project.sh
+++ b/build-project.sh
@@ -3,5 +3,5 @@ set -e
 
 HDFS_VERSION=$1
 
-mvn install:install-file -pl smart-tests
-mvn clean install -Pdist,web-ui,hadoop-"${HDFS_VERSION}" -DskipTests
+mvn install:install-file -pl smart-tests -Dos.arch=x86_64
+mvn clean install -Pdist,web-ui,hadoop-"${HDFS_VERSION}" -DskipTests -Dos.arch=x86_64

--- a/build-project.sh
+++ b/build-project.sh
@@ -3,5 +3,5 @@ set -e
 
 HDFS_VERSION=$1
 
-mvn install:install-file -pl smart-tests -Dos.arch=x86_64
-mvn clean install -Pdist,web-ui,hadoop-"${HDFS_VERSION}" -DskipTests -Dos.arch=x86_64
+mvn install:install-file -pl smart-tests
+mvn clean install -Pdist,web-ui,hadoop-"${HDFS_VERSION}" -DskipTests

--- a/smart-common/src/main/java/org/smartdata/model/action/ScheduleResult.java
+++ b/smart-common/src/main/java/org/smartdata/model/action/ScheduleResult.java
@@ -21,6 +21,7 @@ public enum ScheduleResult {
   SUCCESS,  // OK for dispatch
   SUCCESS_NO_EXECUTION,  // No need for further execution, mark the action finished successfully
   RETRY,    // Need re-schedule later
+  SKIP,
   FAIL;
 
   public static boolean isSuccessful(ScheduleResult result) {

--- a/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
+++ b/smart-engine/src/main/java/org/smartdata/server/engine/CmdletManager.java
@@ -540,6 +540,11 @@ public class CmdletManager extends AbstractService
           cmdletPurgeTask.onCmdletFinished();
           cmdletInfoHandler.onCmdletFinished(cmdlet, true);
           onCmdletStatusUpdate(statusFromCmdletInfo(cmdlet));
+          break;
+        case SKIP:
+          cmdlet.updateState(CmdletState.DISABLED);
+          cmdletInfoHandler.onCmdletFinished(cmdlet, true);
+          deleteCmdletInternal(cmdlet.getId());
       }
     } catch (Exception exception) {
       LOG.error("Error handling scheduling result for {}", cmdlet, exception);

--- a/smart-hive-support/src/main/java/org/smartdata/hive/HiveSmartConf.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/HiveSmartConf.java
@@ -47,9 +47,6 @@ public class HiveSmartConf extends Configuration {
   public static final String HMS_CLIENT_CACHE_TTL_MS = "smart.hive.client.cache.ttl.ms";
   public static final long HMS_CLIENT_CACHE_TTL_MS_DEFAULT = 120000L;
 
-  public static final String HMS_CLIENT_CACHE_INITIAL_CAPACITY = "smart.hive.client.cache.size.initial";
-  public static final int HMS_CLIENT_CACHE_INITIAL_CAPACITY_DEFAULT = 50;
-
   public static final String HMS_CLIENT_CACHE_MAX_CAPACITY = "smart.hive.client.cache.size.max";
   public static final int HMS_CLIENT_CACHE_MAX_CAPACITY_DEFAULT = 50;
 

--- a/smart-hive-support/src/main/java/org/smartdata/hive/action/HmsSyncScheduler.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/action/HmsSyncScheduler.java
@@ -160,25 +160,28 @@ public class HmsSyncScheduler extends ActionSchedulerService {
 
     boolean isNewAction = ruleState.eventsInProcessing.add(eventId);
     if (!isNewAction) {
-      log.info("Event {} is already in processing.", eventId);
+      log.debug("Event {} is already in processing.", eventId);
       return ScheduleResult.RETRY;
     }
 
     if (ruleState.handledEvents.contains(eventId)
         || eventId <= ruleState.eventIdWatermark.get()) {
-      log.info("Event with id {} has already been handled for rule {}, skipping",
+      log.debug("Event with id {} has already been handled for rule {}, skipping",
           eventId, ruleId(actionInfo));
       ruleState.eventsInProcessing.remove(eventId);
-      return ScheduleResult.SUCCESS_NO_EXECUTION;
+      return ScheduleResult.SKIP;
     }
 
     HiveNotificationEvent event = hmsEventDao.get(eventId);
-    boolean isNewLock = ruleState.entityLocks.putIfNoIntersectingLocks(trieKey(event), true);
-    if (!isNewLock) {
-      log.info("Entity {} is locked or has locked parent objects. Retrying later.", event.getFullName());
+    if (ruleState.isLocked(event) || ruleState.hasEventsToRetryForEntity(event)) {
+      log.debug("Entity {} is locked or has locked parent objects. Retrying later.", event.getFullName());
       ruleState.eventsInProcessing.remove(eventId);
+      ruleState.addRetryState(event);
       return ScheduleResult.RETRY;
     }
+
+    ruleState.putEntityLock(event);
+    ruleState.clearRetryState(event);
 
     actionInfo.getArgs().put(HmsSyncAction.ENTITY_NAME, event.getFullName());
     actionInfo.getArgs().put(HmsSyncAction.TABLE_NAME, event.getTableName());
@@ -187,8 +190,7 @@ public class HmsSyncScheduler extends ActionSchedulerService {
       handleEvent(event, action);
       return ScheduleResult.SUCCESS;
     } catch (Exception e) {
-      ruleState.eventsInProcessing.remove(eventId);
-      removeLock(ruleState, actionInfo);
+      ruleState.clearEventState(event);
 
       log.error("Error trying to schedule HMS event {}", event, e);
       return ScheduleResult.FAIL;
@@ -198,7 +200,7 @@ public class HmsSyncScheduler extends ActionSchedulerService {
   @Override
   public void onActionFinished(CmdletInfo cmdletInfo, ActionInfo actionInfo) {
     long eventId = eventId(actionInfo);
-    log.info("Event {} has been handled", eventId);
+    log.debug("Event {} has been handled", eventId);
 
     RuleState ruleState = getRuleState(actionInfo);
     ruleState.eventsInProcessing.remove(eventId);
@@ -206,7 +208,7 @@ public class HmsSyncScheduler extends ActionSchedulerService {
 
     try {
       // Set the watermark as the id just before the earliest event still in progress
-      updateWatermark(ruleState, ruleState.eventsInProcessing.first() - 1);
+      ruleState.updateWatermark(ruleState.eventsInProcessing.first() - 1);
     } catch (NoSuchElementException e) {
       // There is no way to check the size of eventsInProcessing and get
       // the first element from it atomically except pessimistic locks.
@@ -215,7 +217,7 @@ public class HmsSyncScheduler extends ActionSchedulerService {
       //
       // Set the watermark as the current maxHandledEventId in case
       // if the action with the highest event id finished earlier
-      updateWatermark(ruleState, getMaxHandledEventId(ruleState, eventId));
+      ruleState.updateWatermark(ruleState.getMaxHandledEventId(eventId));
     } finally {
       // Remove the entity lock only after setting the progress of the current rule
       // to cover the case when the same event is scheduled for any reason
@@ -225,6 +227,8 @@ public class HmsSyncScheduler extends ActionSchedulerService {
   }
 
   private void handleEvent(HiveNotificationEvent event, LaunchAction action) {
+    log.debug("Starting handling event: {}", event);
+
     action.getArgs().put(HmsSyncAction.EVENT_MESSAGE, event.getMessage());
     action.getArgs().put(HmsSyncAction.EVENT_MESSAGE_FORMAT, event.getMessageFormat());
 
@@ -236,6 +240,8 @@ public class HmsSyncScheduler extends ActionSchedulerService {
         .orElseThrow(() -> new IllegalArgumentException(
             "Unexpected Hive operation type: " + event.getEntityType() + " for entity: " + hiveEntity));
     actionBluePrint.mutate(action);
+
+    log.debug("Event successfully transformed to action '{}'", action);
   }
 
   @Override
@@ -263,7 +269,7 @@ public class HmsSyncScheduler extends ActionSchedulerService {
 
   private void removeLock(RuleState ruleState, ActionInfo actionInfo) {
     String entityName = getEntityName(actionInfo);
-    ruleState.entityLocks.remove(trieKey(entityName));
+    ruleState.removeLock(entityName);
   }
 
   private long eventId(ActionInfo actionInfo) {
@@ -285,29 +291,11 @@ public class HmsSyncScheduler extends ActionSchedulerService {
         });
   }
 
-  private long getMaxHandledEventId(RuleState ruleState, long defaultEventId) {
-    try {
-      return ruleState.handledEvents.last();
-    } catch (NoSuchElementException exception) {
-      // There is no way to check the size of handledEvents and get
-      // the last element from it atomically except pessimistic locks.
-      // We don't want to penalize the performance just for this case,
-      // so recover from the exception instead
-      return defaultEventId;
-    }
-  }
-
-  private void updateWatermark(RuleState ruleState, long eventId) {
-    long watermarkEventId = ruleState.eventIdWatermark
-        .updateAndGet(currentId -> Math.max(currentId, eventId));
-    ruleState.handledEvents
-        .removeIf(handledEventId -> handledEventId <= watermarkEventId);
-  }
-
   private RuleState getRuleState(ActionInfo actionInfo) {
     long ruleId = ruleId(actionInfo);
     return ruleStateMap.computeIfAbsent(ruleId, key -> {
-      throw new IllegalArgumentException("Unknown rule id, this should never happen");
+      throw new IllegalArgumentException(
+          "No rule id argument found, hms-sync action should only be used inside rules");
     });
   }
 
@@ -348,6 +336,77 @@ public class HmsSyncScheduler extends ActionSchedulerService {
     private final Trie<String, Boolean> entityLocks = Trie.synchronize(new DefaultTrie<>());
     // the max id of the handled event for which all prior events have also been handled
     private final AtomicLong eventIdWatermark = new AtomicLong(Long.MIN_VALUE);
+
+    // retry events state
+    private final NavigableSet<Long> retryEvents = new ConcurrentSkipListSet<>();
+    private final Trie<String, Long> retryEntityLocks = Trie.synchronize(new DefaultTrie<>());
+
+    void putEntityLock(HiveNotificationEvent event) {
+      entityLocks.putIfNoIntersectingLocks(trieKey(event), true);
+    }
+
+    boolean isLocked(HiveNotificationEvent event) {
+      return entityLocks.getIntersectingLock(trieKey(event)).isPresent();
+    }
+
+    boolean hasEventsToRetryForEntity(HiveNotificationEvent event) {
+      return retryEntityLocks
+          .getIntersectingLock(trieKey(event))
+          .map(lockEventId -> lockEventId != event.getId())
+          .orElse(false);
+    }
+
+    void addRetryState(HiveNotificationEvent event) {
+      retryEvents.add(event.getId());
+      retryEntityLocks.putIfNoIntersectingLocks(trieKey(event), event.getId());
+    }
+
+    void clearRetryState(HiveNotificationEvent event) {
+      retryEvents.remove(event.getId());
+      retryEntityLocks.remove(trieKey(event));
+    }
+
+    void clearEventState(HiveNotificationEvent event) {
+      eventsInProcessing.remove(event.getId());
+      removeLock(event.getFullName());
+      clearRetryState(event);
+    }
+
+    void removeLock(String entityName) {
+      entityLocks.remove(trieKey(entityName));
+    }
+
+    void updateWatermark(long eventId) {
+      long watermarkEventId = eventIdWatermark
+          .updateAndGet(currentId ->
+              Math.max(currentId, getLastHandledEventIdBeforeRetries(eventId)));
+      handledEvents
+          .removeIf(handledEventId -> handledEventId <= watermarkEventId);
+    }
+
+    private long getLastHandledEventIdBeforeRetries(long defaultEventId) {
+      try {
+        return retryEvents.first() - 1;
+      } catch (NoSuchElementException exception) {
+        // There is no way to check the size of handledEvents and get
+        // the last element from it atomically except pessimistic locks.
+        // We don't want to penalize the performance just for this case,
+        // so recover from the exception instead
+        return defaultEventId;
+      }
+    }
+
+    private long getMaxHandledEventId(long defaultEventId) {
+      try {
+        return handledEvents.last();
+      } catch (NoSuchElementException exception) {
+        // There is no way to check the size of handledEvents and get
+        // the last element from it atomically except pessimistic locks.
+        // We don't want to penalize the performance just for this case,
+        // so recover from the exception instead
+        return defaultEventId;
+      }
+    }
   }
 
   @Data

--- a/smart-hive-support/src/main/java/org/smartdata/hive/client/CachingMetaStoreClientProvider.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/client/CachingMetaStoreClientProvider.java
@@ -26,8 +26,6 @@ import org.smartdata.hdfs.impersonation.UserImpersonationStrategy;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.smartdata.hive.HiveSmartConf.HMS_CLIENT_CACHE_INITIAL_CAPACITY;
-import static org.smartdata.hive.HiveSmartConf.HMS_CLIENT_CACHE_INITIAL_CAPACITY_DEFAULT;
 import static org.smartdata.hive.HiveSmartConf.HMS_CLIENT_CACHE_MAX_CAPACITY;
 import static org.smartdata.hive.HiveSmartConf.HMS_CLIENT_CACHE_MAX_CAPACITY_DEFAULT;
 import static org.smartdata.hive.HiveSmartConf.HMS_CLIENT_CACHE_TTL_MS;
@@ -47,10 +45,12 @@ public class CachingMetaStoreClientProvider implements MetaStoreClientProvider {
     baseHiveConf.setTimeVar(HiveConf.ConfVars.METASTORE_CLIENT_CACHE_EXPIRY_TIME,
         configuration.getLong(HMS_CLIENT_CACHE_TTL_MS, HMS_CLIENT_CACHE_TTL_MS_DEFAULT),
         TimeUnit.MILLISECONDS);
+    int cacheCapacity = configuration.getInt(
+        HMS_CLIENT_CACHE_MAX_CAPACITY, HMS_CLIENT_CACHE_MAX_CAPACITY_DEFAULT);
     baseHiveConf.setIntVar(HiveConf.ConfVars.METASTORE_CLIENT_CACHE_INITIAL_CAPACITY,
-        configuration.getInt(HMS_CLIENT_CACHE_INITIAL_CAPACITY, HMS_CLIENT_CACHE_INITIAL_CAPACITY_DEFAULT));
+        cacheCapacity);
     baseHiveConf.setIntVar(HiveConf.ConfVars.METASTORE_CLIENT_CACHE_MAX_CAPACITY,
-        configuration.getInt(HMS_CLIENT_CACHE_MAX_CAPACITY, HMS_CLIENT_CACHE_MAX_CAPACITY_DEFAULT));
+        cacheCapacity);
   }
 
   @Override

--- a/smart-hive-support/src/main/java/org/smartdata/hive/util/DefaultTrie.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/util/DefaultTrie.java
@@ -20,8 +20,6 @@ package org.smartdata.hive.util;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayDeque;
-import java.util.LinkedList;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 
@@ -34,27 +32,8 @@ public class DefaultTrie<K, V> implements Trie<K, V> {
   }
 
   @Override
-  public boolean hasPrefixValues(Key<K> key) {
-    DefaultTrieNode<K, V> iter = root;
-    for (K segment : key.getSegments()) {
-      Optional<DefaultTrieNode<K, V>> child = iter.getChild(segment);
-      if (!child.isPresent()) {
-        break;
-      }
-
-      if (child.get().getValue() != null) {
-        return true;
-      }
-
-      iter = child.get();
-    }
-
-    return false;
-  }
-
-  @Override
   public boolean putIfNoIntersectingLocks(Trie.Key<K> key, V value) {
-    if (hasPrefixValues(key) || hasChildValues(key)) {
+    if (getIntersectingLock(key).isPresent()) {
       return false;
     }
 
@@ -63,31 +42,54 @@ public class DefaultTrie<K, V> implements Trie<K, V> {
   }
 
   @Override
+  public Optional<V> getIntersectingLock(Key<K> key) {
+    return getPrefixValue(key)
+        .map(Optional::of)
+        .orElseGet(() -> getChildValue(key));
+  }
+
+  @Override
   public boolean remove(Trie.Key<K> key) {
     return removeNode(key).isPresent();
   }
 
-  @Override
-  public boolean hasChildValues(Key<K> key) {
-    return getExactNode(key)
-        .map(this::hasChildValues)
-        .isPresent();
+  private Optional<V> getPrefixValue(Key<K> key) {
+    DefaultTrieNode<K, V> iter = root;
+    for (K segment : key.getSegments()) {
+      Optional<DefaultTrieNode<K, V>> child = iter.getChild(segment);
+      if (!child.isPresent()) {
+        break;
+      }
+
+      if (child.get().getValue() != null) {
+        return Optional.of(child.get().getValue());
+      }
+
+      iter = child.get();
+    }
+
+    return Optional.empty();
   }
 
-  private boolean hasChildValues(DefaultTrieNode<K, V> node) {
+  private Optional<V> getChildValue(Key<K> key) {
+    return getExactNode(key)
+        .flatMap(this::getChildValue);
+  }
+
+  private Optional<V> getChildValue(DefaultTrieNode<K, V> node) {
     Queue<DefaultTrieNode<K, V>> children = new ArrayDeque<>(node.getChildren().values());
 
     while (!children.isEmpty()) {
       DefaultTrieNode<K, V> child = children.poll();
 
       if (child.getValue() != null) {
-        return true;
+        return Optional.of(child.getValue());
       }
 
       children.addAll(child.getChildren().values());
     }
 
-    return false;
+    return Optional.empty();
   }
 
   private DefaultTrieNode<K, V> getOrCreateNode(Trie.Key<K> key) {

--- a/smart-hive-support/src/main/java/org/smartdata/hive/util/SynchronizedTrie.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/util/SynchronizedTrie.java
@@ -17,6 +17,7 @@
  */
 package org.smartdata.hive.util;
 
+import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -30,30 +31,20 @@ public class SynchronizedTrie<K, V> implements Trie<K, V> {
   }
 
   @Override
-  public boolean hasPrefixValues(Key<K> key) {
-    lock.writeLock().lock();
-    try {
-      return delegate.hasPrefixValues(key);
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  @Override
-  public boolean hasChildValues(Key<K> key) {
-    lock.writeLock().lock();
-    try {
-      return delegate.hasChildValues(key);
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  @Override
   public boolean putIfNoIntersectingLocks(Key<K> key, V value) {
     lock.writeLock().lock();
     try {
       return delegate.putIfNoIntersectingLocks(key, value);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public Optional<V> getIntersectingLock(Key<K> key) {
+    lock.writeLock().lock();
+    try {
+      return delegate.getIntersectingLock(key);
     } finally {
       lock.writeLock().unlock();
     }

--- a/smart-hive-support/src/main/java/org/smartdata/hive/util/Trie.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/util/Trie.java
@@ -22,15 +22,18 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public interface Trie<K, V> {
-  boolean hasPrefixValues(Key<K> key);
-
-  boolean hasChildValues(Key<K> key);
-
   boolean putIfNoIntersectingLocks(Key<K> key, V value);
 
+  Optional<V> getIntersectingLock(Key<K> key);
+
   boolean remove(Key<K> key);
+
+  default boolean hasIntersectingLock(Key<K> key) {
+    return getIntersectingLock(key).isPresent();
+  }
 
   static <K, V> Trie<K, V> synchronize(Trie<K, V> trie) {
     return SynchronizedTrie.wrap(trie);

--- a/smart-hive-support/src/test/java/org/smartdata/hive/action/HmsSyncSchedulerTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/action/HmsSyncSchedulerTest.java
@@ -59,8 +59,8 @@ import static org.smartdata.hive.action.HmsAction.EVENT_MESSAGE;
 import static org.smartdata.hive.action.HmsAction.EVENT_MESSAGE_FORMAT;
 import static org.smartdata.hive.action.HmsSyncAction.ENTITY_NAME;
 import static org.smartdata.model.action.ScheduleResult.RETRY;
+import static org.smartdata.model.action.ScheduleResult.SKIP;
 import static org.smartdata.model.action.ScheduleResult.SUCCESS;
-import static org.smartdata.model.action.ScheduleResult.SUCCESS_NO_EXECUTION;
 
 @Slf4j
 public class HmsSyncSchedulerTest {
@@ -149,7 +149,7 @@ public class HmsSyncSchedulerTest {
         launchCmdlet(1L, RULE_ID),
         launchAction(1L, RULE_ID)
     );
-    assertEquals(SUCCESS_NO_EXECUTION, scheduleResult);
+    assertEquals(SKIP, scheduleResult);
 
     // check doesn't affect other rules
     scheduleResult = scheduler.onSchedule(
@@ -350,6 +350,63 @@ public class HmsSyncSchedulerTest {
         launchAction(2L, RULE_ID)
     );
     assertEquals(SUCCESS, scheduleResult);
+  }
+
+  @Test
+  public void testRetryActionIfEntityHasRetryEvents() {
+    eventDao.insert(
+        ssmEvent(newCreateDbEvent(1L, "hive.db", "/location")),
+        ssmEvent(newCreateTableEvent(2L, "hive.db.table1",
+            TableType.EXTERNAL_TABLE, "/location/tb1")),
+        ssmEvent(newCreateTableEvent(3L, "hive.db.table1",
+            TableType.EXTERNAL_TABLE, "/location/tb2"))
+    );
+
+    ActionInfo finishedAction = actionInfo(1L, RULE_ID);
+    ScheduleResult scheduleResult = scheduler.onSchedule(
+        cmdletInfo(),
+        finishedAction,
+        launchCmdlet(1L, RULE_ID),
+        launchAction(1L, RULE_ID)
+    );
+    assertEquals(SUCCESS, scheduleResult);
+
+    ScheduleResult scheduleResult2 = scheduler.onSchedule(
+        cmdletInfo(),
+        actionInfo(2L, RULE_ID),
+        launchCmdlet(2L, RULE_ID),
+        launchAction(2L, RULE_ID)
+    );
+    assertEquals(RETRY, scheduleResult2);
+
+    scheduler.onActionFinished(cmdletInfo(), finishedAction);
+
+    ScheduleResult scheduleResult3 = scheduler.onSchedule(
+        cmdletInfo(),
+        actionInfo(3L, RULE_ID),
+        launchCmdlet(3L, RULE_ID),
+        launchAction(3L, RULE_ID)
+    );
+    assertEquals(RETRY, scheduleResult3);
+
+    ActionInfo finishedAction2 = actionInfo(2L, RULE_ID);
+    scheduleResult2 = scheduler.onSchedule(
+        cmdletInfo(),
+        finishedAction2,
+        launchCmdlet(2L, RULE_ID),
+        launchAction(2L, RULE_ID)
+    );
+    assertEquals(SUCCESS, scheduleResult2);
+
+    scheduler.onActionFinished(cmdletInfo(), finishedAction2);
+
+    scheduleResult3 = scheduler.onSchedule(
+        cmdletInfo(),
+        actionInfo(3L, RULE_ID),
+        launchCmdlet(3L, RULE_ID),
+        launchAction(3L, RULE_ID)
+    );
+    assertEquals(SUCCESS, scheduleResult3);
   }
 
   private LaunchCmdlet launchCmdlet(long eventId, long ruleId) {

--- a/smart-hive-support/src/test/java/org/smartdata/hive/util/DefaultTrieTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/util/DefaultTrieTest.java
@@ -20,11 +20,13 @@ package org.smartdata.hive.util;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class DefaultTrieTest {
-  private Trie<String, Boolean> trie;
+  private Trie<String, String> trie;
 
   @Before
   public void init() {
@@ -33,82 +35,105 @@ public class DefaultTrieTest {
 
   @Test
   public void testPutIfNoIntersectingLocks() {
-    boolean isNew = trie.putIfNoIntersectingLocks(key("test1"), true);
+    boolean isNew = trie.putIfNoIntersectingLocks(key("test1"), "true");
     assertTrue(isNew);
 
-    isNew = trie.putIfNoIntersectingLocks(key("test1"), true);
+    isNew = trie.putIfNoIntersectingLocks(key("test1"), "true");
     assertFalse(isNew);
-    isNew = trie.putIfNoIntersectingLocks(key("test1"), false);
-    assertFalse(isNew);
-
-    isNew = trie.putIfNoIntersectingLocks(key("test1", "child"), true);
-    assertFalse(isNew);
-    isNew = trie.putIfNoIntersectingLocks(key("test1", "child2"), true);
+    isNew = trie.putIfNoIntersectingLocks(key("test1"), "false");
     assertFalse(isNew);
 
-    isNew = trie.putIfNoIntersectingLocks(key("parent2", "child"), true);
-    assertTrue(isNew);
-    isNew = trie.putIfNoIntersectingLocks(key("parent2", "child2"), true);
-    assertTrue(isNew);
-    isNew = trie.putIfNoIntersectingLocks(key("parent2", "child2"), true);
+    isNew = trie.putIfNoIntersectingLocks(key("test1", "child"), "true");
+    assertFalse(isNew);
+    isNew = trie.putIfNoIntersectingLocks(key("test1", "child2"), "true");
     assertFalse(isNew);
 
-    isNew = trie.putIfNoIntersectingLocks(key("1", "2"), true);
+    isNew = trie.putIfNoIntersectingLocks(key("parent2", "child"), "true");
     assertTrue(isNew);
-    isNew = trie.putIfNoIntersectingLocks(key("1"), true);
+    isNew = trie.putIfNoIntersectingLocks(key("parent2", "child2"), "true");
+    assertTrue(isNew);
+    isNew = trie.putIfNoIntersectingLocks(key("parent2", "child2"), "true");
+    assertFalse(isNew);
+
+    isNew = trie.putIfNoIntersectingLocks(key("1", "2"), "true");
+    assertTrue(isNew);
+    isNew = trie.putIfNoIntersectingLocks(key("1"), "true");
     assertFalse(isNew);
   }
 
   @Test
-  public void testHasPrefixValues() {
-    trie.putIfNoIntersectingLocks(key("1"), true);
+  public void testHasIntersectingLocks() {
+    trie.putIfNoIntersectingLocks(key("1"), "true");
 
-    assertTrue(trie.hasPrefixValues(key("1", "2", "3")));
-    assertTrue(trie.hasPrefixValues(key("1", "2")));
-    assertTrue(trie.hasPrefixValues(key("1")));
+    assertTrue(trie.hasIntersectingLock(key("1", "2", "3")));
+    assertTrue(trie.hasIntersectingLock(key("1", "2")));
+    assertTrue(trie.hasIntersectingLock(key("1")));
 
-    trie.putIfNoIntersectingLocks(key("4", "5"), true);
-    assertTrue(trie.hasPrefixValues(key("4", "5", "6", "7")));
-    assertTrue(trie.hasPrefixValues(key("4", "5", "6")));
-    assertTrue(trie.hasPrefixValues(key("4", "5")));
+    trie.putIfNoIntersectingLocks(key("4", "5"), "true");
+    assertTrue(trie.hasIntersectingLock(key("4", "5", "6", "7")));
+    assertTrue(trie.hasIntersectingLock(key("4", "5", "6")));
+    assertTrue(trie.hasIntersectingLock(key("4", "5")));
+    assertTrue(trie.hasIntersectingLock(key("4")));
 
-    assertFalse(trie.hasPrefixValues(key("4")));
-    assertFalse(trie.hasPrefixValues(key("4", "another_key")));
-    assertFalse(trie.hasPrefixValues(key("4", "another_key", "another_subkey")));
+    assertFalse(trie.hasIntersectingLock(key("4", "another_key")));
+    assertFalse(trie.hasIntersectingLock(key("4", "another_key", "another_subkey")));
+  }
+
+  @Test
+  public void testGetIntersectingLocks() {
+    trie.putIfNoIntersectingLocks(key("1"), "value1");
+
+    assertEquals("value1", getIntersectingLock("1", "2", "3"));
+    assertEquals("value1", getIntersectingLock("1", "2"));
+    assertEquals("value1", getIntersectingLock("1"));
+    assertNull(getIntersectingLock("2"));
+
+    trie.putIfNoIntersectingLocks(key("4", "5"), "val2");
+    assertEquals("val2", getIntersectingLock("4", "5", "6", "7"));
+    assertEquals("val2", getIntersectingLock("4", "5", "6"));
+    assertEquals("val2", getIntersectingLock("4", "5"));
+    assertEquals("val2", getIntersectingLock("4"));
+
+    assertNull(getIntersectingLock("4", "another_key"));
+    assertNull(getIntersectingLock("4", "another_key", "another_subkey"));
+  }
+
+  private String getIntersectingLock(String... keyParts) {
+    return trie.getIntersectingLock(key(keyParts)).orElse(null);
   }
 
   @Test
   public void testRemove() {
-    trie.putIfNoIntersectingLocks(key("1", "2"), true);
-    trie.putIfNoIntersectingLocks(key("1", "3"), true);
+    trie.putIfNoIntersectingLocks(key("1", "2"), "true");
+    trie.putIfNoIntersectingLocks(key("1", "3"), "true");
 
     boolean isRemoved = trie.remove(key("1", "2"));
     assertTrue(isRemoved);
-    assertTrue(trie.hasPrefixValues(key("1", "3")));
-    assertFalse(trie.hasPrefixValues(key("1", "2")));
-    assertFalse(trie.hasPrefixValues(key("1", "2", "3")));
+    assertTrue(trie.hasIntersectingLock(key("1", "3")));
+    assertFalse(trie.hasIntersectingLock(key("1", "2")));
+    assertFalse(trie.hasIntersectingLock(key("1", "2", "3")));
   }
 
   @Test
   public void testRemoveUnknownChild() {
-    trie.putIfNoIntersectingLocks(key("1", "2"), true);
+    trie.putIfNoIntersectingLocks(key("1", "2"), "true");
 
     boolean isRemoved = trie.remove(key("1", "2", "3"));
 
     assertFalse(isRemoved);
-    assertTrue(trie.hasPrefixValues(key("1", "2")));
-    assertTrue(trie.hasPrefixValues(key("1", "2", "3")));
+    assertTrue(trie.hasIntersectingLock(key("1", "2")));
+    assertTrue(trie.hasIntersectingLock(key("1", "2", "3")));
   }
 
   @Test
   public void testRemoveUnknownParent() {
-    trie.putIfNoIntersectingLocks(key("1", "2"), true);
+    trie.putIfNoIntersectingLocks(key("1", "2"), "true");
 
     boolean isRemoved = trie.remove(key("1"));
 
     assertFalse(isRemoved);
-    assertTrue(trie.hasPrefixValues(key("1", "2")));
-    assertFalse(trie.hasPrefixValues(key("1")));
+    assertTrue(trie.hasIntersectingLock(key("1", "2")));
+    assertTrue(trie.hasIntersectingLock(key("1")));
   }
 
   private Trie.Key<String> key(String... parts) {

--- a/supports/tools/docker/multihost/ssm-conf/smart-site-master.xml
+++ b/supports/tools/docker/multihost/ssm-conf/smart-site-master.xml
@@ -144,11 +144,19 @@
         <value>thrift://hive-metastore:9083</value>
     </property>
     <property>
-        <name>hive.metastore.ds.retry.interval</name>
+        <name>hive.hmshandler.retry.interval</name>
         <value>3000ms</value>
     </property>
     <property>
-        <name>hive.metastore.ds.retry.attempts</name>
+        <name>hive.hmshandler.retry.attempts</name>
         <value>30</value>
+    </property>
+    <property>
+        <name>metastore.client.connect.retry.delay</name>
+        <value>5000ms</value>
+    </property>
+    <property>
+        <name>metastore.connect.retries</name>
+        <value>15</value>
     </property>
 </configuration>


### PR DESCRIPTION
- Added new `SKIP` schedule result to skip already scheduled actions 
- Removed unnecessary `smart.hive.client.cache.size.initial` option
- Fixed bug with not considering retried events during rule HMS sync watermark updating