### PR TITLE
[ADH-7540] Fix table and db of HMS foreign key creation event

### DIFF
--- a/smart-hive-support/src/main/java/org/smartdata/hive/HiveMetastoreFetcherService.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/HiveMetastoreFetcherService.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
 import org.apache.hadoop.hive.metastore.messaging.json.gzip.GzipJSONMessageEncoder;
 import org.smartdata.AbstractService;
 import org.smartdata.SmartContext;
@@ -32,7 +33,9 @@ import org.smartdata.hive.fetch.HmsEventSource;
 import org.smartdata.hive.fetch.HmsEventStream;
 import org.smartdata.hive.fetch.HmsInFlightEventSource;
 import org.smartdata.hive.fetch.composite.CompositeHmsEventSource;
-import org.smartdata.hive.fetch.enrich.HmsEventNameSetter;
+import org.smartdata.hive.fetch.enrich.HmsEventEnricher;
+import org.smartdata.hive.fetch.enrich.HmsFkRelatedResourcesSetter;
+import org.smartdata.hive.fetch.enrich.HmsFunctionNameSetter;
 import org.smartdata.hive.fetch.filter.CompositeHmsEventFilter;
 import org.smartdata.hive.fetch.filter.HmsEventFilter;
 import org.smartdata.hive.handler.AsyncHmsEventStreamHandler;
@@ -50,7 +53,8 @@ import org.smartdata.retry.RetrySupport;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -196,8 +200,11 @@ public class HiveMetastoreFetcherService extends AbstractService {
   private HmsInFlightEventSource buildInFlightEventSource(
       Supplier<IMetaStoreClient> metaStoreClientSupplier,
       HmsEventFilter eventFilter) {
-    HmsEventNameSetter eventNameSetter =
-        new HmsEventNameSetter(GzipJSONMessageEncoder.getInstance());
+    MessageEncoder messageEncoder = GzipJSONMessageEncoder.getInstance();
+    List<HmsEventEnricher> eventEnrichers = Arrays.asList(
+        new HmsFunctionNameSetter(messageEncoder),
+        new HmsFkRelatedResourcesSetter(messageEncoder)
+    );
 
     return HmsInFlightEventSource.builder()
         .metaStoreClientSupplier(metaStoreClientSupplier)
@@ -205,7 +212,7 @@ public class HiveMetastoreFetcherService extends AbstractService {
         .eventFilter(eventFilter)
         .fetchPeriodMs(hiveSmartConf.getFetchPeriodMs())
         .eventBatchSize(hiveSmartConf.getFetchBatchSize())
-        .eventEnrichers(Collections.singletonList(eventNameSetter))
+        .eventEnrichers(eventEnrichers)
         .build();
   }
 

--- a/smart-hive-support/src/main/java/org/smartdata/hive/action/HmsSyncAction.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/action/HmsSyncAction.java
@@ -29,6 +29,7 @@ import org.smartdata.action.annotation.ActionSignature;
 public class HmsSyncAction extends HmsAction {
   public static final String NAME = "hms-sync";
   public static final String ENTITY_NAME = "-entityName";
+  public static final String RELATED_RESOURCES = "-relatedResources";
 
   @Override
   protected void execute() throws Exception {

--- a/smart-hive-support/src/main/java/org/smartdata/hive/action/HmsSyncScheduler.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/action/HmsSyncScheduler.java
@@ -61,12 +61,14 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.smartdata.hive.HiveSmartConf.HMS_SYNC_PROGRESS_FLUSH_INTERVAL_MS;
@@ -173,7 +175,7 @@ public class HmsSyncScheduler extends ActionSchedulerService {
     }
 
     HiveNotificationEvent event = hmsEventDao.get(eventId);
-    if (ruleState.isLocked(event) || ruleState.hasEventsToRetryForEntity(event)) {
+    if (isLocked(event, ruleState)) {
       log.debug("Entity {} is locked or has locked parent objects. Retrying later.", event.getFullName());
       ruleState.eventsInProcessing.remove(eventId);
       ruleState.addRetryState(event);
@@ -184,6 +186,8 @@ public class HmsSyncScheduler extends ActionSchedulerService {
     ruleState.clearRetryState(event);
 
     actionInfo.getArgs().put(HmsSyncAction.ENTITY_NAME, event.getFullName());
+    Optional.ofNullable(event.rawRelatedResources())
+        .ifPresent(resources -> actionInfo.getArgs().put(HmsSyncAction.RELATED_RESOURCES, resources));
     Optional.ofNullable(event.getTableName())
         .ifPresent(tableName -> actionInfo.getArgs().put(HmsSyncAction.TABLE_NAME, tableName));
 
@@ -225,6 +229,18 @@ public class HmsSyncScheduler extends ActionSchedulerService {
       // during the execution of the current method.
       removeLock(ruleState, actionInfo);
     }
+  }
+
+  private boolean isLocked(HiveNotificationEvent event, RuleState ruleState) {
+    return isLocked(event, ruleState, event.getFullName())
+        || event.getRelatedResources()
+        .stream()
+        .anyMatch(resourceName -> isLocked(event, ruleState, resourceName));
+  }
+
+  private boolean isLocked(HiveNotificationEvent event, RuleState ruleState, String resourceName) {
+    return ruleState.isLocked(resourceName)
+        || ruleState.hasEventsToRetryForEntity(event, resourceName);
   }
 
   private void handleEvent(HiveNotificationEvent event, LaunchAction action) {
@@ -271,6 +287,7 @@ public class HmsSyncScheduler extends ActionSchedulerService {
   private void removeLock(RuleState ruleState, ActionInfo actionInfo) {
     String entityName = getEntityName(actionInfo);
     ruleState.removeLock(entityName);
+    getRelatedResources(actionInfo).forEach(ruleState::removeLock);
   }
 
   private long eventId(ActionInfo actionInfo) {
@@ -290,6 +307,12 @@ public class HmsSyncScheduler extends ActionSchedulerService {
         .computeIfAbsent(HmsSyncAction.ENTITY_NAME, key -> {
           throw new IllegalArgumentException("Missing entity name");
         });
+  }
+
+  private Set<String> getRelatedResources(ActionInfo actionInfo) {
+    return Optional.ofNullable(actionInfo.getArgs().get(HmsSyncAction.RELATED_RESOURCES))
+        .map(HiveNotificationEvent::extractRelatedResources)
+        .orElseGet(Collections::emptySet);
   }
 
   private RuleState getRuleState(ActionInfo actionInfo) {
@@ -343,34 +366,43 @@ public class HmsSyncScheduler extends ActionSchedulerService {
     private final Trie<String, Long> retryEntityLocks = Trie.synchronize(new DefaultTrie<>());
 
     void putEntityLock(HiveNotificationEvent event) {
-      entityLocks.putIfNoIntersectingLocks(trieKey(event), true);
+      forEntityAndRelatedResources(event, resource ->
+              entityLocks.putIfNoIntersectingLocks(trieKey(resource), true));
     }
 
-    boolean isLocked(HiveNotificationEvent event) {
-      return entityLocks.getIntersectingLock(trieKey(event)).isPresent();
+    boolean isLocked(String resourceName) {
+      return entityLocks.getIntersectingLock(trieKey(resourceName)).isPresent();
     }
 
-    boolean hasEventsToRetryForEntity(HiveNotificationEvent event) {
+    boolean hasEventsToRetryForEntity(HiveNotificationEvent event, String resourceName) {
       return retryEntityLocks
-          .getIntersectingLock(trieKey(event))
+          .getIntersectingLock(trieKey(resourceName))
           .map(lockEventId -> lockEventId != event.getId())
           .orElse(false);
     }
 
     void addRetryState(HiveNotificationEvent event) {
       retryEvents.add(event.getId());
-      retryEntityLocks.putIfNoIntersectingLocks(trieKey(event), event.getId());
+      forEntityAndRelatedResources(event, resource ->
+              retryEntityLocks.putIfNoIntersectingLocks(trieKey(resource), event.getId()));
     }
 
     void clearRetryState(HiveNotificationEvent event) {
       retryEvents.remove(event.getId());
-      retryEntityLocks.remove(trieKey(event));
+      forEntityAndRelatedResources(event,
+          resource -> retryEntityLocks.remove(trieKey(resource)));
     }
 
     void clearEventState(HiveNotificationEvent event) {
       eventsInProcessing.remove(event.getId());
-      removeLock(event.getFullName());
+      forEntityAndRelatedResources(event, this::removeLock);
       clearRetryState(event);
+    }
+
+    void forEntityAndRelatedResources(HiveNotificationEvent event,
+                                      Consumer<String> resourceConsumer) {
+      resourceConsumer.accept(event.getFullName());
+      event.getRelatedResources().forEach(resourceConsumer);
     }
 
     void removeLock(String entityName) {

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/HiveNotificationEvent.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/HiveNotificationEvent.java
@@ -19,10 +19,14 @@ package org.smartdata.hive.fetch;
 
 import lombok.Builder;
 import lombok.Data;
+import org.apache.commons.compress.utils.Sets;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Data
@@ -38,6 +42,7 @@ public class HiveNotificationEvent implements HmsEventStreamRecord {
   private final String tableName;
   private final String message;
   private final String messageFormat;
+  private final Set<String> relatedResources;
 
   // computed fields on SSM side
   private final String fullName;
@@ -52,7 +57,8 @@ public class HiveNotificationEvent implements HmsEventStreamRecord {
         .tableName(event.getTableName())
         .message(event.getMessage())
         .messageFormat(event.getMessageFormat())
-        .fullName(fullResourceName(event));
+        .fullName(fullResourceName(event))
+        .relatedResources(Collections.emptySet());
   }
 
   public static String fullResourceName(NotificationEvent event) {
@@ -65,5 +71,18 @@ public class HiveNotificationEvent implements HmsEventStreamRecord {
     return Arrays.stream(nameParts)
         .filter(Objects::nonNull)
         .collect(Collectors.joining("."));
+  }
+
+  public String rawRelatedResources() {
+    return Optional.ofNullable(relatedResources)
+        .map(resources -> String.join(",", resources))
+        .orElse(null);
+  }
+
+  public static Set<String> extractRelatedResources(String rawRelatedResources) {
+    return Optional.ofNullable(rawRelatedResources)
+        .map(resources -> resources.split(","))
+        .map(resources -> (Set<String>) Sets.newHashSet(resources))
+        .orElseGet(Collections::emptySet);
   }
 }

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/HmsInFlightEventSource.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/HmsInFlightEventSource.java
@@ -23,12 +23,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
-import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
 import org.smartdata.hive.fetch.enrich.HmsEventEnricher;
-import org.smartdata.hive.fetch.enrich.HmsEventNameSetter;
 import org.smartdata.hive.fetch.filter.HmsEventFilter;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsEventModifier.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsEventModifier.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.enrich;
+
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
+import org.smartdata.hive.fetch.HiveEntity;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+import org.smartdata.hive.fetch.HiveOperation;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+public abstract class HmsEventModifier implements HmsEventEnricher {
+  private final Set<HiveEntity> supportedEntities;
+  protected final MessageEncoder messageEncoder;
+
+  public HmsEventModifier(MessageEncoder messageEncoder, HiveEntity... supportedEntities) {
+    this.messageEncoder = messageEncoder;
+    this.supportedEntities = Sets.newHashSet(supportedEntities);
+  }
+
+  @Override
+  public HiveNotificationEvent enrich(HiveNotificationEvent event) {
+    return Optional.ofNullable(event.getEntityType())
+        .map(type -> EnumUtils.getEnum(HiveEntity.class, type))
+        .filter(supportedEntities::contains)
+        .flatMap(ignore -> modifyEvent(event))
+        .orElse(event);
+  }
+
+  protected abstract HiveNotificationEvent modifyEvent(
+      HiveNotificationEvent event,
+      HiveOperation operation);
+
+  private Optional<HiveNotificationEvent> modifyEvent(HiveNotificationEvent event) {
+    if (StringUtils.isBlank(event.getMessage())) {
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable(event.getEventType())
+        .map(type -> EnumUtils.getEnum(HiveOperation.class, type))
+        .map(operation -> modifyEvent(event, operation));
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsFkRelatedResourcesSetter.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsFkRelatedResourcesSetter.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.smartdata.hive.fetch.enrich;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
+import org.apache.hadoop.hive.metastore.messaging.AddForeignKeyMessage;
+import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
+import org.smartdata.hive.fetch.HiveEntity;
+import org.smartdata.hive.fetch.HiveNotificationEvent;
+import org.smartdata.hive.fetch.HiveOperation;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.smartdata.hive.fetch.HiveNotificationEvent.fullResourceName;
+import static org.smartdata.hive.fetch.HiveOperation.CREATE;
+
+@Slf4j
+public class HmsFkRelatedResourcesSetter extends HmsEventModifier {
+  public HmsFkRelatedResourcesSetter(MessageEncoder messageEncoder) {
+    super(messageEncoder, HiveEntity.FOREIGN_KEY);
+  }
+
+  @Override
+  protected HiveNotificationEvent modifyEvent(HiveNotificationEvent event, HiveOperation operation) {
+    try {
+      if (operation == CREATE) {
+        AddForeignKeyMessage msg = messageEncoder.getDeserializer()
+            .getAddForeignKeyMessage(event.getMessage());
+
+        List<SQLForeignKey> foreignKeys = msg.getForeignKeys();
+        if (CollectionUtils.isEmpty(foreignKeys)) {
+          return event;
+        }
+
+        Set<String> relatedResources = foreignKeys.stream()
+            .map(key -> fullResourceName(key.getFktable_db(), key.getFktable_name()))
+            .collect(Collectors.toSet());
+
+        return event.toBuilder()
+            .relatedResources(relatedResources)
+            .build();
+      }
+    } catch (Exception e) {
+      log.error("Failed to parse event message {}", event, e);
+    }
+
+    return event;
+  }
+}

--- a/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsFunctionNameSetter.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/fetch/enrich/HmsFunctionNameSetter.java
@@ -17,10 +17,7 @@
  */
 package org.smartdata.hive.fetch.enrich;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.EnumUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.messaging.CreateFunctionMessage;
 import org.apache.hadoop.hive.metastore.messaging.DropFunctionMessage;
 import org.apache.hadoop.hive.metastore.messaging.MessageEncoder;
@@ -28,64 +25,41 @@ import org.smartdata.hive.fetch.HiveEntity;
 import org.smartdata.hive.fetch.HiveNotificationEvent;
 import org.smartdata.hive.fetch.HiveOperation;
 
-import java.util.Objects;
-import java.util.Optional;
-
 import static org.smartdata.hive.fetch.HiveNotificationEvent.fullResourceName;
 import static org.smartdata.hive.fetch.HiveOperation.CREATE;
 import static org.smartdata.hive.fetch.HiveOperation.DROP;
 import static org.smartdata.hive.snapshot.HiveNotificationEventFactory.fullName;
 
 @Slf4j
-@RequiredArgsConstructor
-public class HmsEventNameSetter implements HmsEventEnricher {
-  private final MessageEncoder messageEncoder;
+public class HmsFunctionNameSetter extends HmsEventModifier {
+  public HmsFunctionNameSetter(MessageEncoder messageEncoder) {
+    super(messageEncoder, HiveEntity.FUNCTION);
+  }
 
   @Override
-  public HiveNotificationEvent enrich(HiveNotificationEvent event) {
-    String newName = extractFullName(event);
-    return Objects.equals(newName, event.getFullName())
-        ? event
-        : event.toBuilder()
-        .fullName(newName)
-        .build();
-  }
-
-  private String extractFullName(HiveNotificationEvent event) {
-    return Optional.ofNullable(event.getEntityType())
-        .map(type -> EnumUtils.getEnum(HiveEntity.class, type))
-        .filter(HiveEntity.FUNCTION::equals)
-        .flatMap(ignore -> extractFunctionName(event))
-        .orElseGet(event::getFullName);
-  }
-
-  private Optional<String> extractFunctionName(HiveNotificationEvent event) {
-    return Optional.ofNullable(event.getEventType())
-        .map(type -> EnumUtils.getEnum(HiveOperation.class, type))
-        .map(operation -> extractFunctionName(event, operation));
-  }
-
-  private String extractFunctionName(HiveNotificationEvent event, HiveOperation operation) {
-    if (StringUtils.isBlank(event.getMessage())) {
-      return event.getFullName();
-    }
-
+  protected HiveNotificationEvent modifyEvent(HiveNotificationEvent event, HiveOperation operation) {
     try {
       if (operation == CREATE) {
         CreateFunctionMessage msg = messageEncoder.getDeserializer()
             .getCreateFunctionMessage(event.getMessage());
-        return fullName(msg.getFunctionObj());
+        return withNewName(event, fullName(msg.getFunctionObj()));
       }
 
       if (operation == DROP) {
         DropFunctionMessage msg = messageEncoder.getDeserializer()
             .getDropFunctionMessage(event.getMessage());
-        return fullResourceName(msg.getDB(), msg.getFunctionName());
+        return withNewName(event, fullResourceName(msg.getDB(), msg.getFunctionName()));
       }
     } catch (Exception e) {
       log.error("Failed to parse event message {}", event, e);
     }
 
-    return event.getFullName();
+    return event;
+  }
+
+  private HiveNotificationEvent withNewName(HiveNotificationEvent event, String newName) {
+    return event.toBuilder()
+        .fullName(newName)
+        .build();
   }
 }

--- a/smart-hive-support/src/main/java/org/smartdata/hive/snapshot/HiveNotificationEventFactory.java
+++ b/smart-hive-support/src/main/java/org/smartdata/hive/snapshot/HiveNotificationEventFactory.java
@@ -152,6 +152,8 @@ public class HiveNotificationEventFactory {
         .entityType(HiveEntity.FOREIGN_KEY.toString())
         .dbName(constraint.getFktable_db())
         .tableName(constraint.getFktable_name())
+        .relatedResources(Collections.singleton(
+            fullResourceName(constraint.getPktable_db(), constraint.getPktable_db())))
         .build();
   }
 

--- a/smart-hive-support/src/test/java/org/smartdata/hive/fetch/enrich/HmsFunctionNameSetterTest.java
+++ b/smart-hive-support/src/test/java/org/smartdata/hive/fetch/enrich/HmsFunctionNameSetterTest.java
@@ -35,15 +35,15 @@ import static org.junit.Assert.assertNull;
 import static org.smartdata.hive.HiveEntityFactory.buildDb;
 import static org.smartdata.hive.HiveEntityFactory.buildFunction;
 
-public class HmsEventNameSetterTest {
+public class HmsFunctionNameSetterTest {
 
-  private HmsEventNameSetter eventNameSetter;
+  private HmsEventModifier eventNameSetter;
   private MessageEncoder messageEncoder;
 
   @Before
   public void setUp() {
     this.messageEncoder = JSONMessageEncoder.getInstance();
-    this.eventNameSetter = new HmsEventNameSetter(messageEncoder);
+    this.eventNameSetter = new HmsFunctionNameSetter(messageEncoder);
   }
 
   @Test

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/postgres/PostgresHmsEventDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/postgres/PostgresHmsEventDao.java
@@ -121,6 +121,7 @@ public class PostgresHmsEventDao extends AbstractDao implements HmsEventDao {
 
   private HiveNotificationEvent mapRow(ResultSet resultSet, int rowNum) throws SQLException {
     return HiveNotificationEvent.builder()
+        .id(resultSet.getLong(ID_FIELD))
         .externalId(resultSet.getLong(EXTERNAL_ID_FIELD))
         .eventTime(resultSet.getLong(EVENT_TIME_FIELD))
         .eventType(resultSet.getString(EVENT_TYPE_FIELD))

--- a/smart-metastore/src/main/java/org/smartdata/metastore/dao/postgres/PostgresHmsEventDao.java
+++ b/smart-metastore/src/main/java/org/smartdata/metastore/dao/postgres/PostgresHmsEventDao.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.smartdata.hive.fetch.HiveNotificationEvent.extractRelatedResources;
 import static org.smartdata.metastore.queries.MetastoreQuery.selectAll;
 import static org.smartdata.metastore.queries.expression.MetastoreQueryDsl.equal;
 
@@ -54,6 +55,7 @@ public class PostgresHmsEventDao extends AbstractDao implements HmsEventDao {
   private static final String TABLE_NAME_FIELD = "table_name";
   private static final String MESSAGE_FIELD = "message";
   private static final String MESSAGE_FORMAT_FIELD = "message_format";
+  private static final String RELATED_RESOURCES_FIELD = "related_resources";
 
   private final MetastoreQueryExecutor queryExecutor;
   private final PostgresInsertSupport insertSupport;
@@ -129,6 +131,8 @@ public class PostgresHmsEventDao extends AbstractDao implements HmsEventDao {
         .tableName(resultSet.getString(TABLE_NAME_FIELD))
         .message(resultSet.getString(MESSAGE_FIELD))
         .messageFormat(resultSet.getString(MESSAGE_FORMAT_FIELD))
+        .relatedResources(extractRelatedResources(
+            resultSet.getString(RELATED_RESOURCES_FIELD)))
         .build();
   }
 
@@ -144,6 +148,7 @@ public class PostgresHmsEventDao extends AbstractDao implements HmsEventDao {
     parameters.put(TABLE_NAME_FIELD, event.getTableName());
     parameters.put(MESSAGE_FIELD, event.getMessage());
     parameters.put(MESSAGE_FORMAT_FIELD, event.getMessageFormat());
+    parameters.put(RELATED_RESOURCES_FIELD, event.rawRelatedResources());
     return parameters;
   }
 

--- a/smart-metastore/src/main/resources/db/changelog/changelog-12.add-related-resources-field.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-12.add-related-resources-field.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="2026.01.22_001" author="tmanasyan">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="hive_metastore_event" columnName="related_resources"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="hive_metastore_event">
+            <column name="related_resources" type="TEXT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/smart-metastore/src/main/resources/db/changelog/changelog-root.xml
+++ b/smart-metastore/src/main/resources/db/changelog/changelog-root.xml
@@ -19,4 +19,5 @@
     <include file="/db/changelog/changelog-9.add-cmdlet-rule-owner.xml"/>
     <include file="/db/changelog/changelog-10.add-hive-event-tables.xml"/>
     <include file="/db/changelog/changelog-11.add-hive-sync-progress-table.xml"/>
+    <include file="/db/changelog/changelog-12.add-related-resources-field.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Added related resources fields to the Hive event to lock both source and target tables of the foreign key constraint 